### PR TITLE
feat(frost/dkg): wire a real distributed FROST DKG into the node (transport + forward secrecy)

### DIFF
--- a/ci/frost-signer-pin.env
+++ b/ci/frost-signer-pin.env
@@ -15,4 +15,4 @@
 #
 # After the scaffold and mirror branches merge into one, replace the cross-branch
 # checkout with an in-tree cargo build and retire this pin (keep the gate).
-FROST_SIGNER_MIRROR_REF=a5762aaaed5bb891335ed6c2d173c20d3bf9b6bc
+FROST_SIGNER_MIRROR_REF=0d2ebcbbfe66c9c5abd39a66b09484d6ab414a03

--- a/ci/frost-signer-pin.env
+++ b/ci/frost-signer-pin.env
@@ -15,4 +15,4 @@
 #
 # After the scaffold and mirror branches merge into one, replace the cross-branch
 # checkout with an in-tree cargo build and retire this pin (keep the gate).
-FROST_SIGNER_MIRROR_REF=82cffedb3cb43c78a3a6d10facfb0927cda6281a
+FROST_SIGNER_MIRROR_REF=a5762aaaed5bb891335ed6c2d173c20d3bf9b6bc

--- a/ci/frost-signer-pin.env
+++ b/ci/frost-signer-pin.env
@@ -15,4 +15,4 @@
 #
 # After the scaffold and mirror branches merge into one, replace the cross-branch
 # checkout with an in-tree cargo build and retire this pin (keep the gate).
-FROST_SIGNER_MIRROR_REF=1d6f9465150d48f734c4789db3f3e80a5f14cc8d
+FROST_SIGNER_MIRROR_REF=4ac4a42ee81911e82f222d71b66c13d1f58a0773

--- a/ci/frost-signer-pin.env
+++ b/ci/frost-signer-pin.env
@@ -15,4 +15,4 @@
 #
 # After the scaffold and mirror branches merge into one, replace the cross-branch
 # checkout with an in-tree cargo build and retire this pin (keep the gate).
-FROST_SIGNER_MIRROR_REF=6e3718ba00455c7a89499592ef57648c6e9b2c69
+FROST_SIGNER_MIRROR_REF=5a88e9a44e066495e7f7c268682b2a3500d2b62d

--- a/ci/frost-signer-pin.env
+++ b/ci/frost-signer-pin.env
@@ -15,4 +15,4 @@
 #
 # After the scaffold and mirror branches merge into one, replace the cross-branch
 # checkout with an in-tree cargo build and retire this pin (keep the gate).
-FROST_SIGNER_MIRROR_REF=0d2ebcbbfe66c9c5abd39a66b09484d6ab414a03
+FROST_SIGNER_MIRROR_REF=1d6f9465150d48f734c4789db3f3e80a5f14cc8d

--- a/ci/frost-signer-pin.env
+++ b/ci/frost-signer-pin.env
@@ -15,4 +15,4 @@
 #
 # After the scaffold and mirror branches merge into one, replace the cross-branch
 # checkout with an in-tree cargo build and retire this pin (keep the gate).
-FROST_SIGNER_MIRROR_REF=5a88e9a44e066495e7f7c268682b2a3500d2b62d
+FROST_SIGNER_MIRROR_REF=82cffedb3cb43c78a3a6d10facfb0927cda6281a

--- a/pkg/crypto/ephemeral/private_key.go
+++ b/pkg/crypto/ephemeral/private_key.go
@@ -69,6 +69,26 @@ func (pk *PrivateKey) Marshal() []byte {
 	return (*btcec.PrivateKey)(pk).Serialize()
 }
 
+// Zero best-effort scrubs the private key's secret scalar in place, so a
+// short-lived key (a one-time or per-attempt ephemeral) does not linger in the
+// heap - and thus a core dump or swap file - after its single use. big.Int does
+// not expose zeroization, so this wipes the backing words of D directly. Callers
+// that hold an ephemeral key should Zero() it as soon as they are done with it.
+func (pk *PrivateKey) Zero() {
+	if pk == nil {
+		return
+	}
+	d := (*btcec.PrivateKey)(pk).D
+	if d == nil {
+		return
+	}
+	words := d.Bits()
+	for i := range words {
+		words[i] = 0
+	}
+	d.SetInt64(0)
+}
+
 // Marshal turns a `PublicKey` into a slice of bytes.
 func (pk *PublicKey) Marshal() []byte {
 	return (*btcec.PublicKey)(pk).SerializeCompressed()

--- a/pkg/crypto/ephemeral/private_key_test.go
+++ b/pkg/crypto/ephemeral/private_key_test.go
@@ -5,6 +5,35 @@ import (
 	"testing"
 )
 
+func TestPrivateKeyZero(t *testing.T) {
+	keyPair, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	allZero := func(b []byte) bool {
+		for _, x := range b {
+			if x != 0 {
+				return false
+			}
+		}
+		return true
+	}
+
+	if allZero(keyPair.PrivateKey.Marshal()) {
+		t.Fatal("a freshly generated private key must not be all-zero")
+	}
+
+	keyPair.PrivateKey.Zero()
+	if scrubbed := keyPair.PrivateKey.Marshal(); !allZero(scrubbed) {
+		t.Fatalf("Zero() must scrub the secret scalar; got [%x]", scrubbed)
+	}
+
+	// Zero is nil-safe.
+	var nilKey *PrivateKey
+	nilKey.Zero()
+}
+
 func TestMarshalUnmarshalPublicKey(t *testing.T) {
 	keyPair, err := GenerateKeyPair()
 	if err != nil {

--- a/pkg/frost/signing/distributed_dkg_multinode_net_e2e_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_multinode_net_e2e_frost_native_test.go
@@ -113,6 +113,7 @@ func TestDistributedDKG_MultiNode_NetTransport(t *testing.T) {
 				[]group.MemberIndex{member}, // one seat per node
 				identifierByID,
 				threshold,
+				nil, // no prebuffer: this test subscribes before Start (no readiness barrier)
 			)
 			outcomes <- nodeOutcome{member: member, persist: persist, err: err}
 		}()

--- a/pkg/frost/signing/distributed_dkg_multinode_net_e2e_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_multinode_net_e2e_frost_native_test.go
@@ -27,8 +27,8 @@ import (
 // RunDistributedDKGForSeats seam - the exact call the node's
 // executeDistributedFrostDKG makes. Unlike the in-process-bus e2e, every round
 // package crosses the real transport adapter and is membership-authenticated
-// against the sender's operator key, and round-2 shares are ECIES-sealed to
-// peers' operator keys LEARNED from their authenticated round-1 broadcasts. So a
+// against the sender's operator key, and round-2 shares are ECIES-sealed to peers'
+// per-DKG EPHEMERAL keys LEARNED from their authenticated round-1 broadcasts. So a
 // passing run proves the production orchestration + net bus + key learning +
 // encrypted round-2 all work together over real messaging.
 //
@@ -151,7 +151,12 @@ func TestDistributedDKG_MultiNode_NetTransport(t *testing.T) {
 	}
 	t.Logf("%d nodes agreed on group key %s… over the real net transport", n, keyGroup[:16])
 
-	// ---- Interactive threshold signing over the accumulated session. ----
+	// ---- Interactive threshold signing under a DISTINCT session. ----
+	// The DKG persisted under `session`, but interactive ROAST signing runs under a
+	// per-message RoastSessionID that is NOT the DKG session - the production shape.
+	// The engine resolves the wallet key by keyGroup, so signing under a different
+	// session must still work (a distributed-DKG wallet is signable ONLY this way).
+	signingSession := session + "-roast-signing"
 	signingMembers := members[:threshold]
 	includedParticipants := make([]uint16, len(signingMembers))
 	for i, m := range signingMembers {
@@ -159,7 +164,7 @@ func TestDistributedDKG_MultiNode_NetTransport(t *testing.T) {
 	}
 
 	derived, err := engine.DeriveInteractiveAttemptContext(
-		session, message, keyGroup, threshold, 0, includedParticipants,
+		signingSession, message, keyGroup, threshold, 0, includedParticipants,
 	)
 	if err != nil {
 		t.Fatalf("derive interactive attempt context: %v", err)
@@ -173,7 +178,7 @@ func TestDistributedDKG_MultiNode_NetTransport(t *testing.T) {
 	commitments := make([]nativeFROSTCommitment, 0, len(signingMembers))
 	for _, m := range signingMembers {
 		open, err := engine.InteractiveSessionOpen(
-			session, uint16(m), message, keyGroup, threshold, nil, derived.AttemptContext,
+			signingSession, uint16(m), message, keyGroup, threshold, nil, derived.AttemptContext,
 		)
 		if err != nil {
 			t.Fatalf("interactive session open (member %d): %v", m, err)
@@ -181,7 +186,7 @@ func TestDistributedDKG_MultiNode_NetTransport(t *testing.T) {
 		if attemptID == "" {
 			attemptID = open.AttemptID
 		}
-		commitmentData, err := engine.InteractiveRound1(session, open.AttemptID, uint16(m))
+		commitmentData, err := engine.InteractiveRound1(signingSession, open.AttemptID, uint16(m))
 		if err != nil {
 			t.Fatalf("interactive round 1 (member %d): %v", m, err)
 		}
@@ -198,7 +203,7 @@ func TestDistributedDKG_MultiNode_NetTransport(t *testing.T) {
 
 	shares := make([]nativeFROSTSignatureShare, 0, len(signingMembers))
 	for _, m := range signingMembers {
-		shareData, err := engine.InteractiveRound2(session, attemptID, uint16(m), signingPackage)
+		shareData, err := engine.InteractiveRound2(signingSession, attemptID, uint16(m), signingPackage)
 		if err != nil {
 			t.Fatalf("interactive round 2 (member %d): %v", m, err)
 		}
@@ -208,7 +213,7 @@ func TestDistributedDKG_MultiNode_NetTransport(t *testing.T) {
 		})
 	}
 
-	signatureBytes, err := engine.InteractiveAggregate(session, attemptID, signingPackage, shares, nil)
+	signatureBytes, err := engine.InteractiveAggregate(signingSession, attemptID, signingPackage, shares, nil)
 	if err != nil {
 		t.Fatalf("interactive aggregate: %v", err)
 	}

--- a/pkg/frost/signing/distributed_dkg_multinode_net_e2e_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_multinode_net_e2e_frost_native_test.go
@@ -1,0 +1,239 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package signing
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+
+	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/chain/local_v1"
+	"github.com/keep-network/keep-core/pkg/net"
+	netlocal "github.com/keep-network/keep-core/pkg/net/local"
+	"github.com/keep-network/keep-core/pkg/operator"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// This is the multi-NODE integration test for the distributed-DKG node wiring: n
+// independent nodes, each with its OWN operator key, run the distributed FROST
+// DKG over the REAL pkg/net broadcast transport through the exported
+// RunDistributedDKGForSeats seam - the exact call the node's
+// executeDistributedFrostDKG makes. Unlike the in-process-bus e2e, every round
+// package crosses the real transport adapter and is membership-authenticated
+// against the sender's operator key, and round-2 shares are ECIES-sealed to
+// peers' operator keys LEARNED from their authenticated round-1 broadcasts. So a
+// passing run proves the production orchestration + net bus + key learning +
+// encrypted round-2 all work together over real messaging.
+//
+// All nodes share ONE process-global engine, so each node's persist accumulates
+// its seat's key package into one session; after every node persists, a threshold
+// subset interactive-signs to a BIP-340 signature that verifies under the group
+// key - proving the whole distributed DKG -> persist -> sign path over real
+// transport.
+func TestDistributedDKG_MultiNode_NetTransport(t *testing.T) {
+	setupRealCgoSignerState(t)
+
+	const n = 3
+	const threshold uint16 = 2
+	members := []group.MemberIndex{1, 2, 3}
+	session := fmt.Sprintf("real-cgo-distributed-multinode-%d", realCgoSessionSeq.Add(1))
+	message := bytesOf(0x42, 32)
+
+	engine := &buildTaggedTBTCSignerEngine{}
+
+	// One operator per seat; the MembershipValidator maps each seat to that
+	// operator's address so the DKG bus authenticates every round message's
+	// claimed seat against its authenticated sender key.
+	chainSigning := local_v1.Connect(n, n).Signing()
+	privateKeys := make([]*operator.PrivateKey, n)
+	publicKeys := make([]*operator.PublicKey, n)
+	addresses := make([]chain.Address, n)
+	for i := 0; i < n; i++ {
+		priv, pub, err := operator.GenerateKeyPair(local_v1.DefaultCurve)
+		if err != nil {
+			t.Fatalf("operator key (seat %d): %v", i+1, err)
+		}
+		privateKeys[i] = priv
+		publicKeys[i] = pub
+		addresses[i] = chainSigning.PublicKeyBytesToAddress(operator.MarshalUncompressed(pub))
+	}
+	validator := group.NewMembershipValidator(&testutils.MockLogger{}, addresses, chainSigning)
+
+	// Canonical identifiers over the full participant set (as the node builds them).
+	identifierByID := make(map[group.MemberIndex]string, n)
+	for _, m := range members {
+		identifierByID[m] = CanonicalFROSTIdentifier(uint16(m))
+	}
+
+	channelName := fmt.Sprintf("%s-frost-dkg", session)
+
+	// Join the shared named channel for every node BEFORE running, so no node's
+	// round-1 broadcast is lost to a not-yet-connected peer.
+	channels := make([]net.BroadcastChannel, n)
+	for i := 0; i < n; i++ {
+		channel, err := netlocal.ConnectWithKey(publicKeys[i]).BroadcastChannelFor(channelName)
+		if err != nil {
+			t.Fatalf("broadcast channel (seat %d): %v", i+1, err)
+		}
+		channels[i] = channel
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	type nodeOutcome struct {
+		member  group.MemberIndex
+		persist map[group.MemberIndex]*NativeTBTCSignerDKGResult
+		err     error
+	}
+	outcomes := make(chan nodeOutcome, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		i := i
+		member := members[i]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			persist, err := RunDistributedDKGForSeats(
+				ctx,
+				&testutils.MockLogger{},
+				channels[i],
+				validator,
+				engine,
+				session,
+				members,
+				[]group.MemberIndex{member}, // one seat per node
+				identifierByID,
+				threshold,
+				privateKeys[i],
+			)
+			outcomes <- nodeOutcome{member: member, persist: persist, err: err}
+		}()
+	}
+	wg.Wait()
+	close(outcomes)
+
+	results := make(map[group.MemberIndex]*NativeTBTCSignerDKGResult, n)
+	for outcome := range outcomes {
+		if errors.Is(outcome.err, ErrNativeCryptographyUnavailable) {
+			t.Skip("linked tbtc-signer FFI symbols unavailable")
+		}
+		if outcome.err != nil {
+			t.Fatalf("node for seat %d failed: %v", outcome.member, outcome.err)
+		}
+		seatResult, ok := outcome.persist[outcome.member]
+		if !ok {
+			t.Fatalf("node for seat %d returned no persist result for its own seat", outcome.member)
+		}
+		results[outcome.member] = seatResult
+	}
+
+	// Every node agreed on ONE group key over the real transport.
+	var keyGroup string
+	for _, m := range members {
+		if keyGroup == "" {
+			keyGroup = results[m].KeyGroup
+		} else if results[m].KeyGroup != keyGroup {
+			t.Fatalf("node for seat %d disagreed on the group key: %s != %s", m, results[m].KeyGroup, keyGroup)
+		}
+	}
+	if len(keyGroup) != 66 {
+		t.Fatalf("group key must be a 33-byte compressed key (66 hex chars); got %d", len(keyGroup))
+	}
+	t.Logf("%d nodes agreed on group key %s… over the real net transport", n, keyGroup[:16])
+
+	// ---- Interactive threshold signing over the accumulated session. ----
+	signingMembers := members[:threshold]
+	includedParticipants := make([]uint16, len(signingMembers))
+	for i, m := range signingMembers {
+		includedParticipants[i] = uint16(m)
+	}
+
+	derived, err := engine.DeriveInteractiveAttemptContext(
+		session, message, keyGroup, threshold, 0, includedParticipants,
+	)
+	if err != nil {
+		t.Fatalf("derive interactive attempt context: %v", err)
+	}
+	frostIDByMember := make(map[group.MemberIndex]string, len(derived.FrostIdentifiers))
+	for _, id := range derived.FrostIdentifiers {
+		frostIDByMember[group.MemberIndex(id.ParticipantIdentifier)] = id.FrostIdentifier
+	}
+
+	var attemptID string
+	commitments := make([]nativeFROSTCommitment, 0, len(signingMembers))
+	for _, m := range signingMembers {
+		open, err := engine.InteractiveSessionOpen(
+			session, uint16(m), message, keyGroup, threshold, nil, derived.AttemptContext,
+		)
+		if err != nil {
+			t.Fatalf("interactive session open (member %d): %v", m, err)
+		}
+		if attemptID == "" {
+			attemptID = open.AttemptID
+		}
+		commitmentData, err := engine.InteractiveRound1(session, open.AttemptID, uint16(m))
+		if err != nil {
+			t.Fatalf("interactive round 1 (member %d): %v", m, err)
+		}
+		commitments = append(commitments, nativeFROSTCommitment{
+			Identifier: frostIDByMember[m],
+			Data:       commitmentData,
+		})
+	}
+
+	signingPackage, err := engine.NewSigningPackage(message, commitments)
+	if err != nil {
+		t.Fatalf("new signing package: %v", err)
+	}
+
+	shares := make([]nativeFROSTSignatureShare, 0, len(signingMembers))
+	for _, m := range signingMembers {
+		shareData, err := engine.InteractiveRound2(session, attemptID, uint16(m), signingPackage)
+		if err != nil {
+			t.Fatalf("interactive round 2 (member %d): %v", m, err)
+		}
+		shares = append(shares, nativeFROSTSignatureShare{
+			Identifier: frostIDByMember[m],
+			Data:       shareData,
+		})
+	}
+
+	signatureBytes, err := engine.InteractiveAggregate(session, attemptID, signingPackage, shares, nil)
+	if err != nil {
+		t.Fatalf("interactive aggregate: %v", err)
+	}
+	if len(signatureBytes) != 64 {
+		t.Fatalf("aggregate signature length = %d, want 64", len(signatureBytes))
+	}
+
+	// Verify against the 32-byte x-only group key (the compressed key without its
+	// even-Y "02" prefix).
+	groupKeyBytes, err := hex.DecodeString(keyGroup[2:])
+	if err != nil {
+		t.Fatalf("decode x-only group key: %v", err)
+	}
+	publicKey, err := schnorr.ParsePubKey(groupKeyBytes)
+	if err != nil {
+		t.Fatalf("parse group key: %v", err)
+	}
+	signature, err := schnorr.ParseSignature(signatureBytes)
+	if err != nil {
+		t.Fatalf("parse signature: %v", err)
+	}
+	if !signature.Verify(message, publicKey) {
+		t.Fatal("interactive threshold signature does not verify under the multi-node DKG group key")
+	}
+	t.Logf(
+		"multi-node distributed DKG -> persist -> interactive %d-of-%d signature verifies over real transport",
+		threshold, n,
+	)
+}

--- a/pkg/frost/signing/distributed_dkg_multinode_net_e2e_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_multinode_net_e2e_frost_native_test.go
@@ -49,18 +49,19 @@ func TestDistributedDKG_MultiNode_NetTransport(t *testing.T) {
 	engine := &buildTaggedTBTCSignerEngine{}
 
 	// One operator per seat; the MembershipValidator maps each seat to that
-	// operator's address so the DKG bus authenticates every round message's
-	// claimed seat against its authenticated sender key.
+	// operator's address so the DKG bus authenticates every round message's claimed
+	// seat against its authenticated sender key. The operator key stays bound to the
+	// channel (transport signing) - the DKG itself uses fresh per-seat ephemeral
+	// keys generated inside RunDistributedDKGForSeats, so no operator PRIVATE key is
+	// handed to the DKG (recipient-side forward secrecy).
 	chainSigning := local_v1.Connect(n, n).Signing()
-	privateKeys := make([]*operator.PrivateKey, n)
 	publicKeys := make([]*operator.PublicKey, n)
 	addresses := make([]chain.Address, n)
 	for i := 0; i < n; i++ {
-		priv, pub, err := operator.GenerateKeyPair(local_v1.DefaultCurve)
+		_, pub, err := operator.GenerateKeyPair(local_v1.DefaultCurve)
 		if err != nil {
 			t.Fatalf("operator key (seat %d): %v", i+1, err)
 		}
-		privateKeys[i] = priv
 		publicKeys[i] = pub
 		addresses[i] = chainSigning.PublicKeyBytesToAddress(operator.MarshalUncompressed(pub))
 	}
@@ -112,7 +113,6 @@ func TestDistributedDKG_MultiNode_NetTransport(t *testing.T) {
 				[]group.MemberIndex{member}, // one seat per node
 				identifierByID,
 				threshold,
-				privateKeys[i],
 			)
 			outcomes <- nodeOutcome{member: member, persist: persist, err: err}
 		}()

--- a/pkg/frost/signing/distributed_dkg_multinode_net_e2e_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_multinode_net_e2e_frost_native_test.go
@@ -5,7 +5,6 @@ package signing
 import (
 	"context"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -123,12 +122,14 @@ func TestDistributedDKG_MultiNode_NetTransport(t *testing.T) {
 
 	results := make(map[group.MemberIndex]*NativeTBTCSignerDKGResult, n)
 	for outcome := range outcomes {
-		if errors.Is(outcome.err, ErrNativeCryptographyUnavailable) {
-			t.Skip("linked tbtc-signer FFI symbols unavailable")
-		}
-		if outcome.err != nil {
-			t.Fatalf("node for seat %d failed: %v", outcome.member, outcome.err)
-		}
+		// Skips in dev when the lib is absent/stale, but FAILS under the require-cgo
+		// gate (and fatals on any other error), so the cgo job cannot silently drop
+		// this coverage.
+		skipFrostUnavailable(
+			t,
+			fmt.Sprintf("multi-node distributed DKG (seat %d)", outcome.member),
+			outcome.err,
+		)
 		seatResult, ok := outcome.persist[outcome.member]
 		if !ok {
 			t.Fatalf("node for seat %d returned no persist result for its own seat", outcome.member)

--- a/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/ipfs/go-log/v2"
 
+	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
 	"github.com/keep-network/keep-core/pkg/net"
-	"github.com/keep-network/keep-core/pkg/operator"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
@@ -82,22 +82,10 @@ func RunDistributedDKGForSeats(
 	localMemberIndexes []group.MemberIndex,
 	identifierByID map[group.MemberIndex]string,
 	threshold uint16,
-	selfOperatorKey *operator.PrivateKey,
 ) (map[group.MemberIndex]*NativeTBTCSignerDKGResult, error) {
 	if len(localMemberIndexes) == 0 {
 		return nil, fmt.Errorf("no local seats to run the distributed DKG for")
 	}
-	if selfOperatorKey == nil {
-		return nil, fmt.Errorf("self operator key is nil")
-	}
-
-	// One operator key for every local seat: peers learn each seat's round-2
-	// sealing key from the authenticated operator key on its round-1 broadcasts.
-	selfKey, err := operatorPrivateKeyToEphemeral(selfOperatorKey)
-	if err != nil {
-		return nil, fmt.Errorf("cannot convert operator private key to ephemeral: [%v]", err)
-	}
-	selfPublicKey := operator.MarshalUncompressed(&selfOperatorKey.PublicKey)
 
 	bus, err := NewBroadcastChannelDKGBus(ctx, logger, channel, membershipValidator)
 	if err != nil {
@@ -110,6 +98,16 @@ func RunDistributedDKGForSeats(
 	// bus before any of them broadcasts round 1.
 	runners := make(map[group.MemberIndex]*distributedDKGRunner, len(localMemberIndexes))
 	for _, seat := range localMemberIndexes {
+		// A FRESH per-DKG ephemeral key pair per seat: peers seal this seat's round-2
+		// shares to its ephemeral public key (learned from its authenticated round-1
+		// broadcast) and it opens them with the ephemeral private key, which is
+		// discarded when the DKG ends. This gives the shares two-sided forward
+		// secrecy - a recorded broadcast plus a later operator-key leak reveals
+		// nothing, because the sealing key never existed at rest.
+		seatEphemeral, err := ephemeral.GenerateKeyPair()
+		if err != nil {
+			return nil, fmt.Errorf("cannot generate the ephemeral key for seat [%v]: [%v]", seat, err)
+		}
 		runner, err := newDistributedDKGRunner(
 			seat,
 			session,
@@ -118,8 +116,8 @@ func RunDistributedDKGForSeats(
 			threshold,
 			engine,
 			bus,
-			selfKey,
-			selfPublicKey,
+			seatEphemeral.PrivateKey,
+			seatEphemeral.PublicKey.Marshal(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create the distributed DKG runner for seat [%v]: [%w]", seat, err)

--- a/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
@@ -1,0 +1,192 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ipfs/go-log/v2"
+
+	"github.com/keep-network/keep-core/pkg/net"
+	"github.com/keep-network/keep-core/pkg/operator"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// NativeTBTCSignerDistributedDKGEngine is the engine capability the distributed
+// DKG orchestration needs but the base NativeTBTCSignerEngine interface does not
+// expose: the stateless three-round FROST primitives plus the op that persists a
+// seat's own key package as signing material. The node type-asserts
+// CurrentNativeTBTCSignerEngine() to this, mirroring how the transitional dealer
+// path asserts NativeTBTCSignerSeededDKGEngine for RunDKGWithSeed.
+type NativeTBTCSignerDistributedDKGEngine interface {
+	Part1(participantIdentifier string, maxSigners, minSigners uint16) (*NativeFROSTDKGPart1Result, error)
+	Part2(
+		secretPackage *NativeFROSTDKGRound1SecretPackage,
+		round1Packages []*NativeFROSTDKGRound1Package,
+	) (*NativeFROSTDKGPart2Result, error)
+	Part3(
+		secretPackage *NativeFROSTDKGRound2SecretPackage,
+		round1Packages []*NativeFROSTDKGRound1Package,
+		round2Packages []*NativeFROSTDKGRound2Package,
+	) (*NativeFROSTDKGResult, error)
+	PersistDistributedDKGKeyPackage(
+		sessionID string,
+		participantIdentifier uint16,
+		threshold uint16,
+		participantCount uint16,
+		keyPackage *NativeFROSTKeyPackage,
+		publicKeyPackage *NativeFROSTPublicKeyPackage,
+	) (*NativeTBTCSignerDKGResult, error)
+}
+
+// CanonicalFROSTIdentifier returns the canonical FROST identifier string for a
+// participant: the identifier as a 32-byte big-endian scalar (value in the
+// least-significant byte), hex-encoded and JSON-quoted. It matches the engine's
+// participant_identifier_to_frost_identifier, which PersistDistributedDKGKeyPackage
+// re-derives and rejects a mismatch against, and which the interactive signing
+// path looks members up by. Callers build identifierByID over the FULL participant
+// set with this (NOT the byte-0 scheme used by the stateless DKG tests).
+func CanonicalFROSTIdentifier(participantIdentifier uint16) string {
+	var id [32]byte
+	binary.BigEndian.PutUint16(id[30:], participantIdentifier)
+	return fmt.Sprintf("%q", hex.EncodeToString(id[:]))
+}
+
+// RunDistributedDKGForSeats runs a real distributed FROST DKG for every local
+// seat of this node over the wallet broadcast channel and persists each seat's
+// resulting key package as signing material, returning the per-seat persist
+// result (all sharing the same group key). It replaces the transitional
+// trusted-dealer RunDKGWithSeed for the node's wallet DKG.
+//
+// memberIndexes is the FULL participant set (the final compact DKG member space);
+// localMemberIndexes are this node's seats in that same space; identifierByID must
+// map EVERY member in memberIndexes to its CanonicalFROSTIdentifier. selfOperatorKey
+// is this node's operator key (shared by all its local seats): round-2 shares are
+// ECIES-sealed to peers' operator keys learned from their authenticated round-1
+// broadcasts, so the channel MUST be the membership-validated wallet channel.
+//
+// One orchestrator runs per local seat. All local runners are constructed (and
+// thereby subscribed to the shared bus) BEFORE any of them starts, so no
+// co-located seat's round-1 broadcast is missed once the channel loops it back.
+func RunDistributedDKGForSeats(
+	ctx context.Context,
+	logger log.StandardLogger,
+	channel net.BroadcastChannel,
+	membershipValidator *group.MembershipValidator,
+	engine NativeTBTCSignerDistributedDKGEngine,
+	session string,
+	memberIndexes []group.MemberIndex,
+	localMemberIndexes []group.MemberIndex,
+	identifierByID map[group.MemberIndex]string,
+	threshold uint16,
+	selfOperatorKey *operator.PrivateKey,
+) (map[group.MemberIndex]*NativeTBTCSignerDKGResult, error) {
+	if len(localMemberIndexes) == 0 {
+		return nil, fmt.Errorf("no local seats to run the distributed DKG for")
+	}
+	if selfOperatorKey == nil {
+		return nil, fmt.Errorf("self operator key is nil")
+	}
+
+	// One operator key for every local seat: peers learn each seat's round-2
+	// sealing key from the authenticated operator key on its round-1 broadcasts.
+	selfKey, err := operatorPrivateKeyToEphemeral(selfOperatorKey)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert operator private key to ephemeral: [%v]", err)
+	}
+	selfPublicKey := operator.MarshalUncompressed(&selfOperatorKey.PublicKey)
+
+	bus, err := NewBroadcastChannelDKGBus(ctx, logger, channel, membershipValidator)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create the distributed DKG bus: [%v]", err)
+	}
+
+	participantCount := uint16(len(memberIndexes))
+
+	// Construct every local runner FIRST so all local seats are subscribed to the
+	// bus before any of them broadcasts round 1.
+	runners := make(map[group.MemberIndex]*distributedDKGRunner, len(localMemberIndexes))
+	for _, seat := range localMemberIndexes {
+		runner, err := newDistributedDKGRunner(
+			seat,
+			session,
+			memberIndexes,
+			identifierByID,
+			threshold,
+			engine,
+			bus,
+			selfKey,
+			selfPublicKey,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("cannot create the distributed DKG runner for seat [%v]: [%v]", seat, err)
+		}
+		runners[seat] = runner
+	}
+
+	type seatOutcome struct {
+		member  group.MemberIndex
+		persist *NativeTBTCSignerDKGResult
+		err     error
+	}
+	outcomes := make(chan seatOutcome, len(runners))
+	for seat, runner := range runners {
+		seat := seat
+		runner := runner
+		go func() {
+			dkgResult, err := runner.Run(ctx)
+			if err != nil {
+				outcomes <- seatOutcome{member: seat, err: fmt.Errorf("distributed DKG for seat [%v] failed: [%v]", seat, err)}
+				return
+			}
+			persisted, err := engine.PersistDistributedDKGKeyPackage(
+				session,
+				uint16(seat),
+				threshold,
+				participantCount,
+				dkgResult.KeyPackage,
+				dkgResult.PublicKeyPackage,
+			)
+			if err != nil {
+				outcomes <- seatOutcome{member: seat, err: fmt.Errorf("cannot persist the key package for seat [%v]: [%v]", seat, err)}
+				return
+			}
+			outcomes <- seatOutcome{member: seat, persist: persisted}
+		}()
+	}
+
+	persistBySeat := make(map[group.MemberIndex]*NativeTBTCSignerDKGResult, len(runners))
+	var keyGroup string
+	var firstErr error
+	for range runners {
+		outcome := <-outcomes
+		if outcome.err != nil {
+			// Keep draining so no goroutine blocks on the channel, but remember the
+			// first failure to return once all seats have reported.
+			if firstErr == nil {
+				firstErr = outcome.err
+			}
+			continue
+		}
+		if keyGroup == "" {
+			keyGroup = outcome.persist.KeyGroup
+		} else if outcome.persist.KeyGroup != keyGroup {
+			if firstErr == nil {
+				firstErr = fmt.Errorf(
+					"local seats disagreed on the group key: [%s] != [%s]",
+					outcome.persist.KeyGroup, keyGroup,
+				)
+			}
+			continue
+		}
+		persistBySeat[outcome.member] = outcome.persist
+	}
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	return persistBySeat, nil
+}

--- a/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
@@ -146,6 +146,15 @@ func RunDistributedDKGForSeats(
 				outcomes <- seatOutcome{member: seat, err: fmt.Errorf("distributed DKG for seat [%v] failed: [%w]", seat, err)}
 				return
 			}
+			// dkgResult.KeyPackage.Data is this seat's long-term SECRET share. The engine
+			// holds the authoritative copy after PersistDistributedDKGKeyPackage; scrub the
+			// Go-side copy when this goroutine returns (on the persist-success AND
+			// persist-error paths) so it does not linger in the heap - and thus a later
+			// core dump or swap - past persistence. The returned persist result carries
+			// only public material (key group), so scrubbing does not affect it.
+			if dkgResult.KeyPackage != nil {
+				defer zeroBytes(dkgResult.KeyPackage.Data)
+			}
 			persisted, err := engine.PersistDistributedDKGKeyPackage(
 				session,
 				uint16(seat),

--- a/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
@@ -83,6 +83,7 @@ func RunDistributedDKGForSeats(
 	localMemberIndexes []group.MemberIndex,
 	identifierByID map[group.MemberIndex]string,
 	threshold uint16,
+	prebuffer *DKGMessagePrebuffer,
 ) (map[group.MemberIndex]*NativeTBTCSignerDKGResult, error) {
 	if len(localMemberIndexes) == 0 {
 		return nil, fmt.Errorf("no local seats to run the distributed DKG for")
@@ -130,6 +131,15 @@ func RunDistributedDKGForSeats(
 	// messages - so no peer's early round-1 is handled with no subscriber and
 	// dropped (which the transport would not retransmit).
 	bus.Start()
+
+	// Replay anything the prebuffer captured BEFORE the readiness barrier: a peer that
+	// the barrier released ahead of us may have broadcast its round-1 before this node
+	// reached Start, and the transport would neither deliver (no subscriber yet) nor
+	// retransmit it. The prebuffer caught those off the channel from before the barrier;
+	// feed them through now (deduped against live delivery by content hash).
+	if prebuffer != nil {
+		bus.Replay(prebuffer.Drain())
+	}
 
 	type seatOutcome struct {
 		member  group.MemberIndex

--- a/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
@@ -127,6 +127,11 @@ func RunDistributedDKGForSeats(
 		runners[seat] = runner
 	}
 
+	// Only now that every local seat is subscribed, begin delivering inbound
+	// messages - so no peer's early round-1 is handled with no subscriber and
+	// dropped (which the transport would not retransmit).
+	bus.Start()
+
 	type seatOutcome struct {
 		member  group.MemberIndex
 		persist *NativeTBTCSignerDKGResult

--- a/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
@@ -132,13 +132,14 @@ func RunDistributedDKGForSeats(
 	// dropped (which the transport would not retransmit).
 	bus.Start()
 
-	// Replay anything the prebuffer captured BEFORE the readiness barrier: a peer that
-	// the barrier released ahead of us may have broadcast its round-1 before this node
-	// reached Start, and the transport would neither deliver (no subscriber yet) nor
-	// retransmit it. The prebuffer caught those off the channel from before the barrier;
-	// feed them through now (deduped against live delivery by content hash).
+	// Hand the prebuffer off to the live bus. It caught round-1 messages a peer broadcast
+	// after the readiness barrier released it but before this node reached Start (which
+	// the transport would neither deliver - no subscriber yet - nor retransmit). Draining
+	// and forwarding is race-free: the captured buffer is delivered AND any message the
+	// prebuffer catches around the drain instant is forwarded live, so none is lost in the
+	// handoff window. Deduped against live delivery by content hash.
 	if prebuffer != nil {
-		bus.Replay(prebuffer.Drain())
+		prebuffer.DrainAndForward(bus.Deliver)
 	}
 
 	type seatOutcome struct {

--- a/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
@@ -63,10 +63,11 @@ func CanonicalFROSTIdentifier(participantIdentifier uint16) string {
 //
 // memberIndexes is the FULL participant set (the final compact DKG member space);
 // localMemberIndexes are this node's seats in that same space; identifierByID must
-// map EVERY member in memberIndexes to its CanonicalFROSTIdentifier. selfOperatorKey
-// is this node's operator key (shared by all its local seats): round-2 shares are
-// ECIES-sealed to peers' operator keys learned from their authenticated round-1
-// broadcasts, so the channel MUST be the membership-validated wallet channel.
+// map EVERY member in memberIndexes to its CanonicalFROSTIdentifier. Round-2 shares
+// are ECIES-sealed to peers' per-DKG EPHEMERAL keys (generated here, one per local
+// seat) learned from their authenticated round-1 broadcasts, so the channel MUST be
+// the membership-validated wallet channel; the operator key stays bound to that
+// channel and never reaches the DKG.
 //
 // One orchestrator runs per local seat. All local runners are constructed (and
 // thereby subscribed to the shared bus) BEFORE any of them starts, so no

--- a/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_orchestration_frost_native.go
@@ -122,7 +122,7 @@ func RunDistributedDKGForSeats(
 			selfPublicKey,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("cannot create the distributed DKG runner for seat [%v]: [%v]", seat, err)
+			return nil, fmt.Errorf("cannot create the distributed DKG runner for seat [%v]: [%w]", seat, err)
 		}
 		runners[seat] = runner
 	}
@@ -144,7 +144,7 @@ func RunDistributedDKGForSeats(
 		go func() {
 			dkgResult, err := runner.Run(ctx)
 			if err != nil {
-				outcomes <- seatOutcome{member: seat, err: fmt.Errorf("distributed DKG for seat [%v] failed: [%v]", seat, err)}
+				outcomes <- seatOutcome{member: seat, err: fmt.Errorf("distributed DKG for seat [%v] failed: [%w]", seat, err)}
 				return
 			}
 			persisted, err := engine.PersistDistributedDKGKeyPackage(
@@ -156,7 +156,7 @@ func RunDistributedDKGForSeats(
 				dkgResult.PublicKeyPackage,
 			)
 			if err != nil {
-				outcomes <- seatOutcome{member: seat, err: fmt.Errorf("cannot persist the key package for seat [%v]: [%v]", seat, err)}
+				outcomes <- seatOutcome{member: seat, err: fmt.Errorf("cannot persist the key package for seat [%v]: [%w]", seat, err)}
 				return
 			}
 			outcomes <- seatOutcome{member: seat, persist: persisted}

--- a/pkg/frost/signing/distributed_dkg_orchestration_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_orchestration_frost_native_test.go
@@ -1,0 +1,48 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+)
+
+// TestCanonicalFROSTIdentifier pins the canonical identifier string the node
+// builds for the DKG to the engine's participant_identifier_to_frost_identifier:
+// the participant as a 32-byte big-endian scalar (value in the LEAST-significant
+// byte), hex-encoded and JSON-quoted. The persist op re-derives and rejects a
+// mismatch, so a regression here would silently break DKG-to-signing.
+func TestCanonicalFROSTIdentifier(t *testing.T) {
+	// Member 1 -> 31 zero bytes then 0x01.
+	id1 := make([]byte, 32)
+	id1[31] = 0x01
+	if got, want := CanonicalFROSTIdentifier(1), fmt.Sprintf("%q", hex.EncodeToString(id1)); got != want {
+		t.Fatalf("CanonicalFROSTIdentifier(1) = %s, want %s", got, want)
+	}
+
+	// Member 256 -> the high byte sits at id[30], id[31] is zero (big-endian).
+	id256 := make([]byte, 32)
+	id256[30] = 0x01
+	if got, want := CanonicalFROSTIdentifier(256), fmt.Sprintf("%q", hex.EncodeToString(id256)); got != want {
+		t.Fatalf("CanonicalFROSTIdentifier(256) = %s, want %s", got, want)
+	}
+
+	// The value is quoted (the engine returns the JSON/textual form of the frost
+	// identifier, not a bare hex string).
+	got := CanonicalFROSTIdentifier(1)
+	if len(got) < 2 || got[0] != '"' || got[len(got)-1] != '"' {
+		t.Fatalf("CanonicalFROSTIdentifier(1) = %s, want a quoted string", got)
+	}
+
+	// Injective over a range spanning the single-byte boundary (distinct scalars
+	// give distinct identifiers, which newDistributedDKGRunner requires).
+	seen := make(map[string]struct{}, 260)
+	for m := uint16(1); m <= 260; m++ {
+		id := CanonicalFROSTIdentifier(m)
+		if _, dup := seen[id]; dup {
+			t.Fatalf("CanonicalFROSTIdentifier is not injective at member %d", m)
+		}
+		seen[id] = struct{}{}
+	}
+}

--- a/pkg/frost/signing/distributed_dkg_persist_interactive_e2e_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_persist_interactive_e2e_frost_native_test.go
@@ -176,6 +176,18 @@ func TestDistributedDKG_PersistThenInteractiveSign(t *testing.T) {
 		frostIDByMember[group.MemberIndex(id.ParticipantIdentifier)] = id.FrostIdentifier
 	}
 
+	// The node builds DKG identifiers with CanonicalFROSTIdentifier; it must equal
+	// what the engine derives for the same participant, or the DKG shares under an
+	// identifier the signing path cannot look up.
+	for _, m := range signingMembers {
+		if got := CanonicalFROSTIdentifier(uint16(m)); got != frostIDByMember[m] {
+			t.Fatalf(
+				"CanonicalFROSTIdentifier(%d) = %s, but the engine derived %s",
+				m, got, frostIDByMember[m],
+			)
+		}
+	}
+
 	// Open + Round1 for each signing seat ON ITS OWN engine (its persisted state).
 	var attemptID string
 	commitments := make([]nativeFROSTCommitment, 0, len(signingMembers))

--- a/pkg/frost/signing/distributed_dkg_persist_interactive_e2e_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_persist_interactive_e2e_frost_native_test.go
@@ -5,7 +5,6 @@ package signing
 import (
 	"context"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -112,14 +111,10 @@ func TestDistributedDKG_PersistThenInteractiveSign(t *testing.T) {
 	wg.Wait()
 
 	for _, m := range members {
-		if errors.Is(outcomes[m].err, ErrNativeCryptographyUnavailable) {
-			t.Skip("linked tbtc-signer FFI symbols unavailable")
-		}
+		// Skips in dev when the lib is absent/stale, fails under the require-cgo gate.
+		skipFrostUnavailable(t, fmt.Sprintf("distributed DKG (member %d)", m), outcomes[m].err)
 	}
 	for _, m := range members {
-		if outcomes[m].err != nil {
-			t.Fatalf("member %d distributed DKG failed: %v", m, outcomes[m].err)
-		}
 		if outcomes[m].result == nil || outcomes[m].result.KeyPackage == nil ||
 			outcomes[m].result.PublicKeyPackage == nil {
 			t.Fatalf("member %d produced an incomplete DKG result", m)

--- a/pkg/frost/signing/distributed_dkg_persist_interactive_e2e_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_persist_interactive_e2e_frost_native_test.go
@@ -1,0 +1,253 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package signing
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// This is the end-to-end proof that a DISTRIBUTED FROST DKG produces usable
+// signing material through the persist bridge. The distributed-DKG orchestrator
+// test (distributed_dkg_runner_real_cgo_frost_native_test.go) signs via the
+// STATELESS path (passing each seat's raw KeyPackage bytes straight into Sign),
+// which never touches persisted engine state. Production signs via the
+// INTERACTIVE path, which loads the key from the engine's persisted session
+// state (dkg_key_packages by member + the public key package) - material the
+// dealer RunDKG persists but distributed Part3 previously discarded.
+//
+// So this test drives the real chain the tBTC node needs:
+//
+//	distributed DKG (bus-orchestrated Part1/2/3)
+//	  -> PersistDistributedDKGKeyPackage  (the bridge under test)
+//	  -> InteractiveSessionOpen / Round1 / Round2 / Aggregate
+//	  -> a BIP-340 signature that verifies under the DKG group key.
+//
+// Crucially, each seat runs on its OWN engine with its OWN persisted state -
+// exactly how nodes deploy, and unlike the dealer path (and the multi-seat
+// interactive test) where every key package lives in one engine. A distributed
+// node holds only its own secret key package; that this still opens, releases a
+// share, and aggregates into a valid threshold signature is the whole point.
+func TestDistributedDKG_PersistThenInteractiveSign(t *testing.T) {
+	setupRealCgoSignerState(t)
+
+	const n = 3
+	const threshold uint16 = 2
+	members := []group.MemberIndex{1, 2, 3}
+	sessionID := fmt.Sprintf("real-cgo-distributed-persist-%d", realCgoSessionSeq.Add(1))
+	message := bytesOf(0x42, 32)
+
+	// Per-seat engines: each node has its OWN engine + persisted state, as
+	// production deploys them. (The dealer path and the multi-seat interactive
+	// test put every key package in one engine; a real distributed node does not.)
+	engines := make(map[group.MemberIndex]*buildTaggedTBTCSignerEngine, n)
+	for _, m := range members {
+		engines[m] = &buildTaggedTBTCSignerEngine{}
+	}
+
+	// CANONICAL FROST identifiers: participant_identifier_to_frost_identifier(m)
+	// serializes the scalar m big-endian (member index in the LEAST-significant
+	// byte). Unlike the byte-0 scheme the stateless DKG tests use, these must be
+	// canonical here because the persist op re-derives each seat's identifier from
+	// its participant index and rejects a mismatch, and the interactive signing
+	// path looks members up by the same canonical identifier.
+	canonicalFrostIdentifier := func(m byte) string {
+		id := make([]byte, 32)
+		id[31] = m
+		return fmt.Sprintf("%q", hex.EncodeToString(id))
+	}
+	identifiers := make(map[group.MemberIndex]string, n)
+	for _, m := range members {
+		identifiers[m] = canonicalFrostIdentifier(byte(m))
+	}
+
+	bus := NewInProcessDKGBus(64)
+	priv, pub := dkgTestKeys(t, members)
+
+	// ---- Distributed DKG across the per-seat engines. ----
+	runners := make(map[group.MemberIndex]*distributedDKGRunner, n)
+	for _, m := range members {
+		runner, err := newDistributedDKGRunner(
+			m, sessionID, members, identifiers, threshold, engines[m], bus, priv[m], pub[m],
+		)
+		if err != nil {
+			t.Fatalf("new runner (member %d): %v", m, err)
+		}
+		runners[m] = runner
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	type seatOutcome struct {
+		result *NativeFROSTDKGResult
+		err    error
+	}
+	outcomes := make(map[group.MemberIndex]*seatOutcome, n)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, m := range members {
+		m := m
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result, err := runners[m].Run(ctx)
+			mu.Lock()
+			outcomes[m] = &seatOutcome{result: result, err: err}
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	for _, m := range members {
+		if errors.Is(outcomes[m].err, ErrNativeCryptographyUnavailable) {
+			t.Skip("linked tbtc-signer FFI symbols unavailable")
+		}
+	}
+	for _, m := range members {
+		if outcomes[m].err != nil {
+			t.Fatalf("member %d distributed DKG failed: %v", m, outcomes[m].err)
+		}
+		if outcomes[m].result == nil || outcomes[m].result.KeyPackage == nil ||
+			outcomes[m].result.PublicKeyPackage == nil {
+			t.Fatalf("member %d produced an incomplete DKG result", m)
+		}
+	}
+	groupVerifyingKey := outcomes[members[0]].result.PublicKeyPackage.VerifyingKey
+
+	// ---- The bridge under test: persist each seat's OWN key package into its
+	// OWN engine, making a distributed-DKG share loadable for interactive signing.
+	// Every seat must derive the SAME key group, equal to the DKG group key. ----
+	var keyGroup string
+	for _, m := range members {
+		persisted, err := engines[m].PersistDistributedDKGKeyPackage(
+			sessionID,
+			uint16(m),
+			threshold,
+			uint16(n),
+			outcomes[m].result.KeyPackage,
+			outcomes[m].result.PublicKeyPackage,
+		)
+		if err != nil {
+			t.Fatalf("persist distributed DKG key package (member %d): %v", m, err)
+		}
+		if keyGroup == "" {
+			keyGroup = persisted.KeyGroup
+		} else if persisted.KeyGroup != keyGroup {
+			t.Fatalf("member %d persisted a different key group: %s != %s", m, persisted.KeyGroup, keyGroup)
+		}
+	}
+	// The persisted key group is the 33-byte COMPRESSED verifying key - the form
+	// run_dkg stores and the signing path consumes (even-Y taproot key, so a "02"
+	// prefix); the DKG result exposes the 32-byte x-only key. They must denote the
+	// same key.
+	if len(keyGroup) != 66 || keyGroup[2:] != groupVerifyingKey {
+		t.Fatalf("persisted key group %s does not match DKG group verifying key %s", keyGroup, groupVerifyingKey)
+	}
+
+	// ---- Interactive threshold signing over the persisted material: any t of n. ----
+	signingMembers := members[:threshold] // {1, 2}
+	includedParticipants := make([]uint16, len(signingMembers))
+	for i, m := range signingMembers {
+		includedParticipants[i] = uint16(m)
+	}
+
+	// The attempt context is deterministic; derive it once (any engine agrees).
+	derived, err := engines[signingMembers[0]].DeriveInteractiveAttemptContext(
+		sessionID, message, keyGroup, threshold, 0, includedParticipants,
+	)
+	if err != nil {
+		t.Fatalf("derive interactive attempt context: %v", err)
+	}
+	frostIDByMember := make(map[group.MemberIndex]string, len(derived.FrostIdentifiers))
+	for _, id := range derived.FrostIdentifiers {
+		frostIDByMember[group.MemberIndex(id.ParticipantIdentifier)] = id.FrostIdentifier
+	}
+
+	// Open + Round1 for each signing seat ON ITS OWN engine (its persisted state).
+	var attemptID string
+	commitments := make([]nativeFROSTCommitment, 0, len(signingMembers))
+	for _, m := range signingMembers {
+		open, err := engines[m].InteractiveSessionOpen(
+			sessionID, uint16(m), message, keyGroup, threshold, nil, derived.AttemptContext,
+		)
+		if err != nil {
+			t.Fatalf("interactive session open (member %d): %v", m, err)
+		}
+		if attemptID == "" {
+			attemptID = open.AttemptID
+		} else if open.AttemptID != attemptID {
+			t.Fatalf("seats derived different attempt ids (%q vs %q)", attemptID, open.AttemptID)
+		}
+		commitmentData, err := engines[m].InteractiveRound1(sessionID, open.AttemptID, uint16(m))
+		if err != nil {
+			t.Fatalf("interactive round 1 (member %d): %v", m, err)
+		}
+		commitments = append(commitments, nativeFROSTCommitment{
+			Identifier: frostIDByMember[m],
+			Data:       commitmentData,
+		})
+	}
+
+	// The coordinator assembles the signing package (stateless).
+	signingPackage, err := engines[signingMembers[0]].NewSigningPackage(message, commitments)
+	if err != nil {
+		t.Fatalf("new signing package: %v", err)
+	}
+
+	// Round2 for each signing seat ON ITS OWN engine: each releases its share from
+	// its own persisted key package.
+	shares := make([]nativeFROSTSignatureShare, 0, len(signingMembers))
+	for _, m := range signingMembers {
+		shareData, err := engines[m].InteractiveRound2(sessionID, attemptID, uint16(m), signingPackage)
+		if err != nil {
+			t.Fatalf("interactive round 2 (member %d): %v", m, err)
+		}
+		shares = append(shares, nativeFROSTSignatureShare{
+			Identifier: frostIDByMember[m],
+			Data:       shareData,
+		})
+	}
+
+	// The coordinator aggregates the shares into a BIP-340 signature.
+	signatureBytes, err := engines[signingMembers[0]].InteractiveAggregate(
+		sessionID, attemptID, signingPackage, shares, nil,
+	)
+	if err != nil {
+		t.Fatalf("interactive aggregate: %v", err)
+	}
+	if len(signatureBytes) != 64 {
+		t.Fatalf("aggregate signature length = %d, want 64", len(signatureBytes))
+	}
+
+	// ---- GOLD: the interactive threshold signature verifies under the DKG group
+	// key - proving the persisted distributed-DKG shares sign correctly. ----
+	// Verify against the 32-byte x-only group key (schnorr/BIP-340 form).
+	groupKeyBytes, err := hex.DecodeString(groupVerifyingKey)
+	if err != nil {
+		t.Fatalf("decode group verifying key: %v", err)
+	}
+	publicKey, err := schnorr.ParsePubKey(groupKeyBytes)
+	if err != nil {
+		t.Fatalf("parse group key: %v", err)
+	}
+	signature, err := schnorr.ParseSignature(signatureBytes)
+	if err != nil {
+		t.Fatalf("parse signature: %v", err)
+	}
+	if !signature.Verify(message, publicKey) {
+		t.Fatal("interactive threshold signature does not verify under the distributed-DKG group key")
+	}
+	t.Logf(
+		"distributed DKG -> persist -> interactive %d-of-%d signature verifies under group key %s…",
+		threshold, n, keyGroup[:16],
+	)
+}

--- a/pkg/frost/signing/distributed_dkg_persist_interactive_e2e_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_persist_interactive_e2e_frost_native_test.go
@@ -45,9 +45,13 @@ func TestDistributedDKG_PersistThenInteractiveSign(t *testing.T) {
 	sessionID := fmt.Sprintf("real-cgo-distributed-persist-%d", realCgoSessionSeq.Add(1))
 	message := bytesOf(0x42, 32)
 
-	// Per-seat engines: each node has its OWN engine + persisted state, as
-	// production deploys them. (The dealer path and the multi-seat interactive
-	// test put every key package in one engine; a real distributed node does not.)
+	// One engine handle per seat. NOTE: in-process these are all handles to the
+	// SAME global engine state, so persisting each seat ACCUMULATES its key
+	// package into one shared session - that is what lets the seats sign together
+	// here, and it exercises the multi-seat-operator accumulate path. In
+	// production each node is a separate process with its own state holding only
+	// its own seat; that single-seat case (a node opening a session whose included
+	// set spans peers it does not hold) is covered separately at the end.
 	engines := make(map[group.MemberIndex]*buildTaggedTBTCSignerEngine, n)
 	for _, m := range members {
 		engines[m] = &buildTaggedTBTCSignerEngine{}
@@ -250,4 +254,38 @@ func TestDistributedDKG_PersistThenInteractiveSign(t *testing.T) {
 		"distributed DKG -> persist -> interactive %d-of-%d signature verifies under group key %s…",
 		threshold, n, keyGroup[:16],
 	)
+
+	// ---- Single-seat-node coverage: a node that persisted ONLY its own key
+	// package must still OPEN a session whose included set spans OTHER members it
+	// does not hold - OPEN validates the included set against the public key
+	// package's verifying shares, not the local key-package map. This is the real
+	// distributed-node scenario the all-seats-accumulated path above does not
+	// exercise (there every included member is already in dkg_key_packages). ----
+	soloSession := sessionID + "-solo"
+	soloResult, err := engines[members[0]].PersistDistributedDKGKeyPackage(
+		soloSession,
+		uint16(members[0]),
+		threshold,
+		uint16(n),
+		outcomes[members[0]].result.KeyPackage,
+		outcomes[members[0]].result.PublicKeyPackage,
+	)
+	if err != nil {
+		t.Fatalf("persist single seat into a fresh session: %v", err)
+	}
+	soloDerived, err := engines[members[0]].DeriveInteractiveAttemptContext(
+		soloSession, message, soloResult.KeyGroup, threshold, 0, includedParticipants,
+	)
+	if err != nil {
+		t.Fatalf("derive single-seat attempt context: %v", err)
+	}
+	// members[1] is a DKG participant (present in the public key package) but was
+	// NOT persisted into soloSession, so its member entry is absent from that
+	// session's key-package map; the open must still succeed.
+	if _, err := engines[members[0]].InteractiveSessionOpen(
+		soloSession, uint16(members[0]), message, soloResult.KeyGroup, threshold, nil, soloDerived.AttemptContext,
+	); err != nil {
+		t.Fatalf("single-seat open with an included set spanning peers must succeed: %v", err)
+	}
+	t.Logf("single-seat node (only its own key package) opened a session spanning peers via the public key package")
 }

--- a/pkg/frost/signing/distributed_dkg_round2_seal_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_round2_seal_frost_native.go
@@ -55,6 +55,9 @@ func sealRound2Share(share []byte, recipient *ephemeral.PublicKey) (*sealedRound
 	if err != nil {
 		return nil, fmt.Errorf("distributed dkg: generate ephemeral key: %w", err)
 	}
+	// Scrub the one-time sender ephemeral after sealing so it does not linger at
+	// rest; only its PUBLIC half travels in the envelope.
+	defer oneTime.PrivateKey.Zero()
 	ciphertext, err := oneTime.PrivateKey.Ecdh(recipient).Encrypt(share)
 	if err != nil {
 		return nil, fmt.Errorf("distributed dkg: seal round-2 share: %w", err)
@@ -65,8 +68,8 @@ func sealRound2Share(share []byte, recipient *ephemeral.PublicKey) (*sealedRound
 	}, nil
 }
 
-// openRound2Share recovers a round-2 share sealed to us, using our static
-// (operator) private key and the ephemeral public key carried in the envelope.
+// openRound2Share recovers a round-2 share sealed to us, using our per-DKG
+// ephemeral private key and the ephemeral public key carried in the envelope.
 // A share sealed to another member, or a tampered envelope, fails to open (the
 // underlying box is authenticated) rather than yielding a wrong share.
 func openRound2Share(sealed *sealedRound2Share, self *ephemeral.PrivateKey) ([]byte, error) {

--- a/pkg/frost/signing/distributed_dkg_round2_seal_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_round2_seal_frost_native.go
@@ -15,15 +15,17 @@ import (
 // clear would leak to every other member. This file seals each share to its
 // recipient with an ECIES envelope over the existing pkg/crypto/ephemeral ECDH:
 // the sender derives a symmetric key from a ONE-TIME ephemeral private key and
-// the recipient's static (operator) public key, encrypts the share, and carries
-// the ephemeral PUBLIC key alongside the ciphertext. Only the recipient, via ECDH
-// between its private key and that ephemeral public key, recovers the same
-// symmetric key and opens the share. The sender's ephemeral private key is
-// discarded after sealing, giving per-message forward secrecy on the sender side.
+// the recipient's public key, encrypts the share, and carries the ephemeral
+// PUBLIC key alongside the ciphertext. Only the recipient, via ECDH between its
+// private key and that ephemeral public key, recovers the same symmetric key and
+// opens the share. The sender's ephemeral private key is discarded after sealing,
+// giving per-message forward secrecy on the sender side.
 //
-// The envelope is generic over ephemeral keys here; the orchestrator supplies
-// each recipient's operator key (converted to an ephemeral public key) when it
-// wires this in.
+// The envelope is generic over ephemeral keys. The orchestrator supplies each
+// recipient's per-DKG EPHEMERAL public key (learned from its authenticated
+// round-1 broadcast), so BOTH sides use ephemeral keys discarded after the DKG,
+// giving two-sided forward secrecy. (operatorPublicKeyToEphemeral converts an
+// operator key to this type too, still used by the seal's own round-trip test.)
 //
 // SECURITY BOUNDARY: the envelope provides CONFIDENTIALITY ONLY. It does not
 // authenticate the sealer, bind to a session/attempt, or prevent replay. Those

--- a/pkg/frost/signing/distributed_dkg_round2_seal_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_round2_seal_frost_native.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
+	"github.com/keep-network/keep-core/pkg/operator"
 )
 
 // Phase 1 of the distributed-DKG wiring makes round-2 CONFIDENTIAL. A FROST DKG
@@ -23,6 +24,16 @@ import (
 // The envelope is generic over ephemeral keys here; the orchestrator supplies
 // each recipient's operator key (converted to an ephemeral public key) when it
 // wires this in.
+//
+// SECURITY BOUNDARY: the envelope provides CONFIDENTIALITY ONLY. It does not
+// authenticate the sealer, bind to a session/attempt, or prevent replay. Those
+// come from (a) the sender-authenticated transport it runs over - the wallet
+// broadcast channel authenticates the claimed sender against its operator key
+// via the group MembershipValidator - and (b) FROST DKG Part3, which
+// cryptographically verifies each round-2 share against the sender's round-1
+// commitment (so a garbage or misdirected share fails the DKG into the existing
+// retry/blame path, not a signing breach). It MUST NOT be used over an
+// unauthenticated transport.
 
 // sealedRound2Share is the confidential on-wire form of a round-2 share: a
 // one-time ephemeral public key bound to the AES-ECDH ciphertext of the share.
@@ -72,4 +83,37 @@ func openRound2Share(sealed *sealedRound2Share, self *ephemeral.PrivateKey) ([]b
 		return nil, fmt.Errorf("distributed dkg: open round-2 share: %w", err)
 	}
 	return share, nil
+}
+
+// operatorPublicKeyToEphemeral converts a member's operator public key into the
+// ephemeral (btcec) public key the seal envelope encrypts to. Operator keys are
+// secp256k1 (the ephemeral package's only curve), so the uncompressed operator
+// key parses directly; a non-secp256k1 key is rejected rather than silently
+// mis-parsed.
+func operatorPublicKeyToEphemeral(publicKey *operator.PublicKey) (*ephemeral.PublicKey, error) {
+	if publicKey == nil {
+		return nil, fmt.Errorf("distributed dkg: nil operator public key")
+	}
+	if publicKey.Curve != operator.Secp256k1 {
+		return nil, fmt.Errorf(
+			"distributed dkg: operator key curve [%v] is not secp256k1", publicKey.Curve,
+		)
+	}
+	return ephemeral.UnmarshalPublicKey(operator.MarshalUncompressed(publicKey))
+}
+
+// operatorPrivateKeyToEphemeral converts this node's operator private key into
+// the ephemeral private key used to open round-2 shares sealed to us.
+func operatorPrivateKeyToEphemeral(privateKey *operator.PrivateKey) (*ephemeral.PrivateKey, error) {
+	if privateKey == nil {
+		return nil, fmt.Errorf("distributed dkg: nil operator private key")
+	}
+	if privateKey.Curve != operator.Secp256k1 {
+		return nil, fmt.Errorf(
+			"distributed dkg: operator key curve [%v] is not secp256k1", privateKey.Curve,
+		)
+	}
+	scalar := make([]byte, 32)
+	privateKey.D.FillBytes(scalar)
+	return ephemeral.UnmarshalPrivateKey(scalar), nil
 }

--- a/pkg/frost/signing/distributed_dkg_round2_seal_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_round2_seal_frost_native.go
@@ -1,0 +1,75 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
+)
+
+// Phase 1 of the distributed-DKG wiring makes round-2 CONFIDENTIAL. A FROST DKG
+// round-2 package carries a per-recipient secret share, but it travels over the
+// wallet BROADCAST channel - visible to the whole group - so a share sent in the
+// clear would leak to every other member. This file seals each share to its
+// recipient with an ECIES envelope over the existing pkg/crypto/ephemeral ECDH:
+// the sender derives a symmetric key from a ONE-TIME ephemeral private key and
+// the recipient's static (operator) public key, encrypts the share, and carries
+// the ephemeral PUBLIC key alongside the ciphertext. Only the recipient, via ECDH
+// between its private key and that ephemeral public key, recovers the same
+// symmetric key and opens the share. The sender's ephemeral private key is
+// discarded after sealing, giving per-message forward secrecy on the sender side.
+//
+// The envelope is generic over ephemeral keys here; the orchestrator supplies
+// each recipient's operator key (converted to an ephemeral public key) when it
+// wires this in.
+
+// sealedRound2Share is the confidential on-wire form of a round-2 share: a
+// one-time ephemeral public key bound to the AES-ECDH ciphertext of the share.
+type sealedRound2Share struct {
+	EphemeralPublicKey []byte `json:"ephemeralPublicKey"`
+	Ciphertext         []byte `json:"ciphertext"`
+}
+
+// sealRound2Share encrypts a round-2 share to the recipient's public key,
+// producing a self-describing envelope any member can route but only the
+// recipient can open.
+func sealRound2Share(share []byte, recipient *ephemeral.PublicKey) (*sealedRound2Share, error) {
+	if recipient == nil {
+		return nil, fmt.Errorf("distributed dkg: nil recipient key for round-2 seal")
+	}
+	oneTime, err := ephemeral.GenerateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("distributed dkg: generate ephemeral key: %w", err)
+	}
+	ciphertext, err := oneTime.PrivateKey.Ecdh(recipient).Encrypt(share)
+	if err != nil {
+		return nil, fmt.Errorf("distributed dkg: seal round-2 share: %w", err)
+	}
+	return &sealedRound2Share{
+		EphemeralPublicKey: oneTime.PublicKey.Marshal(),
+		Ciphertext:         ciphertext,
+	}, nil
+}
+
+// openRound2Share recovers a round-2 share sealed to us, using our static
+// (operator) private key and the ephemeral public key carried in the envelope.
+// A share sealed to another member, or a tampered envelope, fails to open (the
+// underlying box is authenticated) rather than yielding a wrong share.
+func openRound2Share(sealed *sealedRound2Share, self *ephemeral.PrivateKey) ([]byte, error) {
+	if sealed == nil {
+		return nil, fmt.Errorf("distributed dkg: nil sealed round-2 share")
+	}
+	if self == nil {
+		return nil, fmt.Errorf("distributed dkg: nil private key for round-2 open")
+	}
+	oneTimePublic, err := ephemeral.UnmarshalPublicKey(sealed.EphemeralPublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("distributed dkg: parse ephemeral public key: %w", err)
+	}
+	share, err := self.Ecdh(oneTimePublic).Decrypt(sealed.Ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("distributed dkg: open round-2 share: %w", err)
+	}
+	return share, nil
+}

--- a/pkg/frost/signing/distributed_dkg_round2_seal_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_round2_seal_frost_native.go
@@ -115,5 +115,8 @@ func operatorPrivateKeyToEphemeral(privateKey *operator.PrivateKey) (*ephemeral.
 	}
 	scalar := make([]byte, 32)
 	privateKey.D.FillBytes(scalar)
+	// UnmarshalPrivateKey copies the scalar into the returned key, so scrub this
+	// raw copy of the long-lived operator secret on return.
+	defer zeroBytes(scalar)
 	return ephemeral.UnmarshalPrivateKey(scalar), nil
 }

--- a/pkg/frost/signing/distributed_dkg_round2_seal_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_round2_seal_frost_native_test.go
@@ -6,8 +6,42 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/keep-network/keep-core/pkg/chain/local_v1"
 	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
+	"github.com/keep-network/keep-core/pkg/operator"
 )
+
+func TestOperatorKeyConversion_SealsAndOpens(t *testing.T) {
+	priv, pub, err := operator.GenerateKeyPair(local_v1.DefaultCurve)
+	if err != nil {
+		t.Fatalf("operator key: %v", err)
+	}
+
+	// Convert the operator keypair separately, then verify a share sealed to the
+	// converted PUBLIC key opens with the converted PRIVATE key - i.e. the
+	// conversions produce a matching ECDH keypair.
+	recipientPub, err := operatorPublicKeyToEphemeral(pub)
+	if err != nil {
+		t.Fatalf("convert public: %v", err)
+	}
+	recipientPriv, err := operatorPrivateKeyToEphemeral(priv)
+	if err != nil {
+		t.Fatalf("convert private: %v", err)
+	}
+
+	share := []byte("a-share-sealed-to-an-operator-key")
+	sealed, err := sealRound2Share(share, recipientPub)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	opened, err := openRound2Share(sealed, recipientPriv)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if !bytes.Equal(opened, share) {
+		t.Fatal("share sealed to a converted operator public key did not open with the converted private key")
+	}
+}
 
 func TestSealRound2Share_RoundTrip(t *testing.T) {
 	recipient, err := ephemeral.GenerateKeyPair()
@@ -80,6 +114,22 @@ func TestSealRound2Share_TamperedEnvelopeFails(t *testing.T) {
 	opened, err := openRound2Share(sealed, recipient.PrivateKey)
 	if err == nil && bytes.Equal(opened, share) {
 		t.Fatal("a tampered envelope still opened to the original share")
+	}
+}
+
+func TestSealRound2Share_MalformedEphemeralKeyFails(t *testing.T) {
+	recipient, err := ephemeral.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("recipient key: %v", err)
+	}
+	sealed, err := sealRound2Share([]byte("secret-share"), recipient.PublicKey)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	// A garbage ephemeral public key must fail to parse, not panic or open.
+	sealed.EphemeralPublicKey = []byte{0x00, 0x01, 0x02}
+	if _, err := openRound2Share(sealed, recipient.PrivateKey); err == nil {
+		t.Fatal("open with a malformed ephemeral public key must error")
 	}
 }
 

--- a/pkg/frost/signing/distributed_dkg_round2_seal_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_round2_seal_frost_native_test.go
@@ -1,0 +1,104 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
+)
+
+func TestSealRound2Share_RoundTrip(t *testing.T) {
+	recipient, err := ephemeral.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("recipient key: %v", err)
+	}
+	share := []byte("a-secret-frost-round-2-share-payload")
+
+	sealed, err := sealRound2Share(share, recipient.PublicKey)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	// The plaintext share must not appear anywhere in the sealed envelope.
+	if bytes.Contains(sealed.Ciphertext, share) {
+		t.Fatal("sealed ciphertext leaks the plaintext share")
+	}
+	if len(sealed.EphemeralPublicKey) == 0 {
+		t.Fatal("sealed envelope is missing its ephemeral public key")
+	}
+
+	opened, err := openRound2Share(sealed, recipient.PrivateKey)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if !bytes.Equal(opened, share) {
+		t.Fatalf("round-trip mismatch: got %q, want %q", opened, share)
+	}
+}
+
+func TestSealRound2Share_WrongRecipientCannotOpen(t *testing.T) {
+	recipient, err := ephemeral.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("recipient key: %v", err)
+	}
+	intruder, err := ephemeral.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("intruder key: %v", err)
+	}
+	share := []byte("secret-share")
+
+	sealed, err := sealRound2Share(share, recipient.PublicKey)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	// A member the share was NOT sealed to must not recover it: either the
+	// authenticated box fails to open, or (defensively) the result differs.
+	opened, err := openRound2Share(sealed, intruder.PrivateKey)
+	if err == nil && bytes.Equal(opened, share) {
+		t.Fatal("a non-recipient recovered the sealed share")
+	}
+}
+
+func TestSealRound2Share_TamperedEnvelopeFails(t *testing.T) {
+	recipient, err := ephemeral.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("recipient key: %v", err)
+	}
+	share := []byte("secret-share")
+	sealed, err := sealRound2Share(share, recipient.PublicKey)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if len(sealed.Ciphertext) == 0 {
+		t.Fatal("empty ciphertext")
+	}
+	// Flip a ciphertext bit; the authenticated box must not open it to the share.
+	sealed.Ciphertext[len(sealed.Ciphertext)-1] ^= 0xff
+
+	opened, err := openRound2Share(sealed, recipient.PrivateKey)
+	if err == nil && bytes.Equal(opened, share) {
+		t.Fatal("a tampered envelope still opened to the original share")
+	}
+}
+
+func TestSealRound2Share_NilInputs(t *testing.T) {
+	recipient, err := ephemeral.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("recipient key: %v", err)
+	}
+	if _, err := sealRound2Share([]byte("x"), nil); err == nil {
+		t.Fatal("seal to a nil recipient must error")
+	}
+	if _, err := openRound2Share(nil, recipient.PrivateKey); err == nil {
+		t.Fatal("open of a nil envelope must error")
+	}
+	sealed, err := sealRound2Share([]byte("x"), recipient.PublicKey)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if _, err := openRound2Share(sealed, nil); err == nil {
+		t.Fatal("open with a nil private key must error")
+	}
+}

--- a/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native.go
@@ -213,6 +213,69 @@ func (b *broadcastChannelDKGBus) Start() {
 	b.channel.Recv(b.ctx, b.handleMessage)
 }
 
+// Replay pushes messages a DKGMessagePrebuffer captured before Start (from before the
+// readiness barrier) through the same handleMessage path as live delivery. Any that
+// also arrived live are dropped by handleMessage's content-hash dedup, so this is safe
+// to call right after Start. This closes the cross-node window where a peer's round-1
+// broadcast (after the barrier released it) outran a slower peer's Start.
+func (b *broadcastChannelDKGBus) Replay(messages []net.Message) {
+	for _, m := range messages {
+		b.handleMessage(m)
+	}
+}
+
+// DKGMessagePrebuffer captures inbound DKG transport messages from the moment DKG setup
+// begins - BEFORE the cross-node readiness-announcement barrier releases peers - and
+// holds them until the bus is Started and every seat has Subscribed, at which point the
+// orchestrator Replays them. Without it, a fast peer's round-1 broadcast can arrive at a
+// slower peer before that peer installed its DKG receiver; the transport drops it and
+// marks the pubsub sequence seen, suppressing retransmission and stalling collectRound1.
+type DKGMessagePrebuffer struct {
+	mu       sync.Mutex
+	messages []net.Message
+	capacity int
+}
+
+// StartDKGMessagePrebuffer registers the DKG transport unmarshalers (so inbound DKG
+// messages decode even before the bus exists) and starts capturing them off the channel.
+// Call it BEFORE the readiness barrier. It captures at most a bounded number of messages
+// (a DKG's round-1/round-2 traffic is small; the bound guards against unbounded growth
+// from a misbehaving or noisy channel).
+func StartDKGMessagePrebuffer(
+	ctx context.Context,
+	channel net.BroadcastChannel,
+) *DKGMessagePrebuffer {
+	registerDKGTransportUnmarshalers(channel)
+	pb := &DKGMessagePrebuffer{capacity: 4096}
+	channel.Recv(ctx, func(m net.Message) {
+		// Only DKG transport messages; announcement/other traffic is ignored.
+		if _, ok := m.Payload().(*dkgTransportMessage); !ok {
+			return
+		}
+		pb.mu.Lock()
+		defer pb.mu.Unlock()
+		if len(pb.messages) < pb.capacity {
+			pb.messages = append(pb.messages, m)
+		}
+	})
+	return pb
+}
+
+// Drain returns the captured messages and clears the buffer. The channel Recv handler
+// stays registered (the transport has no unsubscribe), but once the live bus is running
+// its content-hash dedup makes any further captures harmless; callers Drain exactly once
+// right after Start.
+func (pb *DKGMessagePrebuffer) Drain() []net.Message {
+	if pb == nil {
+		return nil
+	}
+	pb.mu.Lock()
+	defer pb.mu.Unlock()
+	messages := pb.messages
+	pb.messages = nil
+	return messages
+}
+
 // Subscribe registers a receiver and returns its typed streams. The orchestrator
 // subscribes in its constructor, before broadcasting.
 func (b *broadcastChannelDKGBus) Subscribe(member group.MemberIndex) *dkgBusSubscriber {

--- a/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native.go
@@ -224,16 +224,29 @@ func (b *broadcastChannelDKGBus) Replay(messages []net.Message) {
 	}
 }
 
+// Deliver feeds a single message through the same receive path as live delivery. It is
+// the per-message sink a DKGMessagePrebuffer forwards to at handoff (DrainAndForward),
+// deduped by handleMessage's content hash.
+func (b *broadcastChannelDKGBus) Deliver(message net.Message) {
+	b.handleMessage(message)
+}
+
 // DKGMessagePrebuffer captures inbound DKG transport messages from the moment DKG setup
 // begins - BEFORE the cross-node readiness-announcement barrier releases peers - and
 // holds them until the bus is Started and every seat has Subscribed, at which point the
-// orchestrator Replays them. Without it, a fast peer's round-1 broadcast can arrive at a
-// slower peer before that peer installed its DKG receiver; the transport drops it and
-// marks the pubsub sequence seen, suppressing retransmission and stalling collectRound1.
+// orchestrator hands off via DrainAndForward. Without it, a fast peer's round-1 broadcast
+// can arrive at a slower peer before that peer installed its DKG receiver; the transport
+// drops it and marks the pubsub sequence seen, suppressing retransmission and stalling
+// collectRound1.
 type DKGMessagePrebuffer struct {
 	mu       sync.Mutex
 	messages []net.Message
 	capacity int
+	// forward, once set by DrainAndForward, is where the capture handler sends every
+	// subsequent message instead of buffering it. This makes the handoff race-free: the
+	// handler and DrainAndForward share mu, so a message is EITHER in the drained buffer
+	// OR forwarded live - never dropped in the window around the handoff.
+	forward func(net.Message)
 }
 
 // StartDKGMessagePrebuffer registers the DKG transport unmarshalers (so inbound DKG
@@ -253,27 +266,42 @@ func StartDKGMessagePrebuffer(
 			return
 		}
 		pb.mu.Lock()
-		defer pb.mu.Unlock()
-		if len(pb.messages) < pb.capacity {
-			pb.messages = append(pb.messages, m)
+		forward := pb.forward
+		if forward == nil {
+			if len(pb.messages) < pb.capacity {
+				pb.messages = append(pb.messages, m)
+			}
+			pb.mu.Unlock()
+			return
 		}
+		pb.mu.Unlock()
+		// Post-handoff: forward straight to the live bus (deduped there). Called OUTSIDE
+		// the lock so the sink cannot contend with a concurrent DrainAndForward.
+		forward(m)
 	})
 	return pb
 }
 
-// Drain returns the captured messages and clears the buffer. The channel Recv handler
-// stays registered (the transport has no unsubscribe), but once the live bus is running
-// its content-hash dedup makes any further captures harmless; callers Drain exactly once
-// right after Start.
-func (pb *DKGMessagePrebuffer) Drain() []net.Message {
-	if pb == nil {
-		return nil
+// DrainAndForward hands the prebuffer off to the live bus with no lost-message window: it
+// snapshots-and-clears the captured messages AND installs sink as the destination for any
+// further captures, atomically under one lock. Because the capture handler takes the same
+// lock, every message is EITHER in the snapshot (then delivered through sink below) OR
+// forwarded to sink by the handler - so a message received before Start but delivered by
+// the channel's Recv goroutine around the handoff cannot be dropped. Call once, right
+// after Start and after every seat has Subscribed; the bus dedups by content hash, so
+// messages that also arrive live are ignored.
+func (pb *DKGMessagePrebuffer) DrainAndForward(sink func(net.Message)) {
+	if pb == nil || sink == nil {
+		return
 	}
 	pb.mu.Lock()
-	defer pb.mu.Unlock()
-	messages := pb.messages
+	buffered := pb.messages
 	pb.messages = nil
-	return messages
+	pb.forward = sink
+	pb.mu.Unlock()
+	for _, m := range buffered {
+		sink(m)
+	}
 }
 
 // Subscribe registers a receiver and returns its typed streams. The orchestrator

--- a/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native.go
@@ -40,22 +40,26 @@ var dkgTransportType = map[dkgMessageType]string{
 // dkgTransportMessage is the wire envelope for one dkgMessage. The two DKG
 // message types share this body and are distinguished by Type() (set per
 // registered unmarshaler). The body carries the CLAIMED sender seat, the
-// addressed recipient (0 for a round-1 broadcast), the attempt session, and the
-// opaque round payload; the sender is authenticated by the receive handler.
+// addressed recipient (0 for a round-1 broadcast), the attempt session, the
+// sender's per-DKG EPHEMERAL round-2 sealing public key (round-1 only), and the
+// opaque round payload. The sender seat is authenticated by the receive handler
+// against the message's operator signature; the ephemeral key rides inside that
+// authenticated message, so it too cannot be substituted by a MITM.
 type dkgTransportMessage struct {
-	messageType dkgMessageType
-	sender      group.MemberIndex
-	recipient   group.MemberIndex
-	session     string
-	payload     []byte
+	messageType        dkgMessageType
+	sender             group.MemberIndex
+	recipient          group.MemberIndex
+	session            string
+	ephemeralPublicKey []byte
+	payload            []byte
 }
 
 // Type returns the pkg/net dispatch tag for this message's DKG round type.
 func (m *dkgTransportMessage) Type() string { return dkgTransportType[m.messageType] }
 
 // Marshal encodes the body as: sender(4 BE) || recipient(4 BE) ||
-// session_len(2 BE) || session || payload. The fixed-size prefix plus the
-// length-prefixed session make the payload boundary unambiguous.
+// session_len(2 BE) || session || eph_len(2 BE) || ephemeral_public_key ||
+// payload. Each length-prefixed field keeps the boundaries unambiguous.
 func (m *dkgTransportMessage) Marshal() ([]byte, error) {
 	if m.sender == 0 {
 		return nil, fmt.Errorf("dkg transport: sender is zero")
@@ -63,12 +67,19 @@ func (m *dkgTransportMessage) Marshal() ([]byte, error) {
 	if len(m.session) > 0xffff {
 		return nil, fmt.Errorf("dkg transport: session length [%d] exceeds the 16-bit cap", len(m.session))
 	}
-	out := make([]byte, 10+len(m.session)+len(m.payload))
+	if len(m.ephemeralPublicKey) > 0xffff {
+		return nil, fmt.Errorf("dkg transport: ephemeral key length [%d] exceeds the 16-bit cap", len(m.ephemeralPublicKey))
+	}
+	out := make([]byte, 12+len(m.session)+len(m.ephemeralPublicKey)+len(m.payload))
 	binary.BigEndian.PutUint32(out[0:4], uint32(m.sender))
 	binary.BigEndian.PutUint32(out[4:8], uint32(m.recipient))
 	binary.BigEndian.PutUint16(out[8:10], uint16(len(m.session)))
-	copy(out[10:10+len(m.session)], m.session)
-	copy(out[10+len(m.session):], m.payload)
+	off := 10
+	off += copy(out[off:off+len(m.session)], m.session)
+	binary.BigEndian.PutUint16(out[off:off+2], uint16(len(m.ephemeralPublicKey)))
+	off += 2
+	off += copy(out[off:off+len(m.ephemeralPublicKey)], m.ephemeralPublicKey)
+	copy(out[off:], m.payload)
 	return out, nil
 }
 
@@ -97,13 +108,26 @@ func (m *dkgTransportMessage) Unmarshal(data []byte) error {
 		)
 	}
 	sessionLen := int(binary.BigEndian.Uint16(data[8:10]))
-	if len(data) < prefix+sessionLen {
+	off := prefix
+	if len(data) < off+sessionLen {
 		return fmt.Errorf("dkg transport: message truncated in the session field")
+	}
+	session := string(data[off : off+sessionLen])
+	off += sessionLen
+	if len(data) < off+2 {
+		return fmt.Errorf("dkg transport: message truncated before the ephemeral-key length")
+	}
+	ephLen := int(binary.BigEndian.Uint16(data[off : off+2]))
+	off += 2
+	if len(data) < off+ephLen {
+		return fmt.Errorf("dkg transport: message truncated in the ephemeral key field")
 	}
 	m.sender = group.MemberIndex(rawSender)
 	m.recipient = group.MemberIndex(rawRecipient)
-	m.session = string(data[prefix : prefix+sessionLen])
-	m.payload = append([]byte(nil), data[prefix+sessionLen:]...)
+	m.session = session
+	m.ephemeralPublicKey = append([]byte(nil), data[off:off+ephLen]...)
+	off += ephLen
+	m.payload = append([]byte(nil), data[off:]...)
 	return nil
 }
 
@@ -208,11 +232,12 @@ func (b *broadcastChannelDKGBus) Subscribe(member group.MemberIndex) *dkgBusSubs
 // Send error is logged, not surfaced.
 func (b *broadcastChannelDKGBus) Broadcast(msg dkgMessage) {
 	wire := &dkgTransportMessage{
-		messageType: msg.Type,
-		sender:      msg.Sender,
-		recipient:   msg.Recipient,
-		session:     msg.Session,
-		payload:     msg.Payload,
+		messageType:        msg.Type,
+		sender:             msg.Sender,
+		recipient:          msg.Recipient,
+		session:            msg.Session,
+		ephemeralPublicKey: msg.SenderPublicKey,
+		payload:            msg.Payload,
 	}
 	if err := b.channel.Send(b.ctx, wire); err != nil {
 		b.logger.Warnf("dkg bus: failed to broadcast [%s] message: [%v]", wire.Type(), err)
@@ -242,10 +267,12 @@ func (b *broadcastChannelDKGBus) handleMessage(m net.Message) {
 		Type:    wire.messageType,
 		Session: wire.session,
 		Sender:  wire.sender,
-		// The AUTHENTICATED operator public key, not any value claimed on the wire:
-		// peers learn each other's round-2 sealing key from this, so it must be the
-		// key membership was validated against.
-		SenderPublicKey: m.SenderPublicKey(),
+		// The sender's per-DKG EPHEMERAL round-2 sealing key, carried on the wire.
+		// It is trustworthy because it rides inside the message whose operator
+		// signature we just authenticated the CLAIMED seat against (above), so a
+		// MITM cannot substitute it; using an ephemeral (not the long-lived operator
+		// key) gives the round-2 shares recipient-side forward secrecy.
+		SenderPublicKey: wire.ephemeralPublicKey,
 		Recipient:       wire.recipient,
 		Payload:         wire.payload,
 	}
@@ -273,6 +300,7 @@ func (m dkgMessage) contentHash() [32]byte {
 	h := sha256.New()
 	h.Write([]byte{byte(m.Type), byte(m.Sender), byte(m.Recipient)})
 	h.Write([]byte(m.Session))
+	h.Write(m.SenderPublicKey)
 	h.Write(m.Payload)
 	var out [32]byte
 	copy(out[:], h.Sum(nil))

--- a/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native.go
@@ -1,0 +1,298 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"sync"
+
+	"github.com/ipfs/go-log/v2"
+	"github.com/keep-network/keep-core/pkg/net"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// This file implements the production DKGBus over keep-core's pkg/net
+// BroadcastChannel - the transport the distributed-DKG orchestrator runs on in a
+// real deployment (the wallet DKG broadcast channel, already opened and
+// membership-filtered by pkg/tbtc). It mirrors the ROAST runner bus
+// (roast_runner_bus_net_frost_native.go): it authenticates a message's CLAIMED
+// sender against the message's authenticated operator public key BEFORE
+// delivering, and demuxes into bounded per-subscriber streams with non-blocking
+// sends so a slow or flooding peer never blocks an honest broadcaster.
+//
+// Round-1 messages are broadcast (Recipient 0); round-2 messages are addressed
+// (Recipient set) but still delivered to every subscriber - the orchestrator
+// keeps only the ones addressed to it, and only it can OPEN a share sealed to it.
+// Confidentiality of round-2 shares comes from the seal envelope, not the
+// transport; the transport provides sender authentication and the session
+// discriminator the orchestrator's collectors require.
+
+// dkgTransportType maps each DKG message type to the pkg/net Type() string the
+// BroadcastChannel dispatches on.
+var dkgTransportType = map[dkgMessageType]string{
+	dkgRound1Message: "frost/dkg_runner/round1",
+	dkgRound2Message: "frost/dkg_runner/round2",
+}
+
+// dkgTransportMessage is the wire envelope for one dkgMessage. The two DKG
+// message types share this body and are distinguished by Type() (set per
+// registered unmarshaler). The body carries the CLAIMED sender seat, the
+// addressed recipient (0 for a round-1 broadcast), the attempt session, and the
+// opaque round payload; the sender is authenticated by the receive handler.
+type dkgTransportMessage struct {
+	messageType dkgMessageType
+	sender      group.MemberIndex
+	recipient   group.MemberIndex
+	session     string
+	payload     []byte
+}
+
+// Type returns the pkg/net dispatch tag for this message's DKG round type.
+func (m *dkgTransportMessage) Type() string { return dkgTransportType[m.messageType] }
+
+// Marshal encodes the body as: sender(4 BE) || recipient(4 BE) ||
+// session_len(2 BE) || session || payload. The fixed-size prefix plus the
+// length-prefixed session make the payload boundary unambiguous.
+func (m *dkgTransportMessage) Marshal() ([]byte, error) {
+	if m.sender == 0 {
+		return nil, fmt.Errorf("dkg transport: sender is zero")
+	}
+	if len(m.session) > 0xffff {
+		return nil, fmt.Errorf("dkg transport: session length [%d] exceeds the 16-bit cap", len(m.session))
+	}
+	out := make([]byte, 10+len(m.session)+len(m.payload))
+	binary.BigEndian.PutUint32(out[0:4], uint32(m.sender))
+	binary.BigEndian.PutUint32(out[4:8], uint32(m.recipient))
+	binary.BigEndian.PutUint16(out[8:10], uint16(len(m.session)))
+	copy(out[10:10+len(m.session)], m.session)
+	copy(out[10+len(m.session):], m.payload)
+	return out, nil
+}
+
+// Unmarshal decodes a body produced by Marshal. messageType is preset by the
+// registered unmarshaler (one per Type() string), so it is not carried on wire.
+// It rejects a non-canonical sender/recipient at the decode boundary before the
+// truncating cast to group.MemberIndex (uint8).
+func (m *dkgTransportMessage) Unmarshal(data []byte) error {
+	const prefix = 10
+	if len(data) < prefix {
+		return fmt.Errorf(
+			"dkg transport: message length [%d] shorter than the %d-byte header",
+			len(data), prefix,
+		)
+	}
+	rawSender := binary.BigEndian.Uint32(data[0:4])
+	if rawSender == 0 || rawSender > uint32(group.MaxMemberIndex) {
+		return fmt.Errorf(
+			"dkg transport: sender id [%d] out of range [1, %d]", rawSender, group.MaxMemberIndex,
+		)
+	}
+	rawRecipient := binary.BigEndian.Uint32(data[4:8])
+	if rawRecipient > uint32(group.MaxMemberIndex) {
+		return fmt.Errorf(
+			"dkg transport: recipient id [%d] out of range [0, %d]", rawRecipient, group.MaxMemberIndex,
+		)
+	}
+	sessionLen := int(binary.BigEndian.Uint16(data[8:10]))
+	if len(data) < prefix+sessionLen {
+		return fmt.Errorf("dkg transport: message truncated in the session field")
+	}
+	m.sender = group.MemberIndex(rawSender)
+	m.recipient = group.MemberIndex(rawRecipient)
+	m.session = string(data[prefix : prefix+sessionLen])
+	m.payload = append([]byte(nil), data[prefix+sessionLen:]...)
+	return nil
+}
+
+func registerDKGTransportUnmarshalers(channel net.BroadcastChannel) {
+	for messageType := range dkgTransportType {
+		mt := messageType
+		channel.SetUnmarshaler(func() net.TaggedUnmarshaler {
+			return &dkgTransportMessage{messageType: mt}
+		})
+	}
+}
+
+const (
+	// defaultDKGBusStreamBuffer bounds each per-subscriber stream. A DKG's honest
+	// per-stream volume is bounded (round-1: one per member; round-2: one per
+	// member addressed to us, plus the others we discard), so this is sized well
+	// above it; only a flooding peer can overflow, which degrades the attempt to a
+	// retry rather than losing an honest message.
+	defaultDKGBusStreamBuffer = 1024
+	// defaultDKGBusSeenBound caps the per-subscriber dedup set so a peer flooding
+	// distinct messages cannot grow it without bound; on overflow it resets.
+	defaultDKGBusSeenBound = 4096
+)
+
+// broadcastChannelDKGBus is the production DKGBus over a net.BroadcastChannel.
+type broadcastChannelDKGBus struct {
+	ctx                 context.Context
+	logger              log.StandardLogger
+	channel             net.BroadcastChannel
+	membershipValidator *group.MembershipValidator
+	streamBuffer        int
+	seenBound           int
+
+	mu          sync.Mutex
+	subscribers []*dkgBusSubscriber
+}
+
+// NewBroadcastChannelDKGBus returns a DKGBus over the given wallet DKG broadcast
+// channel. It registers the DKG message unmarshalers and installs a receive
+// handler for the lifetime of ctx; cancel ctx (e.g. at DKG conclusion) to stop
+// receiving. The channel and membershipValidator are the ones pkg/tbtc already
+// carries for the DKG; this adapter does not create them.
+func NewBroadcastChannelDKGBus(
+	ctx context.Context,
+	logger log.StandardLogger,
+	channel net.BroadcastChannel,
+	membershipValidator *group.MembershipValidator,
+) (DKGBus, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("dkg bus: context is nil")
+	}
+	if channel == nil {
+		return nil, fmt.Errorf("dkg bus: broadcast channel is nil")
+	}
+	if membershipValidator == nil {
+		return nil, fmt.Errorf("dkg bus: membership validator is nil")
+	}
+	if logger == nil {
+		logger = log.Logger("frost-distributed-dkg-bus")
+	}
+
+	b := &broadcastChannelDKGBus{
+		ctx:                 ctx,
+		logger:              logger,
+		channel:             channel,
+		membershipValidator: membershipValidator,
+		streamBuffer:        defaultDKGBusStreamBuffer,
+		seenBound:           defaultDKGBusSeenBound,
+	}
+
+	registerDKGTransportUnmarshalers(channel)
+	channel.Recv(ctx, b.handleMessage)
+
+	return b, nil
+}
+
+// Subscribe registers a receiver and returns its typed streams. The orchestrator
+// subscribes in its constructor, before broadcasting.
+func (b *broadcastChannelDKGBus) Subscribe() *dkgBusSubscriber {
+	s := &dkgBusSubscriber{
+		round1: make(chan dkgMessage, b.streamBuffer),
+		round2: make(chan dkgMessage, b.streamBuffer),
+		seen:   make(map[[32]byte]struct{}),
+	}
+	b.mu.Lock()
+	b.subscribers = append(b.subscribers, s)
+	b.mu.Unlock()
+	return s
+}
+
+// Broadcast publishes msg to the channel; pkg/net handles retransmission, so a
+// Send error is logged, not surfaced.
+func (b *broadcastChannelDKGBus) Broadcast(msg dkgMessage) {
+	wire := &dkgTransportMessage{
+		messageType: msg.Type,
+		sender:      msg.Sender,
+		recipient:   msg.Recipient,
+		session:     msg.Session,
+		payload:     msg.Payload,
+	}
+	if err := b.channel.Send(b.ctx, wire); err != nil {
+		b.logger.Warnf("dkg bus: failed to broadcast [%s] message: [%v]", wire.Type(), err)
+	}
+}
+
+// handleMessage is the single Recv handler. It authenticates the claimed sender
+// seat against the message's authenticated operator public key, then demuxes the
+// message into every subscriber's typed stream (non-blocking, deduped).
+func (b *broadcastChannelDKGBus) handleMessage(m net.Message) {
+	wire, ok := m.Payload().(*dkgTransportMessage)
+	if !ok {
+		return
+	}
+	// Bind the CLAIMED seat to the AUTHENTICATED operator public key. A spoofed
+	// seat (one the sender's key was not selected to) is dropped here, before the
+	// orchestrator ever sees it.
+	if !b.membershipValidator.IsValidMembership(wire.sender, m.SenderPublicKey()) {
+		b.logger.Warnf(
+			"dkg bus: dropping [%s] message claiming unauthenticated seat [%d]",
+			wire.Type(), wire.sender,
+		)
+		return
+	}
+
+	msg := dkgMessage{
+		Type:      wire.messageType,
+		Session:   wire.session,
+		Sender:    wire.sender,
+		Recipient: wire.recipient,
+		Payload:   wire.payload,
+	}
+	hash := msg.contentHash()
+
+	b.mu.Lock()
+	subscribers := append([]*dkgBusSubscriber(nil), b.subscribers...)
+	b.mu.Unlock()
+
+	for _, s := range subscribers {
+		s.deliverNonBlocking(hash, msg, b.seenBound)
+	}
+}
+
+// contentHash is the full-message identity used for retransmission dedup; it
+// covers every field so a body-different message hashes differently.
+func (m dkgMessage) contentHash() [32]byte {
+	h := sha256.New()
+	h.Write([]byte{byte(m.Type), byte(m.Sender), byte(m.Recipient)})
+	h.Write([]byte(m.Session))
+	h.Write(m.Payload)
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+func (s *dkgBusSubscriber) streamFor(t dkgMessageType) chan dkgMessage {
+	switch t {
+	case dkgRound1Message:
+		return s.round1
+	case dkgRound2Message:
+		return s.round2
+	default:
+		return nil
+	}
+}
+
+// deliverNonBlocking routes msg into the matching typed stream WITHOUT blocking:
+// on a full stream it drops the newest (earlier, useful messages stay queued).
+// It dedups by full content hash per subscriber; seenBound caps the dedup set.
+func (s *dkgBusSubscriber) deliverNonBlocking(hash [32]byte, msg dkgMessage, seenBound int) {
+	stream := s.streamFor(msg.Type)
+	if stream == nil {
+		return
+	}
+	// Own the payload bytes per delivery so no receiver can mutate another's view.
+	delivered := msg
+	delivered.Payload = append([]byte(nil), msg.Payload...)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, dup := s.seen[hash]; dup {
+		return
+	}
+	select {
+	case stream <- delivered:
+		if seenBound > 0 && len(s.seen) >= seenBound {
+			s.seen = make(map[[32]byte]struct{})
+		}
+		s.seen[hash] = struct{}{}
+	default:
+		// Stream full: drop the newest (a flood -> retry), leaving it un-seen.
+	}
+}

--- a/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native.go
@@ -117,11 +117,12 @@ func registerDKGTransportUnmarshalers(channel net.BroadcastChannel) {
 }
 
 const (
-	// defaultDKGBusStreamBuffer bounds each per-subscriber stream. A DKG's honest
-	// per-stream volume is bounded (round-1: one per member; round-2: one per
-	// member addressed to us, plus the others we discard), so this is sized well
-	// above it; only a flooding peer can overflow, which degrades the attempt to a
-	// retry rather than losing an honest message.
+	// defaultDKGBusStreamBuffer bounds each per-subscriber stream. Because round-2
+	// messages are delivered only to their addressed recipient, a subscriber's
+	// honest per-stream volume is O(n): round-1 is one per member and round-2 is
+	// one per OTHER member (those addressed to this seat). 1024 sits well above the
+	// largest tBTC group (MaxMemberIndex 255), so honest operation never overflows;
+	// only a flooding peer can, which degrades the attempt to a retry.
 	defaultDKGBusStreamBuffer = 1024
 	// defaultDKGBusSeenBound caps the per-subscriber dedup set so a peer flooding
 	// distinct messages cannot grow it without bound; on overflow it resets.
@@ -182,8 +183,9 @@ func NewBroadcastChannelDKGBus(
 
 // Subscribe registers a receiver and returns its typed streams. The orchestrator
 // subscribes in its constructor, before broadcasting.
-func (b *broadcastChannelDKGBus) Subscribe() *dkgBusSubscriber {
+func (b *broadcastChannelDKGBus) Subscribe(member group.MemberIndex) *dkgBusSubscriber {
 	s := &dkgBusSubscriber{
+		member: member,
 		round1: make(chan dkgMessage, b.streamBuffer),
 		round2: make(chan dkgMessage, b.streamBuffer),
 		seen:   make(map[[32]byte]struct{}),
@@ -246,6 +248,13 @@ func (b *broadcastChannelDKGBus) handleMessage(m net.Message) {
 	b.mu.Unlock()
 
 	for _, s := range subscribers {
+		// A round-2 message is ADDRESSED: deliver it only to its recipient's
+		// subscriber, so a subscriber buffers O(n) round-2 messages (those for it),
+		// not the O(n^2) whole-group fan-out that would overflow the stream at
+		// mainnet group sizes. Round-1 messages are broadcast to every subscriber.
+		if msg.Type == dkgRound2Message && s.member != msg.Recipient {
+			continue
+		}
 		s.deliverNonBlocking(hash, msg, b.seenBound)
 	}
 }

--- a/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native.go
@@ -229,11 +229,15 @@ func (b *broadcastChannelDKGBus) handleMessage(m net.Message) {
 	}
 
 	msg := dkgMessage{
-		Type:      wire.messageType,
-		Session:   wire.session,
-		Sender:    wire.sender,
-		Recipient: wire.recipient,
-		Payload:   wire.payload,
+		Type:    wire.messageType,
+		Session: wire.session,
+		Sender:  wire.sender,
+		// The AUTHENTICATED operator public key, not any value claimed on the wire:
+		// peers learn each other's round-2 sealing key from this, so it must be the
+		// key membership was validated against.
+		SenderPublicKey: m.SenderPublicKey(),
+		Recipient:       wire.recipient,
+		Payload:         wire.payload,
 	}
 	hash := msg.contentHash()
 

--- a/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native.go
@@ -176,9 +176,17 @@ func NewBroadcastChannelDKGBus(
 	}
 
 	registerDKGTransportUnmarshalers(channel)
-	channel.Recv(ctx, b.handleMessage)
 
 	return b, nil
+}
+
+// Start installs the channel Recv handler that demuxes inbound messages to
+// subscribers. It is deferred out of the constructor so the orchestrator can
+// Subscribe every local seat FIRST: a message handled before any subscriber
+// exists is dropped, and the transport's retransmission layer may have already
+// marked it seen, so it would never be redelivered and the DKG would stall.
+func (b *broadcastChannelDKGBus) Start() {
+	b.channel.Recv(b.ctx, b.handleMessage)
 }
 
 // Subscribe registers a receiver and returns its typed streams. The orchestrator

--- a/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native_test.go
@@ -198,6 +198,39 @@ func TestBroadcastChannelDKGBus_ReplayDeliversAndDedups(t *testing.T) {
 	}
 }
 
+// TestDKGMessagePrebuffer_DrainAndForwardHandsOff covers the race-free handoff: draining
+// delivers the already-captured messages to the sink AND installs the sink so any message
+// the capture handler catches around the drain instant is forwarded live rather than
+// buffered-then-lost. (The handler's forward branch is exercised end-to-end by the
+// multi-node e2e; here we pin the DrainAndForward contract deterministically.)
+func TestDKGMessagePrebuffer_DrainAndForwardHandsOff(t *testing.T) {
+	f := newDKGBusAuthFixture(t, 8)
+
+	pb := &DKGMessagePrebuffer{capacity: 10}
+	pb.messages = []net.Message{dkgRound1Msg(1, f.operatorA, "sess", "buffered-round1")}
+
+	var forwarded []net.Message
+	pb.DrainAndForward(func(m net.Message) { forwarded = append(forwarded, m) })
+
+	if len(forwarded) != 1 {
+		t.Fatalf("the buffered message must be delivered to the sink on handoff; got %d", len(forwarded))
+	}
+	if payload := forwarded[0].Payload().(*dkgTransportMessage).payload; string(payload) != "buffered-round1" {
+		t.Fatalf("unexpected drained payload: %q", payload)
+	}
+	if pb.messages != nil {
+		t.Fatal("the buffer must be cleared after DrainAndForward")
+	}
+	if pb.forward == nil {
+		t.Fatal("the forward sink must be installed so post-handoff captures are forwarded, not lost")
+	}
+	// A capture arriving after handoff goes to the sink (what the Recv handler does).
+	pb.forward(dkgRound1Msg(2, f.operatorB, "sess", "post-handoff-round1"))
+	if len(forwarded) != 2 {
+		t.Fatal("a post-handoff capture must be forwarded to the sink")
+	}
+}
+
 func TestBroadcastChannelDKGBus_RejectsSpoofedSeat(t *testing.T) {
 	f := newDKGBusAuthFixture(t, 8)
 	sub := f.bus.Subscribe(1)

--- a/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native_test.go
@@ -100,10 +100,11 @@ func dkgRound2Msg(sender, recipient group.MemberIndex, authorKey []byte, session
 
 func TestBroadcastChannelDKGBus_AuthenticatedMessagesDemuxed(t *testing.T) {
 	f := newDKGBusAuthFixture(t, 8)
-	sub := f.bus.Subscribe()
+	// Subscribe as seat 2 so it receives the round-2 message addressed to it.
+	sub := f.bus.Subscribe(2)
 
 	// Operator A authentically sends a round-1 broadcast as seat 1 and a round-2
-	// message as seat 3 (both seats it holds).
+	// message as seat 3 (both seats it holds), the latter addressed to seat 2.
 	f.bus.handleMessage(dkgRound1Msg(1, f.operatorA, "sess", "round1-from-1"))
 	f.bus.handleMessage(dkgRound2Msg(3, 2, f.operatorA, "sess", "round2-from-3"))
 
@@ -111,6 +112,11 @@ func TestBroadcastChannelDKGBus_AuthenticatedMessagesDemuxed(t *testing.T) {
 	case msg := <-sub.round1:
 		if msg.Sender != 1 || msg.Session != "sess" || string(msg.Payload) != "round1-from-1" || msg.Type != dkgRound1Message {
 			t.Fatalf("unexpected round-1 delivery: %+v", msg)
+		}
+		// The delivered SenderPublicKey must be the AUTHENTICATED operator key
+		// (what peers learn their round-2 sealing key from), not any wire claim.
+		if !bytes.Equal(msg.SenderPublicKey, f.operatorA) {
+			t.Fatalf("round-1 SenderPublicKey must be the authenticated key")
 		}
 	default:
 		t.Fatal("expected the authenticated round-1 message on the round-1 stream")
@@ -120,6 +126,9 @@ func TestBroadcastChannelDKGBus_AuthenticatedMessagesDemuxed(t *testing.T) {
 		if msg.Sender != 3 || msg.Recipient != 2 || string(msg.Payload) != "round2-from-3" || msg.Type != dkgRound2Message {
 			t.Fatalf("unexpected round-2 delivery: %+v", msg)
 		}
+		if !bytes.Equal(msg.SenderPublicKey, f.operatorA) {
+			t.Fatalf("round-2 SenderPublicKey must be the authenticated key")
+		}
 	default:
 		t.Fatal("expected the authenticated round-2 message on the round-2 stream")
 	}
@@ -127,7 +136,7 @@ func TestBroadcastChannelDKGBus_AuthenticatedMessagesDemuxed(t *testing.T) {
 
 func TestBroadcastChannelDKGBus_RejectsSpoofedSeat(t *testing.T) {
 	f := newDKGBusAuthFixture(t, 8)
-	sub := f.bus.Subscribe()
+	sub := f.bus.Subscribe(1)
 
 	// Operator B (seat 2) claims seat 1; an outsider claims seat 1; operator A
 	// claims seat 2 (operator B's). All must be dropped.
@@ -144,7 +153,7 @@ func TestBroadcastChannelDKGBus_RejectsSpoofedSeat(t *testing.T) {
 
 func TestBroadcastChannelDKGBus_MultiSeatOperator(t *testing.T) {
 	f := newDKGBusAuthFixture(t, 8)
-	sub := f.bus.Subscribe()
+	sub := f.bus.Subscribe(1)
 
 	// Operator A holds seats 1 AND 3: it may authentically send as either.
 	f.bus.handleMessage(dkgRound1Msg(1, f.operatorA, "sess", "from-1"))
@@ -167,7 +176,7 @@ func TestBroadcastChannelDKGBus_MultiSeatOperator(t *testing.T) {
 
 func TestBroadcastChannelDKGBus_DedupsByteIdentical(t *testing.T) {
 	f := newDKGBusAuthFixture(t, 8)
-	sub := f.bus.Subscribe()
+	sub := f.bus.Subscribe(1)
 
 	msg := dkgRound1Msg(1, f.operatorA, "sess", "same-body")
 	f.bus.handleMessage(msg)
@@ -185,6 +194,21 @@ func TestBroadcastChannelDKGBus_DedupsByteIdentical(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("byte-identical retransmission must be deduped to a single delivery, got %d", count)
+	}
+}
+
+func TestBroadcastChannelDKGBus_Round2DeliveredOnlyToRecipient(t *testing.T) {
+	f := newDKGBusAuthFixture(t, 8)
+	// This subscriber is seat 1; a round-2 message addressed to seat 2 must NOT
+	// reach it (that would be the O(n^2) fan-out the recipient filter prevents).
+	sub := f.bus.Subscribe(1)
+
+	f.bus.handleMessage(dkgRound2Msg(3, 2, f.operatorA, "sess", "for-seat-2"))
+
+	select {
+	case msg := <-sub.round2:
+		t.Fatalf("seat 1 received a round-2 message addressed to seat 2: %+v", msg)
+	default:
 	}
 }
 

--- a/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native_test.go
@@ -73,14 +73,19 @@ func newDKGBusAuthFixture(t *testing.T, streamSize int) dkgBusAuthFixture {
 	return dkgBusAuthFixture{bus: bus, operatorA: operatorA, operatorB: operatorB, outsider: outsider}
 }
 
+// dkgRound1Msg builds a round-1 message authored (signed) by authorKey. For test
+// simplicity the sender's on-wire ephemeral sealing key is set to authorKey too;
+// TestBroadcastChannelDKGBus_CarriesWireEphemeralKey exercises the case where they
+// differ.
 func dkgRound1Msg(sender group.MemberIndex, authorKey []byte, session, payload string) fakeDKGNetMessage {
 	return fakeDKGNetMessage{
 		senderPublicKey: authorKey,
 		payload: &dkgTransportMessage{
-			messageType: dkgRound1Message,
-			sender:      sender,
-			session:     session,
-			payload:     []byte(payload),
+			messageType:        dkgRound1Message,
+			sender:             sender,
+			session:            session,
+			ephemeralPublicKey: authorKey,
+			payload:            []byte(payload),
 		},
 	}
 }
@@ -89,11 +94,12 @@ func dkgRound2Msg(sender, recipient group.MemberIndex, authorKey []byte, session
 	return fakeDKGNetMessage{
 		senderPublicKey: authorKey,
 		payload: &dkgTransportMessage{
-			messageType: dkgRound2Message,
-			sender:      sender,
-			recipient:   recipient,
-			session:     session,
-			payload:     []byte(payload),
+			messageType:        dkgRound2Message,
+			sender:             sender,
+			recipient:          recipient,
+			session:            session,
+			ephemeralPublicKey: authorKey,
+			payload:            []byte(payload),
 		},
 	}
 }
@@ -113,10 +119,10 @@ func TestBroadcastChannelDKGBus_AuthenticatedMessagesDemuxed(t *testing.T) {
 		if msg.Sender != 1 || msg.Session != "sess" || string(msg.Payload) != "round1-from-1" || msg.Type != dkgRound1Message {
 			t.Fatalf("unexpected round-1 delivery: %+v", msg)
 		}
-		// The delivered SenderPublicKey must be the AUTHENTICATED operator key
-		// (what peers learn their round-2 sealing key from), not any wire claim.
+		// The delivered SenderPublicKey is the sender's ephemeral sealing key
+		// carried on the wire (here equal to the author key).
 		if !bytes.Equal(msg.SenderPublicKey, f.operatorA) {
-			t.Fatalf("round-1 SenderPublicKey must be the authenticated key")
+			t.Fatalf("round-1 SenderPublicKey must be the wire ephemeral key")
 		}
 	default:
 		t.Fatal("expected the authenticated round-1 message on the round-1 stream")
@@ -127,10 +133,39 @@ func TestBroadcastChannelDKGBus_AuthenticatedMessagesDemuxed(t *testing.T) {
 			t.Fatalf("unexpected round-2 delivery: %+v", msg)
 		}
 		if !bytes.Equal(msg.SenderPublicKey, f.operatorA) {
-			t.Fatalf("round-2 SenderPublicKey must be the authenticated key")
+			t.Fatalf("round-2 SenderPublicKey must be the wire ephemeral key")
 		}
 	default:
 		t.Fatal("expected the authenticated round-2 message on the round-2 stream")
+	}
+}
+
+// TestBroadcastChannelDKGBus_CarriesWireEphemeralKey proves the delivered
+// SenderPublicKey (peers' round-2 sealing key) is the sender's EPHEMERAL key
+// carried on the wire - NOT the operator key the message was authenticated
+// against. So a seat seals to a key that never exists at rest (forward secrecy),
+// while the seat itself is still bound to its operator for authentication.
+func TestBroadcastChannelDKGBus_CarriesWireEphemeralKey(t *testing.T) {
+	f := newDKGBusAuthFixture(t, 8)
+	sub := f.bus.Subscribe(1)
+
+	// Operator A (seat 1) authenticates the message, but the on-wire ephemeral
+	// sealing key is DISTINCT from the operator key.
+	ephemeralKey := []byte("distinct-ephemeral-round2-sealing-key")
+	msg := dkgRound1Msg(1, f.operatorA, "sess", "round1")
+	msg.payload.(*dkgTransportMessage).ephemeralPublicKey = ephemeralKey
+	f.bus.handleMessage(msg)
+
+	select {
+	case delivered := <-sub.round1:
+		if bytes.Equal(delivered.SenderPublicKey, f.operatorA) {
+			t.Fatal("delivered sealing key must be the wire ephemeral, not the operator key")
+		}
+		if !bytes.Equal(delivered.SenderPublicKey, ephemeralKey) {
+			t.Fatal("delivered sealing key must equal the sender's wire ephemeral key")
+		}
+	default:
+		t.Fatal("expected the round-1 message on the round-1 stream")
 	}
 }
 
@@ -214,23 +249,26 @@ func TestBroadcastChannelDKGBus_Round2DeliveredOnlyToRecipient(t *testing.T) {
 
 func TestDKGTransportMessage_MarshalRoundTrip(t *testing.T) {
 	original := &dkgTransportMessage{
-		messageType: dkgRound2Message,
-		sender:      7,
-		recipient:   3,
-		session:     "wallet-seed-0xabcd-attempt-2",
-		payload:     []byte("sealed-round-2-share-bytes"),
+		messageType:        dkgRound1Message,
+		sender:             7,
+		recipient:          3,
+		session:            "wallet-seed-0xabcd-attempt-2",
+		ephemeralPublicKey: []byte("per-dkg-ephemeral-sealing-pubkey"),
+		payload:            []byte("sealed-round-2-share-bytes"),
 	}
 	encoded, err := original.Marshal()
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	decoded := &dkgTransportMessage{messageType: dkgRound2Message}
+	decoded := &dkgTransportMessage{messageType: dkgRound1Message}
 	if err := decoded.Unmarshal(encoded); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if decoded.sender != original.sender || decoded.recipient != original.recipient ||
-		decoded.session != original.session || !bytes.Equal(decoded.payload, original.payload) {
+		decoded.session != original.session ||
+		!bytes.Equal(decoded.ephemeralPublicKey, original.ephemeralPublicKey) ||
+		!bytes.Equal(decoded.payload, original.payload) {
 		t.Fatalf("round-trip mismatch: got %+v, want %+v", decoded, original)
 	}
 }

--- a/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native_test.go
@@ -1,0 +1,231 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/chain/local_v1"
+	"github.com/keep-network/keep-core/pkg/net"
+	"github.com/keep-network/keep-core/pkg/operator"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// fakeDKGNetMessage is a minimal net.Message for exercising the DKG bus receive
+// path (sender authentication + demux) without standing up a real network.
+type fakeDKGNetMessage struct {
+	senderPublicKey []byte
+	payload         interface{}
+}
+
+func (m fakeDKGNetMessage) TransportSenderID() net.TransportIdentifier { return nil }
+func (m fakeDKGNetMessage) SenderPublicKey() []byte                    { return m.senderPublicKey }
+func (m fakeDKGNetMessage) Payload() interface{}                       { return m.payload }
+func (m fakeDKGNetMessage) Seqno() uint64                              { return 0 }
+func (m fakeDKGNetMessage) Type() string {
+	if w, ok := m.payload.(*dkgTransportMessage); ok {
+		return w.Type()
+	}
+	return ""
+}
+
+// dkgBusAuthFixture builds a three-seat group with a MULTI-SEAT operator
+// (operator A holds seats 1 and 3; operator B holds seat 2) and a bus wired to
+// the resulting MembershipValidator.
+type dkgBusAuthFixture struct {
+	bus       *broadcastChannelDKGBus
+	operatorA []byte // seats 1 and 3
+	operatorB []byte // seat 2
+	outsider  []byte // not selected
+}
+
+func newDKGBusAuthFixture(t *testing.T, streamSize int) dkgBusAuthFixture {
+	t.Helper()
+	signing := local_v1.Connect(3, 3).Signing()
+
+	key := func() []byte {
+		_, publicKey, err := operator.GenerateKeyPair(local_v1.DefaultCurve)
+		if err != nil {
+			t.Fatalf("generate operator key: %v", err)
+		}
+		return operator.MarshalUncompressed(publicKey)
+	}
+	operatorA, operatorB, outsider := key(), key(), key()
+
+	addrA := signing.PublicKeyBytesToAddress(operatorA)
+	addrB := signing.PublicKeyBytesToAddress(operatorB)
+	// Ordered seats: 1 -> A, 2 -> B, 3 -> A (operator A is multi-seat).
+	validator := group.NewMembershipValidator(
+		&testutils.MockLogger{},
+		[]chain.Address{addrA, addrB, addrA},
+		signing,
+	)
+
+	bus := &broadcastChannelDKGBus{
+		logger:              &testutils.MockLogger{},
+		membershipValidator: validator,
+		streamBuffer:        streamSize,
+		seenBound:           defaultDKGBusSeenBound,
+	}
+	return dkgBusAuthFixture{bus: bus, operatorA: operatorA, operatorB: operatorB, outsider: outsider}
+}
+
+func dkgRound1Msg(sender group.MemberIndex, authorKey []byte, session, payload string) fakeDKGNetMessage {
+	return fakeDKGNetMessage{
+		senderPublicKey: authorKey,
+		payload: &dkgTransportMessage{
+			messageType: dkgRound1Message,
+			sender:      sender,
+			session:     session,
+			payload:     []byte(payload),
+		},
+	}
+}
+
+func dkgRound2Msg(sender, recipient group.MemberIndex, authorKey []byte, session, payload string) fakeDKGNetMessage {
+	return fakeDKGNetMessage{
+		senderPublicKey: authorKey,
+		payload: &dkgTransportMessage{
+			messageType: dkgRound2Message,
+			sender:      sender,
+			recipient:   recipient,
+			session:     session,
+			payload:     []byte(payload),
+		},
+	}
+}
+
+func TestBroadcastChannelDKGBus_AuthenticatedMessagesDemuxed(t *testing.T) {
+	f := newDKGBusAuthFixture(t, 8)
+	sub := f.bus.Subscribe()
+
+	// Operator A authentically sends a round-1 broadcast as seat 1 and a round-2
+	// message as seat 3 (both seats it holds).
+	f.bus.handleMessage(dkgRound1Msg(1, f.operatorA, "sess", "round1-from-1"))
+	f.bus.handleMessage(dkgRound2Msg(3, 2, f.operatorA, "sess", "round2-from-3"))
+
+	select {
+	case msg := <-sub.round1:
+		if msg.Sender != 1 || msg.Session != "sess" || string(msg.Payload) != "round1-from-1" || msg.Type != dkgRound1Message {
+			t.Fatalf("unexpected round-1 delivery: %+v", msg)
+		}
+	default:
+		t.Fatal("expected the authenticated round-1 message on the round-1 stream")
+	}
+	select {
+	case msg := <-sub.round2:
+		if msg.Sender != 3 || msg.Recipient != 2 || string(msg.Payload) != "round2-from-3" || msg.Type != dkgRound2Message {
+			t.Fatalf("unexpected round-2 delivery: %+v", msg)
+		}
+	default:
+		t.Fatal("expected the authenticated round-2 message on the round-2 stream")
+	}
+}
+
+func TestBroadcastChannelDKGBus_RejectsSpoofedSeat(t *testing.T) {
+	f := newDKGBusAuthFixture(t, 8)
+	sub := f.bus.Subscribe()
+
+	// Operator B (seat 2) claims seat 1; an outsider claims seat 1; operator A
+	// claims seat 2 (operator B's). All must be dropped.
+	f.bus.handleMessage(dkgRound1Msg(1, f.operatorB, "sess", "spoofed"))
+	f.bus.handleMessage(dkgRound1Msg(1, f.outsider, "sess", "outsider"))
+	f.bus.handleMessage(dkgRound1Msg(2, f.operatorA, "sess", "claiming-Bs-seat"))
+
+	select {
+	case msg := <-sub.round1:
+		t.Fatalf("expected spoofed-seat messages to be dropped, got sender [%d]", msg.Sender)
+	default:
+	}
+}
+
+func TestBroadcastChannelDKGBus_MultiSeatOperator(t *testing.T) {
+	f := newDKGBusAuthFixture(t, 8)
+	sub := f.bus.Subscribe()
+
+	// Operator A holds seats 1 AND 3: it may authentically send as either.
+	f.bus.handleMessage(dkgRound1Msg(1, f.operatorA, "sess", "from-1"))
+	f.bus.handleMessage(dkgRound1Msg(3, f.operatorA, "sess", "from-3"))
+
+	got := map[group.MemberIndex]string{}
+	for {
+		select {
+		case msg := <-sub.round1:
+			got[msg.Sender] = string(msg.Payload)
+			continue
+		default:
+		}
+		break
+	}
+	if len(got) != 2 || got[1] != "from-1" || got[3] != "from-3" {
+		t.Fatalf("expected both of operator A's seats delivered, got %v", got)
+	}
+}
+
+func TestBroadcastChannelDKGBus_DedupsByteIdentical(t *testing.T) {
+	f := newDKGBusAuthFixture(t, 8)
+	sub := f.bus.Subscribe()
+
+	msg := dkgRound1Msg(1, f.operatorA, "sess", "same-body")
+	f.bus.handleMessage(msg)
+	f.bus.handleMessage(msg) // an identical retransmission
+
+	count := 0
+	for {
+		select {
+		case <-sub.round1:
+			count++
+			continue
+		default:
+		}
+		break
+	}
+	if count != 1 {
+		t.Fatalf("byte-identical retransmission must be deduped to a single delivery, got %d", count)
+	}
+}
+
+func TestDKGTransportMessage_MarshalRoundTrip(t *testing.T) {
+	original := &dkgTransportMessage{
+		messageType: dkgRound2Message,
+		sender:      7,
+		recipient:   3,
+		session:     "wallet-seed-0xabcd-attempt-2",
+		payload:     []byte("sealed-round-2-share-bytes"),
+	}
+	encoded, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	decoded := &dkgTransportMessage{messageType: dkgRound2Message}
+	if err := decoded.Unmarshal(encoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.sender != original.sender || decoded.recipient != original.recipient ||
+		decoded.session != original.session || !bytes.Equal(decoded.payload, original.payload) {
+		t.Fatalf("round-trip mismatch: got %+v, want %+v", decoded, original)
+	}
+}
+
+func TestDKGTransportMessage_UnmarshalRejectsMalformed(t *testing.T) {
+	// Too short for the header.
+	if err := (&dkgTransportMessage{}).Unmarshal([]byte{0x00, 0x01}); err == nil {
+		t.Fatal("expected an error for a truncated header")
+	}
+	// Out-of-range sender (0).
+	zeroSender := make([]byte, 10)
+	if err := (&dkgTransportMessage{}).Unmarshal(zeroSender); err == nil {
+		t.Fatal("expected an error for a zero sender")
+	}
+	// Session length longer than the remaining bytes.
+	badSession := make([]byte, 10)
+	badSession[3] = 1  // sender = 1
+	badSession[9] = 20 // session_len = 20, but no session bytes follow
+	if err := (&dkgTransportMessage{}).Unmarshal(badSession); err == nil {
+		t.Fatal("expected an error for a truncated session field")
+	}
+}

--- a/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_runner_bus_net_frost_native_test.go
@@ -169,6 +169,35 @@ func TestBroadcastChannelDKGBus_CarriesWireEphemeralKey(t *testing.T) {
 	}
 }
 
+// TestBroadcastChannelDKGBus_ReplayDeliversAndDedups covers the prebuffer rescue path:
+// a round-1 message captured before Start (by the prebuffer, from before the readiness
+// barrier) is delivered when Replayed, and Replaying it again - as if it also arrived
+// live - is deduplicated by content, so a member never sees the same round-1 twice.
+func TestBroadcastChannelDKGBus_ReplayDeliversAndDedups(t *testing.T) {
+	f := newDKGBusAuthFixture(t, 8)
+	sub := f.bus.Subscribe(1)
+
+	msg := dkgRound1Msg(1, f.operatorA, "sess", "prebuffered-round1")
+	f.bus.Replay([]net.Message{msg})
+
+	select {
+	case delivered := <-sub.round1:
+		if string(delivered.Payload) != "prebuffered-round1" {
+			t.Fatalf("unexpected replayed payload: %q", delivered.Payload)
+		}
+	default:
+		t.Fatal("a replayed round-1 message must be delivered")
+	}
+
+	// The same message arriving live (or replayed again) must NOT redeliver.
+	f.bus.Replay([]net.Message{msg})
+	select {
+	case dup := <-sub.round1:
+		t.Fatalf("a duplicate replay must be deduped, got: %q", dup.Payload)
+	default:
+	}
+}
+
 func TestBroadcastChannelDKGBus_RejectsSpoofedSeat(t *testing.T) {
 	f := newDKGBusAuthFixture(t, 8)
 	sub := f.bus.Subscribe(1)

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -230,6 +230,17 @@ func (r *distributedDKGRunner) Run(ctx context.Context) (*NativeFROSTDKGResult, 
 			len(part2.Packages), n-1,
 		)
 	}
+	// The OUTGOING round-2 packages each carry a per-recipient secret share; scrub
+	// them on return. They are needed only for the broadcast below - Part3
+	// consumes the RECEIVED round-2 packages, not these - so leaving them resident
+	// would defeat the zeroization the rest of this function does.
+	defer func() {
+		for _, pkg := range part2.Packages {
+			if pkg != nil {
+				zeroBytes(pkg.Data)
+			}
+		}
+	}()
 	for _, pkg := range part2.Packages {
 		recipient, ok := r.idByIdentifier[pkg.Identifier]
 		if !ok {

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -82,6 +82,13 @@ type dkgMessage struct {
 	// Sender is the authenticated originating member (the transport binds it;
 	// the orchestrator never trusts an id inside Payload for routing).
 	Sender group.MemberIndex
+	// SenderPublicKey is the sender's AUTHENTICATED operator public key, set by
+	// the transport (the net bus overwrites any claimed value with the key it
+	// authenticated the sender against). The orchestrator learns each member's
+	// round-2 sealing key from the round-1 message it broadcasts, since peer
+	// operator public keys are not known up front (group selection carries only
+	// addresses).
+	SenderPublicKey []byte
 	// Recipient is the addressed member for a round-2 message; unused (0) for a
 	// broadcast round-1 message.
 	Recipient group.MemberIndex
@@ -132,13 +139,16 @@ type distributedDKGRunner struct {
 	engine         distributedDKGEngine
 	bus            DKGBus
 	sub            *dkgBusSubscriber
-	// recipientKeys holds each other member's public key, used to SEAL that
-	// member's round-2 share before it is broadcast over the group-visible
-	// channel. selfKey is this node's private key, used to OPEN the round-2 shares
-	// sealed to us. In production these are the members' operator keys (converted
-	// via operatorPublicKeyToEphemeral / operatorPrivateKeyToEphemeral).
+	// recipientKeys is LEARNED during round 1: each member's authenticated
+	// operator public key (from the SenderPublicKey on its round-1 message) is the
+	// key its round-2 share is SEALED to. It is written only by collectRound1 and
+	// read only by the later round-2 send, both on the single Run goroutine.
 	recipientKeys map[group.MemberIndex]*ephemeral.PublicKey
+	// selfKey is this node's operator private key, used to OPEN the round-2 shares
+	// sealed to us; selfPublicKey is its marshaled operator public key, stamped on
+	// our own broadcasts so peers learn the key to seal our share to.
 	selfKey       *ephemeral.PrivateKey
+	selfPublicKey []byte
 }
 
 func newDistributedDKGRunner(
@@ -149,8 +159,8 @@ func newDistributedDKGRunner(
 	threshold uint16,
 	engine distributedDKGEngine,
 	bus DKGBus,
-	recipientKeys map[group.MemberIndex]*ephemeral.PublicKey,
 	selfKey *ephemeral.PrivateKey,
+	selfPublicKey []byte,
 ) (*distributedDKGRunner, error) {
 	switch {
 	case engine == nil:
@@ -159,6 +169,8 @@ func newDistributedDKGRunner(
 		return nil, fmt.Errorf("distributed dkg: bus is nil")
 	case selfKey == nil:
 		return nil, fmt.Errorf("distributed dkg: self key is nil")
+	case len(selfPublicKey) == 0:
+		return nil, fmt.Errorf("distributed dkg: self public key is empty")
 	case session == "":
 		return nil, fmt.Errorf("distributed dkg: session is empty")
 	case threshold == 0:
@@ -195,10 +207,6 @@ func newDistributedDKGRunner(
 		memberSet[m] = struct{}{}
 		if m == member {
 			memberInSet = true
-		} else if recipientKeys[m] == nil {
-			// Every other member's share is sealed to its key; a missing one would
-			// stall the DKG at round 2, so fail fast at construction.
-			return nil, fmt.Errorf("distributed dkg: no sealing key for member [%d]", m)
 		}
 	}
 	if !memberInSet {
@@ -215,8 +223,9 @@ func newDistributedDKGRunner(
 		threshold:      threshold,
 		engine:         engine,
 		bus:            bus,
-		recipientKeys:  recipientKeys,
+		recipientKeys:  make(map[group.MemberIndex]*ephemeral.PublicKey, len(memberIndexes)),
 		selfKey:        selfKey,
+		selfPublicKey:  selfPublicKey,
 		// Subscribe at construction so no peer's round-1 broadcast is missed.
 		sub: bus.Subscribe(),
 	}, nil
@@ -283,10 +292,17 @@ func (r *distributedDKGRunner) Run(ctx context.Context) (*NativeFROSTDKGResult, 
 				"distributed dkg: part2 package addressed to unknown identifier",
 			)
 		}
-		// Seal the share to the recipient before it crosses the group-visible
-		// channel: only the recipient can open it. recipientKeys[recipient] is
-		// guaranteed non-nil by the constructor (recipient != self).
-		sealed, err := sealRound2Share(pkg.Data, r.recipientKeys[recipient])
+		// Seal the share to the recipient's key - learned from its round-1 message -
+		// before it crosses the group-visible channel: only the recipient can open
+		// it. The key is present because we accept a round-1 sender only after
+		// learning its key, and Part2 produces packages only for round-1 senders.
+		recipientKey, ok := r.recipientKeys[recipient]
+		if !ok {
+			return nil, fmt.Errorf(
+				"distributed dkg: no learned round-2 sealing key for recipient [%d]", recipient,
+			)
+		}
+		sealed, err := sealRound2Share(pkg.Data, recipientKey)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"distributed dkg: seal round-2 share for member [%d]: %w", recipient, err,
@@ -332,11 +348,12 @@ func (r *distributedDKGRunner) broadcastPackage(
 		return fmt.Errorf("distributed dkg: marshal package: %w", err)
 	}
 	r.bus.Broadcast(dkgMessage{
-		Type:      msgType,
-		Session:   r.session,
-		Sender:    r.member,
-		Recipient: recipient,
-		Payload:   payload,
+		Type:            msgType,
+		Session:         r.session,
+		Sender:          r.member,
+		SenderPublicKey: r.selfPublicKey,
+		Recipient:       recipient,
+		Payload:         payload,
 	})
 	return nil
 }
@@ -382,6 +399,14 @@ func (r *distributedDKGRunner) collectRound1(
 			if pkg.Identifier != r.identifierByID[msg.Sender] {
 				continue
 			}
+			// Learn this sender's round-2 sealing key from its authenticated operator
+			// public key. A sender whose key we cannot parse is skipped, not counted:
+			// we could not seal a round-2 share to it, so it must not fill a slot.
+			recipientKey, err := ephemeral.UnmarshalPublicKey(msg.SenderPublicKey)
+			if err != nil {
+				continue
+			}
+			r.recipientKeys[msg.Sender] = recipientKey
 			pkgCopy := pkg
 			bySender[msg.Sender] = &pkgCopy
 		}

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -38,16 +38,17 @@ import (
 //     PublicKeyPackage (agreed identically by every honest member).
 //
 // Round-2 packages carry secret-share material and are delivered confidentially
-// per recipient: each share is ECIES-sealed to the recipient's STATIC operator
-// key (a fresh sender ephemeral per message; see
-// distributed_dkg_round2_seal_frost_native.go). NOTE the forward-secrecy scope:
-// this gives per-message secrecy on the SENDER side only. Unlike pkg/tecdsa/dkg,
-// which runs a two-sided per-DKG EPHEMERAL key exchange, the recipient key here
-// is long-lived, so an observer who records the round-2 broadcasts and LATER
-// obtains recipients' operator private keys can recover the shares addressed to
-// them. Closing that gap would require an ephemeral-key-exchange round (a
-// deliberate trade-off deferred here); the bus abstraction keeps any such change
-// local to the transport.
+// per recipient with TWO-SIDED forward secrecy: each share is ECIES-sealed with a
+// fresh sender ephemeral to the recipient's per-DKG EPHEMERAL public key (learned
+// from the recipient's authenticated round-1 broadcast), and opened with the
+// recipient's matching ephemeral private key, which is discarded when the DKG
+// ends (see distributed_dkg_round2_seal_frost_native.go). BOTH the sender and
+// recipient keys are ephemeral, so - like pkg/tecdsa/dkg's exchange round - an
+// observer who records the round-2 broadcasts and LATER obtains members' operator
+// keys learns nothing: the sealing keys never existed at rest. The long-lived
+// operator key stays with the transport, which authenticates the round-1 message
+// (and thus the ephemeral key riding in it). No extra round is needed - the
+// ephemeral public key piggybacks on the round-1 broadcast that already exists.
 
 // distributedDKGEngine is the subset of the native FROST engine the DKG
 // orchestrator needs. *buildTaggedTBTCSignerEngine satisfies it.
@@ -88,12 +89,13 @@ type dkgMessage struct {
 	// Sender is the authenticated originating member (the transport binds it;
 	// the orchestrator never trusts an id inside Payload for routing).
 	Sender group.MemberIndex
-	// SenderPublicKey is the sender's AUTHENTICATED operator public key, set by
-	// the transport (the net bus overwrites any claimed value with the key it
-	// authenticated the sender against). The orchestrator learns each member's
-	// round-2 sealing key from the round-1 message it broadcasts, since peer
-	// operator public keys are not known up front (group selection carries only
-	// addresses).
+	// SenderPublicKey is the sender's per-DKG EPHEMERAL round-2 sealing public key,
+	// carried on its round-1 message. Peers learn it here and seal this sender's
+	// round-2 shares to it; the sender opens them with the matching ephemeral
+	// private key, which is discarded when the DKG ends (recipient-side forward
+	// secrecy). It is trustworthy because the round-1 message is authenticated
+	// (the net bus binds the claimed seat to the operator key that signed the
+	// message, and the ephemeral key rides inside that same authenticated message).
 	SenderPublicKey []byte
 	// Recipient is the addressed member for a round-2 message; unused (0) for a
 	// broadcast round-1 message.
@@ -157,16 +159,17 @@ type distributedDKGRunner struct {
 	engine         distributedDKGEngine
 	bus            DKGBus
 	sub            *dkgBusSubscriber
-	// recipientKeys is LEARNED during round 1: each member's authenticated
-	// operator public key (from the SenderPublicKey on its round-1 message) is the
-	// key its round-2 share is SEALED to. It is written only by collectRound1 and
-	// read only by the later round-2 send, both on the single Run goroutine.
+	// recipientKeys is LEARNED during round 1: each member's per-DKG EPHEMERAL
+	// public key (from the SenderPublicKey on its round-1 message) is the key its
+	// round-2 share is SEALED to. It is written only by collectRound1 and read only
+	// by the later round-2 send, both on the single Run goroutine.
 	recipientKeys map[group.MemberIndex]*ephemeral.PublicKey
-	// selfKey is this node's operator private key, used to OPEN the round-2 shares
-	// sealed to us. selfPublicKey is its marshaled operator public key, stamped on
-	// our broadcasts so peers learn the key to seal our share to. Over the net bus
-	// the stamp is dropped and re-derived from the AUTHENTICATED transport key, so
-	// this trusted stamp path is used only by the in-process test bus.
+	// selfKey is this seat's per-DKG EPHEMERAL private key, used to OPEN the round-2
+	// shares sealed to us; selfPublicKey is its marshaled ephemeral public key,
+	// stamped on our broadcasts so peers seal our share to it. The ephemeral key is
+	// fresh per DKG and discarded afterward, giving recipient-side forward secrecy;
+	// the operator key stays with the transport, which authenticates the broadcast
+	// this ephemeral key rides in.
 	selfKey       *ephemeral.PrivateKey
 	selfPublicKey []byte
 }

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
+	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
@@ -118,6 +119,13 @@ type DKGBus interface {
 	// dropped, and the transport may have already marked it seen and never
 	// retransmit it, stalling the DKG.
 	Start()
+	// Replay feeds messages captured by a DKGMessagePrebuffer - which starts intaking
+	// BEFORE the cross-node readiness barrier - through the receive path, so a peer's
+	// round-1 broadcast that arrived before this node installed its receiver (the
+	// window between the barrier releasing peers and Start) is not lost. Call after
+	// Start and after every seat has Subscribed; messages are deduplicated by content,
+	// so any that also arrived live are ignored.
+	Replay(messages []net.Message)
 }
 
 // dkgBusSubscriber exposes one member's typed round streams. member is the seat
@@ -581,6 +589,10 @@ func (b *inProcessDKGBus) Subscribe(member group.MemberIndex) *dkgBusSubscriber 
 // Start is a no-op: the in-process bus delivers synchronously in Broadcast, so
 // there is no inbound-receive handler to defer.
 func (b *inProcessDKGBus) Start() {}
+
+// Replay is a no-op: the in-process bus has no real transport and no readiness
+// barrier, so there is no pre-barrier window to rescue messages from.
+func (b *inProcessDKGBus) Replay(_ []net.Message) {}
 
 func (b *inProcessDKGBus) Broadcast(msg dkgMessage) {
 	b.mu.Lock()

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -103,6 +103,12 @@ type DKGBus interface {
 type dkgBusSubscriber struct {
 	round1 chan dkgMessage
 	round2 chan dkgMessage
+
+	// mu and seen back the net bus's per-subscriber dedup of byte-identical
+	// retransmissions (keyed by full message content hash); the in-process bus
+	// leaves them unused.
+	mu   sync.Mutex
+	seen map[[32]byte]struct{}
 }
 
 // distributedDKGRunner drives one member's participation in one distributed FROST

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -37,11 +37,17 @@ import (
 //     to me) -> this node's long-term KeyPackage (its secret share) + the group
 //     PublicKeyPackage (agreed identically by every honest member).
 //
-// Round-2 packages carry secret-share material and MUST be delivered
-// confidentially per recipient in production (Phase 1 encrypts them to the
-// recipient's operator key, reusing the pkg/tecdsa/dkg ephemeral-ECDH envelope).
-// Here they are addressed but not yet encrypted; the bus abstraction keeps that
-// change local to the transport.
+// Round-2 packages carry secret-share material and are delivered confidentially
+// per recipient: each share is ECIES-sealed to the recipient's STATIC operator
+// key (a fresh sender ephemeral per message; see
+// distributed_dkg_round2_seal_frost_native.go). NOTE the forward-secrecy scope:
+// this gives per-message secrecy on the SENDER side only. Unlike pkg/tecdsa/dkg,
+// which runs a two-sided per-DKG EPHEMERAL key exchange, the recipient key here
+// is long-lived, so an observer who records the round-2 broadcasts and LATER
+// obtains recipients' operator private keys can recover the shares addressed to
+// them. Closing that gap would require an ephemeral-key-exchange round (a
+// deliberate trade-off deferred here); the bus abstraction keeps any such change
+// local to the transport.
 
 // distributedDKGEngine is the subset of the native FROST engine the DKG
 // orchestrator needs. *buildTaggedTBTCSignerEngine satisfies it.

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -1,0 +1,408 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// This file wires the real DISTRIBUTED FROST DKG (three-round Pedersen DKG:
+// Part1 -> Part2 -> Part3) into a per-member, bus-driven orchestrator - the shape
+// the tBTC node needs. Today the node's wallet-DKG path
+// (pkg/tbtc executeTBTCSignerFROSTDKG -> RunDKGWithSeed) is a transitional
+// TRUSTED-DEALER key generation (frost::keys::generate_with_dealer seeded by the
+// public on-chain seed), which the Rust signer HARD-DISABLES under
+// TBTC_SIGNER_PROFILE=production ("production requires distributed DKG wiring").
+// The distributed-DKG crypto already exists (engine Part1/Part2/Part3 over the
+// tbtc-signer FFI); what was missing is an orchestrator that exchanges the round
+// packages between nodes so each node ends up with its OWN secret share of a
+// t-of-n key that NO node ever holds in full. This is that orchestrator, driven
+// over a message bus so it can later run over the real wallet broadcast channel.
+//
+// Round structure (frost-core / RFC-9591), for member m with identifier id_m:
+//   Round 1: Part1(id_m, n, t) -> a local round-1 SECRET package (never leaves
+//     the node) + a public round-1 package, BROADCAST to all. Collect the other
+//     n-1 members' round-1 packages.
+//   Round 2: Part2(secret1, others' round-1 packages) -> a local round-2 secret
+//     package + one round-2 package PER OTHER member (each carrying its
+//     recipient's identifier and secret-share material). Send each to its
+//     recipient. Collect the n-1 round-2 packages addressed to me.
+//   Round 3: Part3(secret2, others' round-1 packages, round-2 packages addressed
+//     to me) -> this node's long-term KeyPackage (its secret share) + the group
+//     PublicKeyPackage (agreed identically by every honest member).
+//
+// Round-2 packages carry secret-share material and MUST be delivered
+// confidentially per recipient in production (Phase 1 encrypts them to the
+// recipient's operator key, reusing the pkg/tecdsa/dkg ephemeral-ECDH envelope).
+// Here they are addressed but not yet encrypted; the bus abstraction keeps that
+// change local to the transport.
+
+// distributedDKGEngine is the subset of the native FROST engine the DKG
+// orchestrator needs. *buildTaggedTBTCSignerEngine satisfies it.
+type distributedDKGEngine interface {
+	Part1(participantIdentifier string, maxSigners, minSigners uint16) (*NativeFROSTDKGPart1Result, error)
+	Part2(
+		secretPackage *NativeFROSTDKGRound1SecretPackage,
+		round1Packages []*NativeFROSTDKGRound1Package,
+	) (*NativeFROSTDKGPart2Result, error)
+	Part3(
+		secretPackage *NativeFROSTDKGRound2SecretPackage,
+		round1Packages []*NativeFROSTDKGRound1Package,
+		round2Packages []*NativeFROSTDKGRound2Package,
+	) (*NativeFROSTDKGResult, error)
+}
+
+// dkgMessageType tags a DKG round message so subscribers route it.
+type dkgMessageType int
+
+const (
+	// dkgRound1Message carries a member's public round-1 package (broadcast).
+	dkgRound1Message dkgMessageType = iota
+	// dkgRound2Message carries a round-2 package addressed to one recipient.
+	dkgRound2Message
+)
+
+// dkgMessage is one DKG round message on the bus. Payload is the JSON-encoded
+// round-1 or round-2 package; the bus treats it as opaque.
+type dkgMessage struct {
+	Type dkgMessageType
+	// Sender is the authenticated originating member (the transport binds it;
+	// the orchestrator never trusts an id inside Payload for routing).
+	Sender group.MemberIndex
+	// Recipient is the addressed member for a round-2 message; unused (0) for a
+	// broadcast round-1 message.
+	Recipient group.MemberIndex
+	Payload   []byte
+}
+
+// DKGBus is the DKG round-exchange transport. The in-process implementation here
+// drives the orchestrator's deterministic tests; production wraps the wallet
+// broadcast channel (with round-2 encrypted to the recipient).
+type DKGBus interface {
+	// Broadcast delivers msg to every subscriber. A round-2 message is addressed
+	// (Recipient set); subscribers keep only the ones addressed to them.
+	Broadcast(msg dkgMessage)
+	// Subscribe registers a receiver up front (before any Broadcast).
+	Subscribe() *dkgBusSubscriber
+}
+
+// dkgBusSubscriber exposes one member's typed round streams.
+type dkgBusSubscriber struct {
+	round1 chan dkgMessage
+	round2 chan dkgMessage
+}
+
+// distributedDKGRunner drives one member's participation in one distributed FROST
+// DKG over a DKGBus. Every secret (round-1/round-2 secret packages, the final key
+// package) stays local to this runner; only the public round-1 package and the
+// per-recipient round-2 packages cross the bus.
+type distributedDKGRunner struct {
+	member         group.MemberIndex
+	identifier     string
+	memberIndexes  []group.MemberIndex
+	identifierByID map[group.MemberIndex]string
+	idByIdentifier map[string]group.MemberIndex
+	threshold      uint16
+	engine         distributedDKGEngine
+	bus            DKGBus
+	sub            *dkgBusSubscriber
+}
+
+func newDistributedDKGRunner(
+	member group.MemberIndex,
+	memberIndexes []group.MemberIndex,
+	identifierByID map[group.MemberIndex]string,
+	threshold uint16,
+	engine distributedDKGEngine,
+	bus DKGBus,
+) (*distributedDKGRunner, error) {
+	switch {
+	case engine == nil:
+		return nil, fmt.Errorf("distributed dkg: engine is nil")
+	case bus == nil:
+		return nil, fmt.Errorf("distributed dkg: bus is nil")
+	case threshold == 0:
+		return nil, fmt.Errorf("distributed dkg: threshold is zero")
+	case int(threshold) > len(memberIndexes):
+		return nil, fmt.Errorf(
+			"distributed dkg: threshold [%d] exceeds member count [%d]",
+			threshold, len(memberIndexes),
+		)
+	}
+	identifier, ok := identifierByID[member]
+	if !ok {
+		return nil, fmt.Errorf("distributed dkg: no identifier for member [%d]", member)
+	}
+	idByIdentifier := make(map[string]group.MemberIndex, len(identifierByID))
+	memberInSet := false
+	for m, id := range identifierByID {
+		idByIdentifier[id] = m
+	}
+	for _, m := range memberIndexes {
+		if _, ok := identifierByID[m]; !ok {
+			return nil, fmt.Errorf("distributed dkg: no identifier for member [%d] in set", m)
+		}
+		if m == member {
+			memberInSet = true
+		}
+	}
+	if !memberInSet {
+		return nil, fmt.Errorf("distributed dkg: member [%d] is not in the member set", member)
+	}
+	return &distributedDKGRunner{
+		member:         member,
+		identifier:     identifier,
+		memberIndexes:  memberIndexes,
+		identifierByID: identifierByID,
+		idByIdentifier: idByIdentifier,
+		threshold:      threshold,
+		engine:         engine,
+		bus:            bus,
+		// Subscribe at construction so no peer's round-1 broadcast is missed.
+		sub: bus.Subscribe(),
+	}, nil
+}
+
+// Run executes the three DKG rounds for this member and returns its DKG result
+// (secret KeyPackage + the group PublicKeyPackage). It honors ctx cancellation
+// while collecting each round's packages: a member that never broadcasts stalls
+// the round to the deadline, failing into the (existing) DKG retry/challenge
+// path rather than hanging forever.
+func (r *distributedDKGRunner) Run(ctx context.Context) (*NativeFROSTDKGResult, error) {
+	n := len(r.memberIndexes)
+
+	// ---- Round 1: our public package broadcast; secret kept local. ----
+	part1, err := r.engine.Part1(r.identifier, uint16(n), r.threshold)
+	if err != nil {
+		return nil, fmt.Errorf("distributed dkg: part1: %w", err)
+	}
+	if part1.Package == nil || part1.SecretPackage == nil {
+		return nil, fmt.Errorf("distributed dkg: part1 returned an incomplete result")
+	}
+	if err := r.broadcastPackage(dkgRound1Message, 0, part1.Package); err != nil {
+		return nil, err
+	}
+	round1Packages, err := r.collectRound1(ctx, n-1)
+	if err != nil {
+		return nil, err
+	}
+
+	// ---- Round 2: a package per other member, addressed to its recipient. ----
+	part2, err := r.engine.Part2(part1.SecretPackage, round1Packages)
+	if err != nil {
+		return nil, fmt.Errorf("distributed dkg: part2: %w", err)
+	}
+	if len(part2.Packages) != n-1 {
+		return nil, fmt.Errorf(
+			"distributed dkg: part2 produced [%d] packages, want [%d]",
+			len(part2.Packages), n-1,
+		)
+	}
+	for _, pkg := range part2.Packages {
+		recipient, ok := r.idByIdentifier[pkg.Identifier]
+		if !ok {
+			return nil, fmt.Errorf(
+				"distributed dkg: part2 package addressed to unknown identifier",
+			)
+		}
+		if err := r.broadcastPackage(dkgRound2Message, recipient, pkg); err != nil {
+			return nil, err
+		}
+	}
+	round2Packages, err := r.collectRound2(ctx, n-1)
+	if err != nil {
+		return nil, err
+	}
+
+	// ---- Round 3: our long-term secret share + the agreed group key. ----
+	result, err := r.engine.Part3(part2.SecretPackage, round1Packages, round2Packages)
+	if err != nil {
+		return nil, fmt.Errorf("distributed dkg: part3: %w", err)
+	}
+	if result.KeyPackage == nil || result.PublicKeyPackage == nil {
+		return nil, fmt.Errorf("distributed dkg: part3 returned an incomplete result")
+	}
+	return result, nil
+}
+
+// broadcastPackage JSON-encodes a round package and broadcasts it on the bus.
+func (r *distributedDKGRunner) broadcastPackage(
+	msgType dkgMessageType,
+	recipient group.MemberIndex,
+	pkg any,
+) error {
+	payload, err := json.Marshal(pkg)
+	if err != nil {
+		return fmt.Errorf("distributed dkg: marshal package: %w", err)
+	}
+	r.bus.Broadcast(dkgMessage{
+		Type:      msgType,
+		Sender:    r.member,
+		Recipient: recipient,
+		Payload:   payload,
+	})
+	return nil
+}
+
+// collectRound1 gathers the other members' public round-1 packages (excluding
+// our own), keyed by sender so each member is counted at most once, until `want`
+// distinct senders have arrived or ctx expires. The package's embedded identifier
+// must match its authenticated sender, so a member cannot smuggle another's slot.
+func (r *distributedDKGRunner) collectRound1(
+	ctx context.Context,
+	want int,
+) ([]*NativeFROSTDKGRound1Package, error) {
+	bySender := make(map[group.MemberIndex]*NativeFROSTDKGRound1Package, want)
+	for len(bySender) < want {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf(
+				"distributed dkg: collect round1: got [%d] of [%d] packages: %w",
+				len(bySender), want, ctx.Err(),
+			)
+		case msg := <-r.sub.round1:
+			if msg.Sender == r.member {
+				continue // never our own echo
+			}
+			if _, have := bySender[msg.Sender]; have {
+				continue
+			}
+			var pkg NativeFROSTDKGRound1Package
+			if err := json.Unmarshal(msg.Payload, &pkg); err != nil {
+				continue
+			}
+			// Bind the package's own identifier to its authenticated sender: a
+			// member must not contribute a round-1 package under another's id.
+			if pkg.Identifier != r.identifierByID[msg.Sender] {
+				continue
+			}
+			pkgCopy := pkg
+			bySender[msg.Sender] = &pkgCopy
+		}
+	}
+	return sortedRound1Packages(r.memberIndexes, r.member, bySender), nil
+}
+
+// collectRound2 gathers the round-2 packages ADDRESSED to us, one per other
+// member, tagging each with its authenticated sender's identifier (Part3 keys
+// round-2 packages by sender). Packages addressed to other recipients are
+// ignored here.
+func (r *distributedDKGRunner) collectRound2(
+	ctx context.Context,
+	want int,
+) ([]*NativeFROSTDKGRound2Package, error) {
+	bySender := make(map[group.MemberIndex]*NativeFROSTDKGRound2Package, want)
+	for len(bySender) < want {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf(
+				"distributed dkg: collect round2: got [%d] of [%d] packages: %w",
+				len(bySender), want, ctx.Err(),
+			)
+		case msg := <-r.sub.round2:
+			if msg.Sender == r.member || msg.Recipient != r.member {
+				continue // not addressed to us (or our own echo)
+			}
+			if _, have := bySender[msg.Sender]; have {
+				continue
+			}
+			var pkg NativeFROSTDKGRound2Package
+			if err := json.Unmarshal(msg.Payload, &pkg); err != nil {
+				continue
+			}
+			// The package must be addressed to us; reject a misrouted one.
+			if pkg.Identifier != r.identifier {
+				continue
+			}
+			// Tag the sender: Part3 keys round-2 packages by sender while the
+			// package itself carries the recipient identifier.
+			pkg.SenderIdentifier = r.identifierByID[msg.Sender]
+			pkgCopy := pkg
+			bySender[msg.Sender] = &pkgCopy
+		}
+	}
+	return sortedRound2Packages(r.memberIndexes, r.member, bySender), nil
+}
+
+// sortedRound1Packages returns the collected round-1 packages in ascending
+// member order (deterministic input to Part2/Part3), excluding our own.
+func sortedRound1Packages(
+	memberIndexes []group.MemberIndex,
+	self group.MemberIndex,
+	bySender map[group.MemberIndex]*NativeFROSTDKGRound1Package,
+) []*NativeFROSTDKGRound1Package {
+	out := make([]*NativeFROSTDKGRound1Package, 0, len(bySender))
+	for _, m := range memberIndexes {
+		if m == self {
+			continue
+		}
+		if pkg, ok := bySender[m]; ok {
+			out = append(out, pkg)
+		}
+	}
+	return out
+}
+
+// sortedRound2Packages returns the round-2 packages addressed to us in ascending
+// sender order, excluding our own.
+func sortedRound2Packages(
+	memberIndexes []group.MemberIndex,
+	self group.MemberIndex,
+	bySender map[group.MemberIndex]*NativeFROSTDKGRound2Package,
+) []*NativeFROSTDKGRound2Package {
+	out := make([]*NativeFROSTDKGRound2Package, 0, len(bySender))
+	for _, m := range memberIndexes {
+		if m == self {
+			continue
+		}
+		if pkg, ok := bySender[m]; ok {
+			out = append(out, pkg)
+		}
+	}
+	return out
+}
+
+// inProcessDKGBus is the deterministic in-process DKGBus for orchestrator tests.
+// Broadcast delivers synchronously into every subscriber's buffered round
+// streams; the buffer is sized above a whole DKG's message volume so an honest
+// run never blocks.
+type inProcessDKGBus struct {
+	subscribers []*dkgBusSubscriber
+	bufferSize  int
+}
+
+// NewInProcessDKGBus returns an in-process DKG bus with per-stream buffers of the
+// given size.
+func NewInProcessDKGBus(bufferSize int) DKGBus {
+	if bufferSize < 1 {
+		bufferSize = 1
+	}
+	return &inProcessDKGBus{bufferSize: bufferSize}
+}
+
+func (b *inProcessDKGBus) Subscribe() *dkgBusSubscriber {
+	s := &dkgBusSubscriber{
+		round1: make(chan dkgMessage, b.bufferSize),
+		round2: make(chan dkgMessage, b.bufferSize),
+	}
+	b.subscribers = append(b.subscribers, s)
+	return s
+}
+
+func (b *inProcessDKGBus) Broadcast(msg dkgMessage) {
+	for _, s := range b.subscribers {
+		// Own the payload per delivery so no receiver can mutate another's view.
+		delivered := msg
+		delivered.Payload = append([]byte(nil), msg.Payload...)
+		switch msg.Type {
+		case dkgRound1Message:
+			s.round1 <- delivered
+		case dkgRound2Message:
+			s.round2 <- delivered
+		}
+	}
+}

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -222,18 +222,11 @@ func (r *distributedDKGRunner) Run(ctx context.Context) (*NativeFROSTDKGResult, 
 	if part2.SecretPackage == nil {
 		return nil, fmt.Errorf("distributed dkg: part2 returned an incomplete result")
 	}
-	// Scrub the round-2 secret package on return (consumed by Part3 below).
+	// Scrub the round-2 secret package AND the OUTGOING per-recipient share
+	// packages on return: both carry secret material and are consumed only within
+	// this function (Part3 consumes the RECEIVED packages, not these). Registered
+	// BEFORE the count check so an unexpected-count return still scrubs them.
 	defer zeroBytes(part2.SecretPackage.Data)
-	if len(part2.Packages) != n-1 {
-		return nil, fmt.Errorf(
-			"distributed dkg: part2 produced [%d] packages, want [%d]",
-			len(part2.Packages), n-1,
-		)
-	}
-	// The OUTGOING round-2 packages each carry a per-recipient secret share; scrub
-	// them on return. They are needed only for the broadcast below - Part3
-	// consumes the RECEIVED round-2 packages, not these - so leaving them resident
-	// would defeat the zeroization the rest of this function does.
 	defer func() {
 		for _, pkg := range part2.Packages {
 			if pkg != nil {
@@ -241,6 +234,12 @@ func (r *distributedDKGRunner) Run(ctx context.Context) (*NativeFROSTDKGResult, 
 			}
 		}
 	}()
+	if len(part2.Packages) != n-1 {
+		return nil, fmt.Errorf(
+			"distributed dkg: part2 produced [%d] packages, want [%d]",
+			len(part2.Packages), n-1,
+		)
+	}
 	for _, pkg := range part2.Packages {
 		recipient, ok := r.idByIdentifier[pkg.Identifier]
 		if !ok {
@@ -353,6 +352,13 @@ func (r *distributedDKGRunner) collectRound2(
 	for len(bySender) < want {
 		select {
 		case <-ctx.Done():
+			// Scrub the partial shares accumulated before the deadline: a missing
+			// round-2 package is an expected dropout/retry path, and each held
+			// package carries incoming secret-share material. len(bySender) is
+			// unaffected by zeroing the payloads, so the count below stays accurate.
+			for _, pkg := range bySender {
+				zeroBytes(pkg.Data)
+			}
 			return nil, fmt.Errorf(
 				"distributed dkg: collect round2: got [%d] of [%d] packages: %w",
 				len(bySender), want, ctx.Err(),

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -263,6 +263,11 @@ func newDistributedDKGRunner(
 func (r *distributedDKGRunner) Run(ctx context.Context) (*NativeFROSTDKGResult, error) {
 	n := len(r.memberIndexes)
 
+	// Scrub this seat's per-DKG ephemeral private key when the DKG concludes: it
+	// exists only to open round-2 shares during this Run, and forward secrecy
+	// depends on it not lingering at rest (in a later core dump or swap file).
+	defer r.selfKey.Zero()
+
 	// ---- Round 1: our public package broadcast; secret kept local. ----
 	part1, err := r.engine.Part1(r.identifier, uint16(n), r.threshold)
 	if err != nil {
@@ -423,9 +428,10 @@ func (r *distributedDKGRunner) collectRound1(
 			if pkg.Identifier != r.identifierByID[msg.Sender] {
 				continue
 			}
-			// Learn this sender's round-2 sealing key from its authenticated operator
-			// public key. A sender whose key we cannot parse is skipped, not counted:
-			// we could not seal a round-2 share to it, so it must not fill a slot.
+			// Learn this sender's round-2 sealing key: its per-DKG EPHEMERAL public
+			// key, carried on (and authenticated with) its round-1 message. A sender
+			// whose key we cannot parse is skipped, not counted: we could not seal a
+			// round-2 share to it, so it must not fill a slot.
 			recipientKey, err := ephemeral.UnmarshalPublicKey(msg.SenderPublicKey)
 			if err != nil {
 				continue

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
@@ -101,9 +102,15 @@ type dkgBusSubscriber struct {
 // package) stays local to this runner; only the public round-1 package and the
 // per-recipient round-2 packages cross the bus.
 type distributedDKGRunner struct {
-	member         group.MemberIndex
-	identifier     string
-	memberIndexes  []group.MemberIndex
+	member        group.MemberIndex
+	identifier    string
+	memberIndexes []group.MemberIndex
+	// memberSet is the DKG participant set as a lookup. A round message from an
+	// authenticated sender NOT in this set (a shared transport may carry other
+	// groups' traffic) must be rejected BEFORE it is counted toward a round's
+	// collection target - otherwise it fills a slot that a real peer's package is
+	// then dropped from, and the runner proceeds with incomplete packages.
+	memberSet      map[group.MemberIndex]struct{}
 	identifierByID map[group.MemberIndex]string
 	idByIdentifier map[string]group.MemberIndex
 	threshold      uint16
@@ -137,15 +144,26 @@ func newDistributedDKGRunner(
 	if !ok {
 		return nil, fmt.Errorf("distributed dkg: no identifier for member [%d]", member)
 	}
-	idByIdentifier := make(map[string]group.MemberIndex, len(identifierByID))
+	// Build the participant set and the identifier<->member routing maps from the
+	// DKG member set only (not the whole identifierByID, which may be broader).
+	// Identifiers must be distinct across participants, or round-2 routing would
+	// silently collapse two members onto one; fail closed on a collision.
+	memberSet := make(map[group.MemberIndex]struct{}, len(memberIndexes))
+	idByIdentifier := make(map[string]group.MemberIndex, len(memberIndexes))
 	memberInSet := false
-	for m, id := range identifierByID {
-		idByIdentifier[id] = m
-	}
 	for _, m := range memberIndexes {
-		if _, ok := identifierByID[m]; !ok {
+		id, ok := identifierByID[m]
+		if !ok {
 			return nil, fmt.Errorf("distributed dkg: no identifier for member [%d] in set", m)
 		}
+		if existing, dup := idByIdentifier[id]; dup {
+			return nil, fmt.Errorf(
+				"distributed dkg: members [%d] and [%d] share identifier %q",
+				existing, m, id,
+			)
+		}
+		idByIdentifier[id] = m
+		memberSet[m] = struct{}{}
 		if m == member {
 			memberInSet = true
 		}
@@ -157,6 +175,7 @@ func newDistributedDKGRunner(
 		member:         member,
 		identifier:     identifier,
 		memberIndexes:  memberIndexes,
+		memberSet:      memberSet,
 		identifierByID: identifierByID,
 		idByIdentifier: idByIdentifier,
 		threshold:      threshold,
@@ -183,6 +202,10 @@ func (r *distributedDKGRunner) Run(ctx context.Context) (*NativeFROSTDKGResult, 
 	if part1.Package == nil || part1.SecretPackage == nil {
 		return nil, fmt.Errorf("distributed dkg: part1 returned an incomplete result")
 	}
+	// Scrub the round-1 secret package on return: Part2 consumes it below, but it
+	// must not linger in the heap afterward (the engine only zeroes its own
+	// transport buffers; the copies handed to the Go caller are ours to scrub).
+	defer zeroBytes(part1.SecretPackage.Data)
 	if err := r.broadcastPackage(dkgRound1Message, 0, part1.Package); err != nil {
 		return nil, err
 	}
@@ -196,6 +219,11 @@ func (r *distributedDKGRunner) Run(ctx context.Context) (*NativeFROSTDKGResult, 
 	if err != nil {
 		return nil, fmt.Errorf("distributed dkg: part2: %w", err)
 	}
+	if part2.SecretPackage == nil {
+		return nil, fmt.Errorf("distributed dkg: part2 returned an incomplete result")
+	}
+	// Scrub the round-2 secret package on return (consumed by Part3 below).
+	defer zeroBytes(part2.SecretPackage.Data)
 	if len(part2.Packages) != n-1 {
 		return nil, fmt.Errorf(
 			"distributed dkg: part2 produced [%d] packages, want [%d]",
@@ -217,6 +245,15 @@ func (r *distributedDKGRunner) Run(ctx context.Context) (*NativeFROSTDKGResult, 
 	if err != nil {
 		return nil, err
 	}
+	// The received round-2 packages carry incoming secret-share material; scrub
+	// them once Part3 (below) has consumed them.
+	defer func() {
+		for _, pkg := range round2Packages {
+			if pkg != nil {
+				zeroBytes(pkg.Data)
+			}
+		}
+	}()
 
 	// ---- Round 3: our long-term secret share + the agreed group key. ----
 	result, err := r.engine.Part3(part2.SecretPackage, round1Packages, round2Packages)
@@ -268,6 +305,12 @@ func (r *distributedDKGRunner) collectRound1(
 			if msg.Sender == r.member {
 				continue // never our own echo
 			}
+			if _, ok := r.memberSet[msg.Sender]; !ok {
+				// Not a participant in THIS DKG. A shared transport may carry other
+				// groups' traffic; counting it would fill a slot a real peer is then
+				// dropped from, so we would proceed with incomplete packages.
+				continue
+			}
 			if _, have := bySender[msg.Sender]; have {
 				continue
 			}
@@ -306,6 +349,9 @@ func (r *distributedDKGRunner) collectRound2(
 		case msg := <-r.sub.round2:
 			if msg.Sender == r.member || msg.Recipient != r.member {
 				continue // not addressed to us (or our own echo)
+			}
+			if _, ok := r.memberSet[msg.Sender]; !ok {
+				continue // not a participant in THIS DKG (shared transport)
 			}
 			if _, have := bySender[msg.Sender]; have {
 				continue
@@ -371,12 +417,17 @@ func sortedRound2Packages(
 // streams; the buffer is sized above a whole DKG's message volume so an honest
 // run never blocks.
 type inProcessDKGBus struct {
+	mu          sync.Mutex
 	subscribers []*dkgBusSubscriber
 	bufferSize  int
 }
 
 // NewInProcessDKGBus returns an in-process DKG bus with per-stream buffers of the
-// given size.
+// given size. Sends are blocking, so bufferSize MUST exceed a whole DKG's
+// per-stream message volume - up to n*(n-1) round-2 messages reach every
+// subscriber's round-2 stream - or a Broadcast can block. It is sized generously
+// for the small groups the orchestrator tests use; production runs over the net
+// broadcast channel, not this bus.
 func NewInProcessDKGBus(bufferSize int) DKGBus {
 	if bufferSize < 1 {
 		bufferSize = 1
@@ -389,12 +440,17 @@ func (b *inProcessDKGBus) Subscribe() *dkgBusSubscriber {
 		round1: make(chan dkgMessage, b.bufferSize),
 		round2: make(chan dkgMessage, b.bufferSize),
 	}
+	b.mu.Lock()
 	b.subscribers = append(b.subscribers, s)
+	b.mu.Unlock()
 	return s
 }
 
 func (b *inProcessDKGBus) Broadcast(msg dkgMessage) {
-	for _, s := range b.subscribers {
+	b.mu.Lock()
+	subscribers := append([]*dkgBusSubscriber(nil), b.subscribers...)
+	b.mu.Unlock()
+	for _, s := range subscribers {
 		// Own the payload per delivery so no receiver can mutate another's view.
 		delivered := msg
 		delivered.Payload = append([]byte(nil), msg.Payload...)

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -105,6 +105,11 @@ type DKGBus interface {
 	// Subscribe registers a receiver for the given seat up front (before any
 	// Broadcast); round-2 messages addressed to that seat are routed to it.
 	Subscribe(member group.MemberIndex) *dkgBusSubscriber
+	// Start begins delivering inbound messages. It MUST be called only after every
+	// local seat has Subscribed: a message handled before any subscriber exists is
+	// dropped, and the transport may have already marked it seen and never
+	// retransmit it, stalling the DKG.
+	Start()
 }
 
 // dkgBusSubscriber exposes one member's typed round streams. member is the seat
@@ -557,6 +562,10 @@ func (b *inProcessDKGBus) Subscribe(member group.MemberIndex) *dkgBusSubscriber 
 	b.mu.Unlock()
 	return s
 }
+
+// Start is a no-op: the in-process bus delivers synchronously in Broadcast, so
+// there is no inbound-receive handler to defer.
+func (b *inProcessDKGBus) Start() {}
 
 func (b *inProcessDKGBus) Broadcast(msg dkgMessage) {
 	b.mu.Lock()

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
@@ -117,6 +118,13 @@ type distributedDKGRunner struct {
 	engine         distributedDKGEngine
 	bus            DKGBus
 	sub            *dkgBusSubscriber
+	// recipientKeys holds each other member's public key, used to SEAL that
+	// member's round-2 share before it is broadcast over the group-visible
+	// channel. selfKey is this node's private key, used to OPEN the round-2 shares
+	// sealed to us. In production these are the members' operator keys (converted
+	// via operatorPublicKeyToEphemeral / operatorPrivateKeyToEphemeral).
+	recipientKeys map[group.MemberIndex]*ephemeral.PublicKey
+	selfKey       *ephemeral.PrivateKey
 }
 
 func newDistributedDKGRunner(
@@ -126,12 +134,16 @@ func newDistributedDKGRunner(
 	threshold uint16,
 	engine distributedDKGEngine,
 	bus DKGBus,
+	recipientKeys map[group.MemberIndex]*ephemeral.PublicKey,
+	selfKey *ephemeral.PrivateKey,
 ) (*distributedDKGRunner, error) {
 	switch {
 	case engine == nil:
 		return nil, fmt.Errorf("distributed dkg: engine is nil")
 	case bus == nil:
 		return nil, fmt.Errorf("distributed dkg: bus is nil")
+	case selfKey == nil:
+		return nil, fmt.Errorf("distributed dkg: self key is nil")
 	case threshold == 0:
 		return nil, fmt.Errorf("distributed dkg: threshold is zero")
 	case int(threshold) > len(memberIndexes):
@@ -166,6 +178,10 @@ func newDistributedDKGRunner(
 		memberSet[m] = struct{}{}
 		if m == member {
 			memberInSet = true
+		} else if recipientKeys[m] == nil {
+			// Every other member's share is sealed to its key; a missing one would
+			// stall the DKG at round 2, so fail fast at construction.
+			return nil, fmt.Errorf("distributed dkg: no sealing key for member [%d]", m)
 		}
 	}
 	if !memberInSet {
@@ -181,6 +197,8 @@ func newDistributedDKGRunner(
 		threshold:      threshold,
 		engine:         engine,
 		bus:            bus,
+		recipientKeys:  recipientKeys,
+		selfKey:        selfKey,
 		// Subscribe at construction so no peer's round-1 broadcast is missed.
 		sub: bus.Subscribe(),
 	}, nil
@@ -247,7 +265,16 @@ func (r *distributedDKGRunner) Run(ctx context.Context) (*NativeFROSTDKGResult, 
 				"distributed dkg: part2 package addressed to unknown identifier",
 			)
 		}
-		if err := r.broadcastPackage(dkgRound2Message, recipient, pkg); err != nil {
+		// Seal the share to the recipient before it crosses the group-visible
+		// channel: only the recipient can open it. recipientKeys[recipient] is
+		// guaranteed non-nil by the constructor (recipient != self).
+		sealed, err := sealRound2Share(pkg.Data, r.recipientKeys[recipient])
+		if err != nil {
+			return nil, fmt.Errorf(
+				"distributed dkg: seal round-2 share for member [%d]: %w", recipient, err,
+			)
+		}
+		if err := r.broadcastPackage(dkgRound2Message, recipient, sealed); err != nil {
 			return nil, err
 		}
 	}
@@ -373,19 +400,26 @@ func (r *distributedDKGRunner) collectRound2(
 			if _, have := bySender[msg.Sender]; have {
 				continue
 			}
-			var pkg NativeFROSTDKGRound2Package
-			if err := json.Unmarshal(msg.Payload, &pkg); err != nil {
+			var sealed sealedRound2Share
+			if err := json.Unmarshal(msg.Payload, &sealed); err != nil {
 				continue
 			}
-			// The package must be addressed to us; reject a misrouted one.
-			if pkg.Identifier != r.identifier {
+			// Open the share sealed to us (only we can, via our private key). A
+			// share we cannot open - corrupt, tampered, or sealed to someone else -
+			// is skipped, not counted: the sender's slot stays empty and the round
+			// fails into the retry path if a valid one never arrives.
+			share, err := openRound2Share(&sealed, r.selfKey)
+			if err != nil {
 				continue
 			}
-			// Tag the sender: Part3 keys round-2 packages by sender while the
-			// package itself carries the recipient identifier.
-			pkg.SenderIdentifier = r.identifierByID[msg.Sender]
-			pkgCopy := pkg
-			bySender[msg.Sender] = &pkgCopy
+			// Reconstruct the round-2 package Part3 consumes: addressed to us (our
+			// identifier) and tagged with its authenticated sender (Part3 keys
+			// round-2 packages by sender while the package carries the recipient).
+			bySender[msg.Sender] = &NativeFROSTDKGRound2Package{
+				Identifier:       r.identifier,
+				SenderIdentifier: r.identifierByID[msg.Sender],
+				Data:             share,
+			}
 		}
 	}
 	return sortedRound2Packages(r.memberIndexes, r.member, bySender), nil

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -72,6 +72,13 @@ const (
 // round-1 or round-2 package; the bus treats it as opaque.
 type dkgMessage struct {
 	Type dkgMessageType
+	// Session binds a message to ONE DKG attempt. Retries for the same wallet seed
+	// share a broadcast channel, so without this discriminator a stale round-1 or
+	// round-2 message from a failed prior attempt (from a retained member) would
+	// pass the sender/recipient checks, fill that sender's slot in the retry, and
+	// mix packages across attempts in Part2/Part3. Collectors accept only messages
+	// carrying the current attempt's session.
+	Session string
 	// Sender is the authenticated originating member (the transport binds it;
 	// the orchestrator never trusts an id inside Payload for routing).
 	Sender group.MemberIndex
@@ -104,6 +111,7 @@ type dkgBusSubscriber struct {
 // per-recipient round-2 packages cross the bus.
 type distributedDKGRunner struct {
 	member        group.MemberIndex
+	session       string
 	identifier    string
 	memberIndexes []group.MemberIndex
 	// memberSet is the DKG participant set as a lookup. A round message from an
@@ -129,6 +137,7 @@ type distributedDKGRunner struct {
 
 func newDistributedDKGRunner(
 	member group.MemberIndex,
+	session string,
 	memberIndexes []group.MemberIndex,
 	identifierByID map[group.MemberIndex]string,
 	threshold uint16,
@@ -144,6 +153,8 @@ func newDistributedDKGRunner(
 		return nil, fmt.Errorf("distributed dkg: bus is nil")
 	case selfKey == nil:
 		return nil, fmt.Errorf("distributed dkg: self key is nil")
+	case session == "":
+		return nil, fmt.Errorf("distributed dkg: session is empty")
 	case threshold == 0:
 		return nil, fmt.Errorf("distributed dkg: threshold is zero")
 	case int(threshold) > len(memberIndexes):
@@ -189,6 +200,7 @@ func newDistributedDKGRunner(
 	}
 	return &distributedDKGRunner{
 		member:         member,
+		session:        session,
 		identifier:     identifier,
 		memberIndexes:  memberIndexes,
 		memberSet:      memberSet,
@@ -315,6 +327,7 @@ func (r *distributedDKGRunner) broadcastPackage(
 	}
 	r.bus.Broadcast(dkgMessage{
 		Type:      msgType,
+		Session:   r.session,
 		Sender:    r.member,
 		Recipient: recipient,
 		Payload:   payload,
@@ -339,6 +352,9 @@ func (r *distributedDKGRunner) collectRound1(
 				len(bySender), want, ctx.Err(),
 			)
 		case msg := <-r.sub.round1:
+			if msg.Session != r.session {
+				continue // a stale message from a different DKG attempt
+			}
 			if msg.Sender == r.member {
 				continue // never our own echo
 			}
@@ -391,6 +407,9 @@ func (r *distributedDKGRunner) collectRound2(
 				len(bySender), want, ctx.Err(),
 			)
 		case msg := <-r.sub.round2:
+			if msg.Session != r.session {
+				continue // a stale message from a different DKG attempt
+			}
 			if msg.Sender == r.member || msg.Recipient != r.member {
 				continue // not addressed to us (or our own echo)
 			}

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -119,13 +119,18 @@ type DKGBus interface {
 	// dropped, and the transport may have already marked it seen and never
 	// retransmit it, stalling the DKG.
 	Start()
-	// Replay feeds messages captured by a DKGMessagePrebuffer - which starts intaking
-	// BEFORE the cross-node readiness barrier - through the receive path, so a peer's
-	// round-1 broadcast that arrived before this node installed its receiver (the
+	// Replay feeds a batch of messages captured by a DKGMessagePrebuffer - which starts
+	// intaking BEFORE the cross-node readiness barrier - through the receive path, so a
+	// peer's round-1 broadcast that arrived before this node installed its receiver (the
 	// window between the barrier releasing peers and Start) is not lost. Call after
 	// Start and after every seat has Subscribed; messages are deduplicated by content,
 	// so any that also arrived live are ignored.
 	Replay(messages []net.Message)
+	// Deliver feeds ONE message through the receive path. It is the sink a
+	// DKGMessagePrebuffer forwards to at handoff (DrainAndForward), so a message the
+	// prebuffer captures around the drain instant is delivered live rather than dropped.
+	// Deduplicated by content, like Replay.
+	Deliver(message net.Message)
 }
 
 // dkgBusSubscriber exposes one member's typed round streams. member is the seat
@@ -593,6 +598,9 @@ func (b *inProcessDKGBus) Start() {}
 // Replay is a no-op: the in-process bus has no real transport and no readiness
 // barrier, so there is no pre-barrier window to rescue messages from.
 func (b *inProcessDKGBus) Replay(_ []net.Message) {}
+
+// Deliver is a no-op for the same reason: no prebuffer forwards to the in-process bus.
+func (b *inProcessDKGBus) Deliver(_ net.Message) {}
 
 func (b *inProcessDKGBus) Broadcast(msg dkgMessage) {
 	b.mu.Lock()

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native.go
@@ -99,15 +99,22 @@ type dkgMessage struct {
 // drives the orchestrator's deterministic tests; production wraps the wallet
 // broadcast channel (with round-2 encrypted to the recipient).
 type DKGBus interface {
-	// Broadcast delivers msg to every subscriber. A round-2 message is addressed
-	// (Recipient set); subscribers keep only the ones addressed to them.
+	// Broadcast delivers a round-1 message to every subscriber and a round-2
+	// message only to the subscriber for its addressed recipient.
 	Broadcast(msg dkgMessage)
-	// Subscribe registers a receiver up front (before any Broadcast).
-	Subscribe() *dkgBusSubscriber
+	// Subscribe registers a receiver for the given seat up front (before any
+	// Broadcast); round-2 messages addressed to that seat are routed to it.
+	Subscribe(member group.MemberIndex) *dkgBusSubscriber
 }
 
-// dkgBusSubscriber exposes one member's typed round streams.
+// dkgBusSubscriber exposes one member's typed round streams. member is the seat
+// this subscriber belongs to: round-1 messages are broadcast to every
+// subscriber, but a round-2 message - which is ADDRESSED to one recipient - is
+// delivered only to the matching subscriber, so a subscriber's round-2 stream
+// holds O(n) messages (the ones addressed to it) rather than the O(n^2) whole-
+// group fan-out (~9900 for a 100-seat group), which would overflow the buffer.
 type dkgBusSubscriber struct {
+	member group.MemberIndex
 	round1 chan dkgMessage
 	round2 chan dkgMessage
 
@@ -145,8 +152,10 @@ type distributedDKGRunner struct {
 	// read only by the later round-2 send, both on the single Run goroutine.
 	recipientKeys map[group.MemberIndex]*ephemeral.PublicKey
 	// selfKey is this node's operator private key, used to OPEN the round-2 shares
-	// sealed to us; selfPublicKey is its marshaled operator public key, stamped on
-	// our own broadcasts so peers learn the key to seal our share to.
+	// sealed to us. selfPublicKey is its marshaled operator public key, stamped on
+	// our broadcasts so peers learn the key to seal our share to. Over the net bus
+	// the stamp is dropped and re-derived from the AUTHENTICATED transport key, so
+	// this trusted stamp path is used only by the in-process test bus.
 	selfKey       *ephemeral.PrivateKey
 	selfPublicKey []byte
 }
@@ -226,8 +235,9 @@ func newDistributedDKGRunner(
 		recipientKeys:  make(map[group.MemberIndex]*ephemeral.PublicKey, len(memberIndexes)),
 		selfKey:        selfKey,
 		selfPublicKey:  selfPublicKey,
-		// Subscribe at construction so no peer's round-1 broadcast is missed.
-		sub: bus.Subscribe(),
+		// Subscribe at construction so no peer's round-1 broadcast is missed;
+		// round-2 messages addressed to this seat route here.
+		sub: bus.Subscribe(member),
 	}, nil
 }
 
@@ -524,11 +534,11 @@ type inProcessDKGBus struct {
 }
 
 // NewInProcessDKGBus returns an in-process DKG bus with per-stream buffers of the
-// given size. Sends are blocking, so bufferSize MUST exceed a whole DKG's
-// per-stream message volume - up to n*(n-1) round-2 messages reach every
-// subscriber's round-2 stream - or a Broadcast can block. It is sized generously
-// for the small groups the orchestrator tests use; production runs over the net
-// broadcast channel, not this bus.
+// given size. Sends are blocking, so bufferSize MUST exceed a subscriber's honest
+// per-stream volume (round-1: one per member; round-2: one per OTHER member, as
+// round-2 is delivered only to its addressed recipient) or a Broadcast can block.
+// It is sized generously for the small groups the orchestrator tests use;
+// production runs over the net broadcast channel, not this bus.
 func NewInProcessDKGBus(bufferSize int) DKGBus {
 	if bufferSize < 1 {
 		bufferSize = 1
@@ -536,8 +546,9 @@ func NewInProcessDKGBus(bufferSize int) DKGBus {
 	return &inProcessDKGBus{bufferSize: bufferSize}
 }
 
-func (b *inProcessDKGBus) Subscribe() *dkgBusSubscriber {
+func (b *inProcessDKGBus) Subscribe(member group.MemberIndex) *dkgBusSubscriber {
 	s := &dkgBusSubscriber{
+		member: member,
 		round1: make(chan dkgMessage, b.bufferSize),
 		round2: make(chan dkgMessage, b.bufferSize),
 	}
@@ -552,6 +563,10 @@ func (b *inProcessDKGBus) Broadcast(msg dkgMessage) {
 	subscribers := append([]*dkgBusSubscriber(nil), b.subscribers...)
 	b.mu.Unlock()
 	for _, s := range subscribers {
+		// An addressed round-2 message goes only to its recipient's subscriber.
+		if msg.Type == dkgRound2Message && s.member != msg.Recipient {
+			continue
+		}
 		// Own the payload per delivery so no receiver can mutate another's view.
 		delivered := msg
 		delivered.Payload = append([]byte(nil), msg.Payload...)

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native_test.go
@@ -1,0 +1,105 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// noopDKGEngine satisfies distributedDKGEngine without touching the FFI, so the
+// bus/collection logic is testable without the linked signer lib (no cgo).
+type noopDKGEngine struct{}
+
+func (noopDKGEngine) Part1(string, uint16, uint16) (*NativeFROSTDKGPart1Result, error) {
+	return nil, nil
+}
+
+func (noopDKGEngine) Part2(
+	*NativeFROSTDKGRound1SecretPackage,
+	[]*NativeFROSTDKGRound1Package,
+) (*NativeFROSTDKGPart2Result, error) {
+	return nil, nil
+}
+
+func (noopDKGEngine) Part3(
+	*NativeFROSTDKGRound2SecretPackage,
+	[]*NativeFROSTDKGRound1Package,
+	[]*NativeFROSTDKGRound2Package,
+) (*NativeFROSTDKGResult, error) {
+	return nil, nil
+}
+
+// TestDistributedDKGRunner_CollectRound1RejectsNonParticipants guards the
+// shared-transport hazard: a message from an authenticated sender that is NOT in
+// THIS DKG's member set must not be counted toward the round's collection target.
+// If it were, it would fill a slot that a real peer's package is then dropped
+// from (sortedRound1Packages iterates only the member set), and the runner would
+// proceed to Part2/Part3 with incomplete packages. Feeding a non-member FIRST and
+// then the two real peers must still collect both real peers' packages.
+func TestDistributedDKGRunner_CollectRound1RejectsNonParticipants(t *testing.T) {
+	members := []group.MemberIndex{1, 2, 3}
+	// identifierByID is deliberately BROADER than the member set: member 4 belongs
+	// to another group sharing the transport, but has a valid, well-formed id.
+	identifierByID := map[group.MemberIndex]string{
+		1: "id-1", 2: "id-2", 3: "id-3", 4: "id-4",
+	}
+
+	bus := NewInProcessDKGBus(16)
+	runner, err := newDistributedDKGRunner(3, members, identifierByID, 2, noopDKGEngine{}, bus)
+	if err != nil {
+		t.Fatalf("new runner: %v", err)
+	}
+
+	push := func(sender group.MemberIndex) {
+		payload, err := json.Marshal(NativeFROSTDKGRound1Package{
+			Identifier: identifierByID[sender],
+			Data:       []byte{byte(sender)},
+		})
+		if err != nil {
+			t.Fatalf("marshal round1 package: %v", err)
+		}
+		runner.sub.round1 <- dkgMessage{Type: dkgRound1Message, Sender: sender, Payload: payload}
+	}
+	// The non-member arrives FIRST; without the member-set gate it would fill a
+	// slot and let collection finish before real peer 2 is read.
+	push(4)
+	push(1)
+	push(2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	got, err := runner.collectRound1(ctx, len(members)-1) // want 2 real peers
+	if err != nil {
+		t.Fatalf("collectRound1: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 real-peer round-1 packages, got %d (a non-member was counted early?)", len(got))
+	}
+	seen := map[string]bool{}
+	for _, pkg := range got {
+		seen[pkg.Identifier] = true
+	}
+	if !seen["id-1"] || !seen["id-2"] || seen["id-4"] {
+		t.Fatalf("collected the wrong peers: %v", seen)
+	}
+}
+
+// TestNewDistributedDKGRunner_RejectsDuplicateIdentifiers guards the routing map:
+// two members sharing an identifier would collapse round-2 routing, so the
+// constructor must fail closed.
+func TestNewDistributedDKGRunner_RejectsDuplicateIdentifiers(t *testing.T) {
+	members := []group.MemberIndex{1, 2, 3}
+	identifierByID := map[group.MemberIndex]string{
+		1: "id-1", 2: "dup", 3: "dup", // 2 and 3 collide
+	}
+	bus := NewInProcessDKGBus(16)
+	if _, err := newDistributedDKGRunner(1, members, identifierByID, 2, noopDKGEngine{}, bus); err == nil {
+		t.Fatal("expected a duplicate-identifier error, got nil")
+	}
+}

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
+const testDKGSession = "dkg-test-session"
+
 // noopDKGEngine satisfies distributedDKGEngine without touching the FFI, so the
 // bus/collection logic is testable without the linked signer lib (no cgo).
 type noopDKGEngine struct{}
@@ -89,7 +91,7 @@ func TestDistributedDKGRunner_CollectRound1RejectsNonParticipants(t *testing.T) 
 	pub, priv := dkgTestKeys(t, members)
 
 	bus := NewInProcessDKGBus(16)
-	runner, err := newDistributedDKGRunner(3, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
+	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
 	if err != nil {
 		t.Fatalf("new runner: %v", err)
 	}
@@ -102,7 +104,7 @@ func TestDistributedDKGRunner_CollectRound1RejectsNonParticipants(t *testing.T) 
 		if err != nil {
 			t.Fatalf("marshal round1 package: %v", err)
 		}
-		runner.sub.round1 <- dkgMessage{Type: dkgRound1Message, Sender: sender, Payload: payload}
+		runner.sub.round1 <- dkgMessage{Type: dkgRound1Message, Session: testDKGSession, Sender: sender, Payload: payload}
 	}
 	// The non-member arrives FIRST; without the member-set gate it would fill a
 	// slot and let collection finish before real peer 2 is read.
@@ -129,6 +131,39 @@ func TestDistributedDKGRunner_CollectRound1RejectsNonParticipants(t *testing.T) 
 	}
 }
 
+// TestDistributedDKGRunner_CollectRound1IgnoresOtherSessions guards the
+// retry hazard: retries for the same wallet seed share a broadcast channel, so a
+// stale round-1 message from a FAILED prior attempt (a different session) must
+// not be counted - otherwise Part2/Part3 would mix packages across attempts.
+// Real-member messages carrying the WRONG session are ignored, so collection
+// stalls to the deadline rather than accepting them.
+func TestDistributedDKGRunner_CollectRound1IgnoresOtherSessions(t *testing.T) {
+	members := []group.MemberIndex{1, 2, 3}
+	identifierByID := map[group.MemberIndex]string{1: "id-1", 2: "id-2", 3: "id-3"}
+	pub, priv := dkgTestKeys(t, members)
+	bus := NewInProcessDKGBus(16)
+	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
+	if err != nil {
+		t.Fatalf("new runner: %v", err)
+	}
+
+	// Both real peers' packages, but stamped with a DIFFERENT (prior-attempt)
+	// session. They must be ignored.
+	for _, sender := range []group.MemberIndex{1, 2} {
+		payload, err := json.Marshal(NativeFROSTDKGRound1Package{Identifier: identifierByID[sender], Data: []byte{byte(sender)}})
+		if err != nil {
+			t.Fatalf("marshal round1 package: %v", err)
+		}
+		runner.sub.round1 <- dkgMessage{Type: dkgRound1Message, Session: "prior-attempt-session", Sender: sender, Payload: payload}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if _, err := runner.collectRound1(ctx, len(members)-1); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("stale-session round-1 messages must be ignored (timeout expected); got %v", err)
+	}
+}
+
 // TestNewDistributedDKGRunner_RejectsDuplicateIdentifiers guards the routing map:
 // two members sharing an identifier would collapse round-2 routing, so the
 // constructor must fail closed.
@@ -139,21 +174,27 @@ func TestNewDistributedDKGRunner_RejectsDuplicateIdentifiers(t *testing.T) {
 	}
 	pub, priv := dkgTestKeys(t, members)
 	bus := NewInProcessDKGBus(16)
-	if _, err := newDistributedDKGRunner(1, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[1]); err == nil {
+	if _, err := newDistributedDKGRunner(1, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[1]); err == nil {
 		t.Fatal("expected a duplicate-identifier error, got nil")
 	}
 }
 
-// TestNewDistributedDKGRunner_RejectsMissingSealingKey ensures a member without a
-// sealing key fails at construction rather than stalling round 2.
-func TestNewDistributedDKGRunner_RejectsMissingSealingKey(t *testing.T) {
+// TestNewDistributedDKGRunner_FailsClosedOnMissingInputs covers the fail-closed
+// construction guards: a missing sealing key and an empty session.
+func TestNewDistributedDKGRunner_FailsClosedOnMissingInputs(t *testing.T) {
 	members := []group.MemberIndex{1, 2, 3}
 	identifierByID := map[group.MemberIndex]string{1: "id-1", 2: "id-2", 3: "id-3"}
+	bus := NewInProcessDKGBus(16)
+
 	pub, priv := dkgTestKeys(t, members)
 	delete(pub, 2) // member 2 has no sealing key
-	bus := NewInProcessDKGBus(16)
-	if _, err := newDistributedDKGRunner(1, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[1]); err == nil {
+	if _, err := newDistributedDKGRunner(1, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[1]); err == nil {
 		t.Fatal("expected a missing-sealing-key error, got nil")
+	}
+
+	fullPub, fullPriv := dkgTestKeys(t, members)
+	if _, err := newDistributedDKGRunner(1, "", members, identifierByID, 2, noopDKGEngine{}, bus, fullPub, fullPriv[1]); err == nil {
+		t.Fatal("expected an empty-session error, got nil")
 	}
 }
 
@@ -169,7 +210,7 @@ func TestDistributedDKGRunner_CollectRound2RejectsNonParticipants(t *testing.T) 
 	pub, priv := dkgTestKeys(t, members)
 	bus := NewInProcessDKGBus(16)
 	// self = 3; it collects round-2 shares addressed to it from members 1, 2.
-	runner, err := newDistributedDKGRunner(3, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
+	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
 	if err != nil {
 		t.Fatalf("new runner: %v", err)
 	}
@@ -179,6 +220,7 @@ func TestDistributedDKGRunner_CollectRound2RejectsNonParticipants(t *testing.T) 
 		payload := sealTestShare(t, []byte{byte(sender)}, pub[3])
 		runner.sub.round2 <- dkgMessage{
 			Type:      dkgRound2Message,
+			Session:   testDKGSession,
 			Sender:    sender,
 			Recipient: 3,
 			Payload:   payload,
@@ -208,6 +250,37 @@ func TestDistributedDKGRunner_CollectRound2RejectsNonParticipants(t *testing.T) 
 	}
 }
 
+// TestDistributedDKGRunner_CollectRound2SkipsUnopenableShare pins the
+// bad-share-into-retry contract: a round-2 message addressed to us but sealed to
+// a DIFFERENT key cannot be opened, so it must be skipped (not counted), leaving
+// the round to time out rather than accepting a share we cannot decrypt.
+func TestDistributedDKGRunner_CollectRound2SkipsUnopenableShare(t *testing.T) {
+	members := []group.MemberIndex{1, 2, 3}
+	identifierByID := map[group.MemberIndex]string{1: "id-1", 2: "id-2", 3: "id-3"}
+	pub, priv := dkgTestKeys(t, members)
+	bus := NewInProcessDKGBus(16)
+	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
+	if err != nil {
+		t.Fatalf("new runner: %v", err)
+	}
+
+	// A share sealed to member 1's key (NOT ours) but routed to us: we cannot open
+	// it, so it must be skipped.
+	runner.sub.round2 <- dkgMessage{
+		Type:      dkgRound2Message,
+		Session:   testDKGSession,
+		Sender:    2,
+		Recipient: 3,
+		Payload:   sealTestShare(t, []byte{2}, pub[1]),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if _, err := runner.collectRound2(ctx, 1); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("an unopenable share must be skipped (timeout expected); got %v", err)
+	}
+}
+
 // TestDistributedDKGRunner_CollectRound2TimesOutOnMissingPackage pins the
 // fail-into-retry contract: when an expected round-2 package never arrives, the
 // collection returns a deadline error (which fails the DKG into the existing
@@ -217,7 +290,7 @@ func TestDistributedDKGRunner_CollectRound2TimesOutOnMissingPackage(t *testing.T
 	identifierByID := map[group.MemberIndex]string{1: "id-1", 2: "id-2", 3: "id-3"}
 	pub, priv := dkgTestKeys(t, members)
 	bus := NewInProcessDKGBus(16)
-	runner, err := newDistributedDKGRunner(3, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
+	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
 	if err != nil {
 		t.Fatalf("new runner: %v", err)
 	}
@@ -225,6 +298,7 @@ func TestDistributedDKGRunner_CollectRound2TimesOutOnMissingPackage(t *testing.T
 	// Only ONE of the two expected round-2 shares arrives.
 	runner.sub.round2 <- dkgMessage{
 		Type:      dkgRound2Message,
+		Session:   testDKGSession,
 		Sender:    1,
 		Recipient: 3,
 		Payload:   sealTestShare(t, []byte{1}, pub[3]),

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
@@ -35,6 +36,42 @@ func (noopDKGEngine) Part3(
 	return nil, nil
 }
 
+// dkgTestKeys generates a per-member ephemeral keypair standing in for the
+// members' operator keys (both secp256k1), returning the public keys the
+// orchestrator seals round-2 shares to and the private keys it opens them with.
+func dkgTestKeys(t *testing.T, members []group.MemberIndex) (
+	map[group.MemberIndex]*ephemeral.PublicKey,
+	map[group.MemberIndex]*ephemeral.PrivateKey,
+) {
+	t.Helper()
+	pub := make(map[group.MemberIndex]*ephemeral.PublicKey, len(members))
+	priv := make(map[group.MemberIndex]*ephemeral.PrivateKey, len(members))
+	for _, m := range members {
+		kp, err := ephemeral.GenerateKeyPair()
+		if err != nil {
+			t.Fatalf("key for member %d: %v", m, err)
+		}
+		pub[m] = kp.PublicKey
+		priv[m] = kp.PrivateKey
+	}
+	return pub, priv
+}
+
+// sealTestShare produces the sealed round-2 payload the orchestrator broadcasts,
+// so collection tests exercise the real open path.
+func sealTestShare(t *testing.T, share []byte, recipient *ephemeral.PublicKey) []byte {
+	t.Helper()
+	sealed, err := sealRound2Share(share, recipient)
+	if err != nil {
+		t.Fatalf("seal test share: %v", err)
+	}
+	payload, err := json.Marshal(sealed)
+	if err != nil {
+		t.Fatalf("marshal sealed share: %v", err)
+	}
+	return payload
+}
+
 // TestDistributedDKGRunner_CollectRound1RejectsNonParticipants guards the
 // shared-transport hazard: a message from an authenticated sender that is NOT in
 // THIS DKG's member set must not be counted toward the round's collection target.
@@ -49,9 +86,10 @@ func TestDistributedDKGRunner_CollectRound1RejectsNonParticipants(t *testing.T) 
 	identifierByID := map[group.MemberIndex]string{
 		1: "id-1", 2: "id-2", 3: "id-3", 4: "id-4",
 	}
+	pub, priv := dkgTestKeys(t, members)
 
 	bus := NewInProcessDKGBus(16)
-	runner, err := newDistributedDKGRunner(3, members, identifierByID, 2, noopDKGEngine{}, bus)
+	runner, err := newDistributedDKGRunner(3, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
 	if err != nil {
 		t.Fatalf("new runner: %v", err)
 	}
@@ -99,9 +137,23 @@ func TestNewDistributedDKGRunner_RejectsDuplicateIdentifiers(t *testing.T) {
 	identifierByID := map[group.MemberIndex]string{
 		1: "id-1", 2: "dup", 3: "dup", // 2 and 3 collide
 	}
+	pub, priv := dkgTestKeys(t, members)
 	bus := NewInProcessDKGBus(16)
-	if _, err := newDistributedDKGRunner(1, members, identifierByID, 2, noopDKGEngine{}, bus); err == nil {
+	if _, err := newDistributedDKGRunner(1, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[1]); err == nil {
 		t.Fatal("expected a duplicate-identifier error, got nil")
+	}
+}
+
+// TestNewDistributedDKGRunner_RejectsMissingSealingKey ensures a member without a
+// sealing key fails at construction rather than stalling round 2.
+func TestNewDistributedDKGRunner_RejectsMissingSealingKey(t *testing.T) {
+	members := []group.MemberIndex{1, 2, 3}
+	identifierByID := map[group.MemberIndex]string{1: "id-1", 2: "id-2", 3: "id-3"}
+	pub, priv := dkgTestKeys(t, members)
+	delete(pub, 2) // member 2 has no sealing key
+	bus := NewInProcessDKGBus(16)
+	if _, err := newDistributedDKGRunner(1, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[1]); err == nil {
+		t.Fatal("expected a missing-sealing-key error, got nil")
 	}
 }
 
@@ -114,21 +166,17 @@ func TestDistributedDKGRunner_CollectRound2RejectsNonParticipants(t *testing.T) 
 	identifierByID := map[group.MemberIndex]string{
 		1: "id-1", 2: "id-2", 3: "id-3", 4: "id-4",
 	}
+	pub, priv := dkgTestKeys(t, members)
 	bus := NewInProcessDKGBus(16)
-	// self = 3; it collects round-2 packages addressed to id-3 from members 1, 2.
-	runner, err := newDistributedDKGRunner(3, members, identifierByID, 2, noopDKGEngine{}, bus)
+	// self = 3; it collects round-2 shares addressed to it from members 1, 2.
+	runner, err := newDistributedDKGRunner(3, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
 	if err != nil {
 		t.Fatalf("new runner: %v", err)
 	}
 
 	push := func(sender group.MemberIndex) {
-		payload, err := json.Marshal(NativeFROSTDKGRound2Package{
-			Identifier: identifierByID[3], // addressed to us
-			Data:       []byte{byte(sender)},
-		})
-		if err != nil {
-			t.Fatalf("marshal round2 package: %v", err)
-		}
+		// A share sealed to us (member 3); the sender labels who it claims to be.
+		payload := sealTestShare(t, []byte{byte(sender)}, pub[3])
 		runner.sub.round2 <- dkgMessage{
 			Type:      dkgRound2Message,
 			Sender:    sender,
@@ -167,18 +215,20 @@ func TestDistributedDKGRunner_CollectRound2RejectsNonParticipants(t *testing.T) 
 func TestDistributedDKGRunner_CollectRound2TimesOutOnMissingPackage(t *testing.T) {
 	members := []group.MemberIndex{1, 2, 3}
 	identifierByID := map[group.MemberIndex]string{1: "id-1", 2: "id-2", 3: "id-3"}
+	pub, priv := dkgTestKeys(t, members)
 	bus := NewInProcessDKGBus(16)
-	runner, err := newDistributedDKGRunner(3, members, identifierByID, 2, noopDKGEngine{}, bus)
+	runner, err := newDistributedDKGRunner(3, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
 	if err != nil {
 		t.Fatalf("new runner: %v", err)
 	}
 
-	// Only ONE of the two expected round-2 packages arrives.
-	payload, err := json.Marshal(NativeFROSTDKGRound2Package{Identifier: identifierByID[3], Data: []byte{1}})
-	if err != nil {
-		t.Fatalf("marshal round2 package: %v", err)
+	// Only ONE of the two expected round-2 shares arrives.
+	runner.sub.round2 <- dkgMessage{
+		Type:      dkgRound2Message,
+		Sender:    1,
+		Recipient: 3,
+		Payload:   sealTestShare(t, []byte{1}, pub[3]),
 	}
-	runner.sub.round2 <- dkgMessage{Type: dkgRound2Message, Sender: 1, Recipient: 3, Payload: payload}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native_test.go
@@ -5,6 +5,7 @@ package signing
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -101,5 +102,88 @@ func TestNewDistributedDKGRunner_RejectsDuplicateIdentifiers(t *testing.T) {
 	bus := NewInProcessDKGBus(16)
 	if _, err := newDistributedDKGRunner(1, members, identifierByID, 2, noopDKGEngine{}, bus); err == nil {
 		t.Fatal("expected a duplicate-identifier error, got nil")
+	}
+}
+
+// TestDistributedDKGRunner_CollectRound2RejectsNonParticipants is the round-2
+// analogue of the round-1 guard: a round-2 message from a non-participant that is
+// (spuriously) addressed to us must not be counted toward the round's target,
+// which would drop a real peer's incoming share and hand Part3 incomplete input.
+func TestDistributedDKGRunner_CollectRound2RejectsNonParticipants(t *testing.T) {
+	members := []group.MemberIndex{1, 2, 3}
+	identifierByID := map[group.MemberIndex]string{
+		1: "id-1", 2: "id-2", 3: "id-3", 4: "id-4",
+	}
+	bus := NewInProcessDKGBus(16)
+	// self = 3; it collects round-2 packages addressed to id-3 from members 1, 2.
+	runner, err := newDistributedDKGRunner(3, members, identifierByID, 2, noopDKGEngine{}, bus)
+	if err != nil {
+		t.Fatalf("new runner: %v", err)
+	}
+
+	push := func(sender group.MemberIndex) {
+		payload, err := json.Marshal(NativeFROSTDKGRound2Package{
+			Identifier: identifierByID[3], // addressed to us
+			Data:       []byte{byte(sender)},
+		})
+		if err != nil {
+			t.Fatalf("marshal round2 package: %v", err)
+		}
+		runner.sub.round2 <- dkgMessage{
+			Type:      dkgRound2Message,
+			Sender:    sender,
+			Recipient: 3,
+			Payload:   payload,
+		}
+	}
+	// A non-member addressed to us arrives first, then the two real peers.
+	push(4)
+	push(1)
+	push(2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	got, err := runner.collectRound2(ctx, len(members)-1) // want 2 real peers
+	if err != nil {
+		t.Fatalf("collectRound2: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 real-peer round-2 packages, got %d (a non-member was counted early?)", len(got))
+	}
+	seen := map[string]bool{}
+	for _, pkg := range got {
+		seen[pkg.SenderIdentifier] = true
+	}
+	if !seen["id-1"] || !seen["id-2"] || seen["id-4"] {
+		t.Fatalf("collected the wrong senders: %v", seen)
+	}
+}
+
+// TestDistributedDKGRunner_CollectRound2TimesOutOnMissingPackage pins the
+// fail-into-retry contract: when an expected round-2 package never arrives, the
+// collection returns a deadline error (which fails the DKG into the existing
+// retry/challenge path) rather than hanging.
+func TestDistributedDKGRunner_CollectRound2TimesOutOnMissingPackage(t *testing.T) {
+	members := []group.MemberIndex{1, 2, 3}
+	identifierByID := map[group.MemberIndex]string{1: "id-1", 2: "id-2", 3: "id-3"}
+	bus := NewInProcessDKGBus(16)
+	runner, err := newDistributedDKGRunner(3, members, identifierByID, 2, noopDKGEngine{}, bus)
+	if err != nil {
+		t.Fatalf("new runner: %v", err)
+	}
+
+	// Only ONE of the two expected round-2 packages arrives.
+	payload, err := json.Marshal(NativeFROSTDKGRound2Package{Identifier: identifierByID[3], Data: []byte{1}})
+	if err != nil {
+		t.Fatalf("marshal round2 package: %v", err)
+	}
+	runner.sub.round2 <- dkgMessage{Type: dkgRound2Message, Sender: 1, Recipient: 3, Payload: payload}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	if _, err := runner.collectRound2(ctx, len(members)-1); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want a deadline-exceeded error when a round-2 package never arrives; got %v", err)
 	}
 }

--- a/pkg/frost/signing/distributed_dkg_runner_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_runner_frost_native_test.go
@@ -39,30 +39,35 @@ func (noopDKGEngine) Part3(
 }
 
 // dkgTestKeys generates a per-member ephemeral keypair standing in for the
-// members' operator keys (both secp256k1), returning the public keys the
-// orchestrator seals round-2 shares to and the private keys it opens them with.
+// members' operator keys (both secp256k1): the private keys open round-2 shares,
+// the marshaled public keys are the "operator public keys" peers learn from
+// round-1 messages and seal round-2 shares to.
 func dkgTestKeys(t *testing.T, members []group.MemberIndex) (
-	map[group.MemberIndex]*ephemeral.PublicKey,
 	map[group.MemberIndex]*ephemeral.PrivateKey,
+	map[group.MemberIndex][]byte,
 ) {
 	t.Helper()
-	pub := make(map[group.MemberIndex]*ephemeral.PublicKey, len(members))
 	priv := make(map[group.MemberIndex]*ephemeral.PrivateKey, len(members))
+	pub := make(map[group.MemberIndex][]byte, len(members))
 	for _, m := range members {
 		kp, err := ephemeral.GenerateKeyPair()
 		if err != nil {
 			t.Fatalf("key for member %d: %v", m, err)
 		}
-		pub[m] = kp.PublicKey
 		priv[m] = kp.PrivateKey
+		pub[m] = kp.PublicKey.Marshal()
 	}
-	return pub, priv
+	return priv, pub
 }
 
-// sealTestShare produces the sealed round-2 payload the orchestrator broadcasts,
-// so collection tests exercise the real open path.
-func sealTestShare(t *testing.T, share []byte, recipient *ephemeral.PublicKey) []byte {
+// sealTestShareToKey seals a round-2 share for a marshaled recipient key, as the
+// orchestrator does before broadcasting.
+func sealTestShareToKey(t *testing.T, share []byte, recipientMarshaled []byte) []byte {
 	t.Helper()
+	recipient, err := ephemeral.UnmarshalPublicKey(recipientMarshaled)
+	if err != nil {
+		t.Fatalf("parse recipient key: %v", err)
+	}
 	sealed, err := sealRound2Share(share, recipient)
 	if err != nil {
 		t.Fatalf("seal test share: %v", err)
@@ -77,21 +82,18 @@ func sealTestShare(t *testing.T, share []byte, recipient *ephemeral.PublicKey) [
 // TestDistributedDKGRunner_CollectRound1RejectsNonParticipants guards the
 // shared-transport hazard: a message from an authenticated sender that is NOT in
 // THIS DKG's member set must not be counted toward the round's collection target.
-// If it were, it would fill a slot that a real peer's package is then dropped
-// from (sortedRound1Packages iterates only the member set), and the runner would
-// proceed to Part2/Part3 with incomplete packages. Feeding a non-member FIRST and
-// then the two real peers must still collect both real peers' packages.
+// Feeding a non-member FIRST and then the two real peers must still collect both
+// real peers' packages.
 func TestDistributedDKGRunner_CollectRound1RejectsNonParticipants(t *testing.T) {
 	members := []group.MemberIndex{1, 2, 3}
-	// identifierByID is deliberately BROADER than the member set: member 4 belongs
-	// to another group sharing the transport, but has a valid, well-formed id.
 	identifierByID := map[group.MemberIndex]string{
 		1: "id-1", 2: "id-2", 3: "id-3", 4: "id-4",
 	}
-	pub, priv := dkgTestKeys(t, members)
+	// Keys for all senders that appear (including non-member 4).
+	priv, pub := dkgTestKeys(t, []group.MemberIndex{1, 2, 3, 4})
 
 	bus := NewInProcessDKGBus(16)
-	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
+	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, priv[3], pub[3])
 	if err != nil {
 		t.Fatalf("new runner: %v", err)
 	}
@@ -104,11 +106,11 @@ func TestDistributedDKGRunner_CollectRound1RejectsNonParticipants(t *testing.T) 
 		if err != nil {
 			t.Fatalf("marshal round1 package: %v", err)
 		}
-		runner.sub.round1 <- dkgMessage{Type: dkgRound1Message, Session: testDKGSession, Sender: sender, Payload: payload}
+		runner.sub.round1 <- dkgMessage{
+			Type: dkgRound1Message, Session: testDKGSession, Sender: sender, SenderPublicKey: pub[sender], Payload: payload,
+		}
 	}
-	// The non-member arrives FIRST; without the member-set gate it would fill a
-	// slot and let collection finish before real peer 2 is read.
-	push(4)
+	push(4) // non-member first
 	push(1)
 	push(2)
 
@@ -129,32 +131,34 @@ func TestDistributedDKGRunner_CollectRound1RejectsNonParticipants(t *testing.T) 
 	if !seen["id-1"] || !seen["id-2"] || seen["id-4"] {
 		t.Fatalf("collected the wrong peers: %v", seen)
 	}
+	// The real peers' sealing keys must have been learned from their round-1 keys.
+	if runner.recipientKeys[1] == nil || runner.recipientKeys[2] == nil {
+		t.Fatalf("expected round-2 sealing keys learned for members 1 and 2")
+	}
 }
 
-// TestDistributedDKGRunner_CollectRound1IgnoresOtherSessions guards the
-// retry hazard: retries for the same wallet seed share a broadcast channel, so a
-// stale round-1 message from a FAILED prior attempt (a different session) must
-// not be counted - otherwise Part2/Part3 would mix packages across attempts.
-// Real-member messages carrying the WRONG session are ignored, so collection
-// stalls to the deadline rather than accepting them.
+// TestDistributedDKGRunner_CollectRound1IgnoresOtherSessions guards the retry
+// hazard: a stale round-1 message from a FAILED prior attempt (a different
+// session) sharing the channel must not be counted, so Part2/Part3 never mix
+// packages across attempts. Wrong-session messages are ignored -> timeout.
 func TestDistributedDKGRunner_CollectRound1IgnoresOtherSessions(t *testing.T) {
 	members := []group.MemberIndex{1, 2, 3}
 	identifierByID := map[group.MemberIndex]string{1: "id-1", 2: "id-2", 3: "id-3"}
-	pub, priv := dkgTestKeys(t, members)
+	priv, pub := dkgTestKeys(t, members)
 	bus := NewInProcessDKGBus(16)
-	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
+	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, priv[3], pub[3])
 	if err != nil {
 		t.Fatalf("new runner: %v", err)
 	}
 
-	// Both real peers' packages, but stamped with a DIFFERENT (prior-attempt)
-	// session. They must be ignored.
 	for _, sender := range []group.MemberIndex{1, 2} {
 		payload, err := json.Marshal(NativeFROSTDKGRound1Package{Identifier: identifierByID[sender], Data: []byte{byte(sender)}})
 		if err != nil {
 			t.Fatalf("marshal round1 package: %v", err)
 		}
-		runner.sub.round1 <- dkgMessage{Type: dkgRound1Message, Session: "prior-attempt-session", Sender: sender, Payload: payload}
+		runner.sub.round1 <- dkgMessage{
+			Type: dkgRound1Message, Session: "prior-attempt-session", Sender: sender, SenderPublicKey: pub[sender], Payload: payload,
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
@@ -164,70 +168,81 @@ func TestDistributedDKGRunner_CollectRound1IgnoresOtherSessions(t *testing.T) {
 	}
 }
 
-// TestNewDistributedDKGRunner_RejectsDuplicateIdentifiers guards the routing map:
-// two members sharing an identifier would collapse round-2 routing, so the
-// constructor must fail closed.
+// TestDistributedDKGRunner_CollectRound1SkipsUnparseableKey ensures a round-1
+// sender whose operator key cannot be parsed is skipped (we could not seal a
+// round-2 share to it), so it does not fill a slot.
+func TestDistributedDKGRunner_CollectRound1SkipsUnparseableKey(t *testing.T) {
+	members := []group.MemberIndex{1, 2, 3}
+	identifierByID := map[group.MemberIndex]string{1: "id-1", 2: "id-2", 3: "id-3"}
+	priv, pub := dkgTestKeys(t, members)
+	bus := NewInProcessDKGBus(16)
+	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, priv[3], pub[3])
+	if err != nil {
+		t.Fatalf("new runner: %v", err)
+	}
+
+	payload, _ := json.Marshal(NativeFROSTDKGRound1Package{Identifier: identifierByID[1], Data: []byte{1}})
+	// Member 1 with a garbage operator key; member 2 with a good one.
+	runner.sub.round1 <- dkgMessage{Type: dkgRound1Message, Session: testDKGSession, Sender: 1, SenderPublicKey: []byte{0x00, 0x01}, Payload: payload}
+	payload2, _ := json.Marshal(NativeFROSTDKGRound1Package{Identifier: identifierByID[2], Data: []byte{2}})
+	runner.sub.round1 <- dkgMessage{Type: dkgRound1Message, Session: testDKGSession, Sender: 2, SenderPublicKey: pub[2], Payload: payload2}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if _, err := runner.collectRound1(ctx, len(members)-1); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("a round-1 sender with an unparseable key must be skipped (timeout expected); got %v", err)
+	}
+}
+
+// TestNewDistributedDKGRunner_RejectsDuplicateIdentifiers guards the routing map.
 func TestNewDistributedDKGRunner_RejectsDuplicateIdentifiers(t *testing.T) {
 	members := []group.MemberIndex{1, 2, 3}
-	identifierByID := map[group.MemberIndex]string{
-		1: "id-1", 2: "dup", 3: "dup", // 2 and 3 collide
-	}
-	pub, priv := dkgTestKeys(t, members)
+	identifierByID := map[group.MemberIndex]string{1: "id-1", 2: "dup", 3: "dup"}
+	priv, pub := dkgTestKeys(t, members)
 	bus := NewInProcessDKGBus(16)
-	if _, err := newDistributedDKGRunner(1, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[1]); err == nil {
+	if _, err := newDistributedDKGRunner(1, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, priv[1], pub[1]); err == nil {
 		t.Fatal("expected a duplicate-identifier error, got nil")
 	}
 }
 
 // TestNewDistributedDKGRunner_FailsClosedOnMissingInputs covers the fail-closed
-// construction guards: a missing sealing key and an empty session.
+// construction guards: an empty self public key and an empty session.
 func TestNewDistributedDKGRunner_FailsClosedOnMissingInputs(t *testing.T) {
 	members := []group.MemberIndex{1, 2, 3}
 	identifierByID := map[group.MemberIndex]string{1: "id-1", 2: "id-2", 3: "id-3"}
 	bus := NewInProcessDKGBus(16)
+	priv, pub := dkgTestKeys(t, members)
 
-	pub, priv := dkgTestKeys(t, members)
-	delete(pub, 2) // member 2 has no sealing key
-	if _, err := newDistributedDKGRunner(1, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[1]); err == nil {
-		t.Fatal("expected a missing-sealing-key error, got nil")
+	if _, err := newDistributedDKGRunner(1, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, priv[1], nil); err == nil {
+		t.Fatal("expected an empty self-public-key error, got nil")
 	}
-
-	fullPub, fullPriv := dkgTestKeys(t, members)
-	if _, err := newDistributedDKGRunner(1, "", members, identifierByID, 2, noopDKGEngine{}, bus, fullPub, fullPriv[1]); err == nil {
+	if _, err := newDistributedDKGRunner(1, "", members, identifierByID, 2, noopDKGEngine{}, bus, priv[1], pub[1]); err == nil {
 		t.Fatal("expected an empty-session error, got nil")
 	}
 }
 
 // TestDistributedDKGRunner_CollectRound2RejectsNonParticipants is the round-2
-// analogue of the round-1 guard: a round-2 message from a non-participant that is
-// (spuriously) addressed to us must not be counted toward the round's target,
-// which would drop a real peer's incoming share and hand Part3 incomplete input.
+// analogue of the round-1 guard.
 func TestDistributedDKGRunner_CollectRound2RejectsNonParticipants(t *testing.T) {
 	members := []group.MemberIndex{1, 2, 3}
 	identifierByID := map[group.MemberIndex]string{
 		1: "id-1", 2: "id-2", 3: "id-3", 4: "id-4",
 	}
-	pub, priv := dkgTestKeys(t, members)
+	priv, pub := dkgTestKeys(t, []group.MemberIndex{1, 2, 3, 4})
 	bus := NewInProcessDKGBus(16)
 	// self = 3; it collects round-2 shares addressed to it from members 1, 2.
-	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
+	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, priv[3], pub[3])
 	if err != nil {
 		t.Fatalf("new runner: %v", err)
 	}
 
 	push := func(sender group.MemberIndex) {
-		// A share sealed to us (member 3); the sender labels who it claims to be.
-		payload := sealTestShare(t, []byte{byte(sender)}, pub[3])
+		payload := sealTestShareToKey(t, []byte{byte(sender)}, pub[3]) // sealed to us
 		runner.sub.round2 <- dkgMessage{
-			Type:      dkgRound2Message,
-			Session:   testDKGSession,
-			Sender:    sender,
-			Recipient: 3,
-			Payload:   payload,
+			Type: dkgRound2Message, Session: testDKGSession, Sender: sender, Recipient: 3, Payload: payload,
 		}
 	}
-	// A non-member addressed to us arrives first, then the two real peers.
-	push(4)
+	push(4) // non-member addressed to us first
 	push(1)
 	push(2)
 
@@ -252,26 +267,20 @@ func TestDistributedDKGRunner_CollectRound2RejectsNonParticipants(t *testing.T) 
 
 // TestDistributedDKGRunner_CollectRound2SkipsUnopenableShare pins the
 // bad-share-into-retry contract: a round-2 message addressed to us but sealed to
-// a DIFFERENT key cannot be opened, so it must be skipped (not counted), leaving
-// the round to time out rather than accepting a share we cannot decrypt.
+// a DIFFERENT key cannot be opened, so it is skipped (timeout), not accepted.
 func TestDistributedDKGRunner_CollectRound2SkipsUnopenableShare(t *testing.T) {
 	members := []group.MemberIndex{1, 2, 3}
 	identifierByID := map[group.MemberIndex]string{1: "id-1", 2: "id-2", 3: "id-3"}
-	pub, priv := dkgTestKeys(t, members)
+	priv, pub := dkgTestKeys(t, members)
 	bus := NewInProcessDKGBus(16)
-	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
+	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, priv[3], pub[3])
 	if err != nil {
 		t.Fatalf("new runner: %v", err)
 	}
 
-	// A share sealed to member 1's key (NOT ours) but routed to us: we cannot open
-	// it, so it must be skipped.
+	// Sealed to member 1's key (NOT ours) but routed to us: we cannot open it.
 	runner.sub.round2 <- dkgMessage{
-		Type:      dkgRound2Message,
-		Session:   testDKGSession,
-		Sender:    2,
-		Recipient: 3,
-		Payload:   sealTestShare(t, []byte{2}, pub[1]),
+		Type: dkgRound2Message, Session: testDKGSession, Sender: 2, Recipient: 3, Payload: sealTestShareToKey(t, []byte{2}, pub[1]),
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
@@ -282,31 +291,24 @@ func TestDistributedDKGRunner_CollectRound2SkipsUnopenableShare(t *testing.T) {
 }
 
 // TestDistributedDKGRunner_CollectRound2TimesOutOnMissingPackage pins the
-// fail-into-retry contract: when an expected round-2 package never arrives, the
-// collection returns a deadline error (which fails the DKG into the existing
-// retry/challenge path) rather than hanging.
+// fail-into-retry contract for a missing round-2 package.
 func TestDistributedDKGRunner_CollectRound2TimesOutOnMissingPackage(t *testing.T) {
 	members := []group.MemberIndex{1, 2, 3}
 	identifierByID := map[group.MemberIndex]string{1: "id-1", 2: "id-2", 3: "id-3"}
-	pub, priv := dkgTestKeys(t, members)
+	priv, pub := dkgTestKeys(t, members)
 	bus := NewInProcessDKGBus(16)
-	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, pub, priv[3])
+	runner, err := newDistributedDKGRunner(3, testDKGSession, members, identifierByID, 2, noopDKGEngine{}, bus, priv[3], pub[3])
 	if err != nil {
 		t.Fatalf("new runner: %v", err)
 	}
 
 	// Only ONE of the two expected round-2 shares arrives.
 	runner.sub.round2 <- dkgMessage{
-		Type:      dkgRound2Message,
-		Session:   testDKGSession,
-		Sender:    1,
-		Recipient: 3,
-		Payload:   sealTestShare(t, []byte{1}, pub[3]),
+		Type: dkgRound2Message, Session: testDKGSession, Sender: 1, Recipient: 3, Payload: sealTestShareToKey(t, []byte{1}, pub[3]),
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
-
 	if _, err := runner.collectRound2(ctx, len(members)-1); !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("want a deadline-exceeded error when a round-2 package never arrives; got %v", err)
 	}

--- a/pkg/frost/signing/distributed_dkg_runner_real_cgo_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_runner_real_cgo_frost_native_test.go
@@ -54,11 +54,16 @@ func TestDistributedDKGRunner_ThreeSeatsAgreeOnGroupKeyWithDistinctShares(t *tes
 
 	bus := NewInProcessDKGBus(64)
 
+	// Per-member keys standing in for operator keys: round-2 shares are SEALED to
+	// the recipient's key and opened with the recipient's own, so this exercises
+	// the encrypted round-2 path end to end.
+	pub, priv := dkgTestKeys(t, members)
+
 	// Build every runner (each subscribes to the bus) BEFORE starting any, so no
 	// peer's round-1 broadcast is missed.
 	runners := make(map[group.MemberIndex]*distributedDKGRunner, n)
 	for _, m := range members {
-		runner, err := newDistributedDKGRunner(m, members, identifiers, threshold, engine, bus)
+		runner, err := newDistributedDKGRunner(m, members, identifiers, threshold, engine, bus, pub, priv[m])
 		if err != nil {
 			t.Fatalf("new runner (member %d): %v", m, err)
 		}

--- a/pkg/frost/signing/distributed_dkg_runner_real_cgo_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_runner_real_cgo_frost_native_test.go
@@ -54,16 +54,16 @@ func TestDistributedDKGRunner_ThreeSeatsAgreeOnGroupKeyWithDistinctShares(t *tes
 
 	bus := NewInProcessDKGBus(64)
 
-	// Per-member keys standing in for operator keys: round-2 shares are SEALED to
-	// the recipient's key and opened with the recipient's own, so this exercises
-	// the encrypted round-2 path end to end.
-	pub, priv := dkgTestKeys(t, members)
+	// Per-member keys standing in for operator keys: each seat stamps its public
+	// key on round 1, peers LEARN it, and round-2 shares are sealed to it and
+	// opened with the seat's own private key - the full encrypted round-2 path.
+	priv, pub := dkgTestKeys(t, members)
 
 	// Build every runner (each subscribes to the bus) BEFORE starting any, so no
 	// peer's round-1 broadcast is missed.
 	runners := make(map[group.MemberIndex]*distributedDKGRunner, n)
 	for _, m := range members {
-		runner, err := newDistributedDKGRunner(m, testDKGSession, members, identifiers, threshold, engine, bus, pub, priv[m])
+		runner, err := newDistributedDKGRunner(m, testDKGSession, members, identifiers, threshold, engine, bus, priv[m], pub[m])
 		if err != nil {
 			t.Fatalf("new runner (member %d): %v", m, err)
 		}

--- a/pkg/frost/signing/distributed_dkg_runner_real_cgo_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_runner_real_cgo_frost_native_test.go
@@ -1,0 +1,203 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package signing
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// This test proves the FIRST increment of the distributed-DKG wiring
+// (distributed_dkg_runner_frost_native.go): a per-member, BUS-DRIVEN orchestrator
+// drives the real three-round FROST DKG so that n nodes, each contributing their
+// own secret entropy and exchanging only round packages over a message bus, end
+// up agreeing on ONE group key while each holds a DISTINCT secret share that no
+// node ever saw in full. This is the shape the tBTC node needs to replace the
+// transitional trusted-dealer keygen (RunDKGWithSeed), which the Rust signer
+// hard-disables in production ("production requires distributed DKG wiring").
+//
+// It is the message-passing analogue of the inline single-goroutine DKG in
+// native_frost_engine_..._test.go: the crypto (Part1/Part2/Part3) is identical,
+// but here each seat is an independent goroutine that only learns its peers'
+// contributions through the bus - so a passing run exercises the ORCHESTRATION
+// (round-1 broadcast, round-2 per-recipient routing, round collection), not just
+// the engine. Part3 cryptographically verifies each round-2 package against its
+// sender's round-1 commitment, so a misrouted or dropped package fails the run;
+// a passing run therefore proves the routing is correct. The final threshold
+// signature, verified against the group key, proves the shares are a real,
+// functional t-of-n key rather than unrelated per-node material.
+
+func TestDistributedDKGRunner_ThreeSeatsAgreeOnGroupKeyWithDistinctShares(t *testing.T) {
+	setupRealCgoSignerState(t)
+
+	const n = 3
+	const threshold uint16 = 2
+	members := []group.MemberIndex{1, 2, 3}
+
+	engine := &buildTaggedTBTCSignerEngine{}
+
+	// Deterministic per-member FROST identifiers (byte-0 = member index), matching
+	// the scheme the engine's DKG tests use. Production supplies identifiers
+	// aligned with the signing path; the orchestrator takes them as input.
+	identifiers := make(map[group.MemberIndex]string, n)
+	for _, m := range members {
+		identifiers[m] = buildTaggedTBTCSignerTestIdentifier(byte(m))
+	}
+
+	bus := NewInProcessDKGBus(64)
+
+	// Build every runner (each subscribes to the bus) BEFORE starting any, so no
+	// peer's round-1 broadcast is missed.
+	runners := make(map[group.MemberIndex]*distributedDKGRunner, n)
+	for _, m := range members {
+		runner, err := newDistributedDKGRunner(m, members, identifiers, threshold, engine, bus)
+		if err != nil {
+			t.Fatalf("new runner (member %d): %v", m, err)
+		}
+		runners[m] = runner
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	type seatOutcome struct {
+		result *NativeFROSTDKGResult
+		err    error
+	}
+	outcomes := make(map[group.MemberIndex]*seatOutcome, n)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, m := range members {
+		m := m
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result, err := runners[m].Run(ctx)
+			mu.Lock()
+			outcomes[m] = &seatOutcome{result: result, err: err}
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	// Skip cleanly if the linked signer lib is unavailable (matches the sibling
+	// real-cgo tests); any other failure is real.
+	for _, m := range members {
+		if errors.Is(outcomes[m].err, ErrNativeCryptographyUnavailable) {
+			t.Skip("linked tbtc-signer FFI symbols unavailable")
+		}
+	}
+	for _, m := range members {
+		if outcomes[m].err != nil {
+			t.Fatalf("member %d distributed DKG failed: %v", m, outcomes[m].err)
+		}
+		if outcomes[m].result == nil || outcomes[m].result.KeyPackage == nil ||
+			outcomes[m].result.PublicKeyPackage == nil {
+			t.Fatalf("member %d produced an incomplete DKG result", m)
+		}
+	}
+
+	// ---- All seats agree on ONE group key. ----
+	groupKey := outcomes[members[0]].result.PublicKeyPackage.VerifyingKey
+	if len(groupKey) != 64 {
+		t.Fatalf("group verifying key must be a 32-byte x-only key (64 hex chars); got %d chars", len(groupKey))
+	}
+	for _, m := range members {
+		pkp := outcomes[m].result.PublicKeyPackage
+		if pkp.VerifyingKey != groupKey {
+			t.Fatalf("member %d disagreed on the group key: %s != %s", m, pkp.VerifyingKey, groupKey)
+		}
+		if len(pkp.VerifyingShares) != n {
+			t.Fatalf("member %d has %d verifying shares, want %d", m, len(pkp.VerifyingShares), n)
+		}
+	}
+
+	// ---- Each seat holds a DISTINCT secret share bound to its own identifier
+	// (no dealer broadcasting one key). Because each seat only ran Part1/2/3 with
+	// its OWN secret packages plus bus-received packages, no seat ever held the
+	// full secret - the distributed property, by construction. ----
+	for _, m := range members {
+		kp := outcomes[m].result.KeyPackage
+		if kp.Identifier != identifiers[m] {
+			t.Fatalf("member %d key package identifier = %q, want %q", m, kp.Identifier, identifiers[m])
+		}
+		if len(kp.Data) == 0 {
+			t.Fatalf("member %d has an empty key package", m)
+		}
+	}
+	for i := 0; i < len(members); i++ {
+		for j := i + 1; j < len(members); j++ {
+			a, b := members[i], members[j]
+			if bytes.Equal(outcomes[a].result.KeyPackage.Data, outcomes[b].result.KeyPackage.Data) {
+				t.Fatalf("members %d and %d hold identical key packages; shares must be distinct", a, b)
+			}
+		}
+	}
+	t.Logf("3 seats agreed on group key %s… with 3 distinct shares (bus-orchestrated distributed DKG)", groupKey[:16])
+
+	// ---- GOLD: a real t-of-n threshold signature over the DKG output verifies
+	// against the group key, proving the bus-orchestrated shares are a functional
+	// threshold key (not just distinct blobs). ----
+	signers := members[:threshold] // any t of the n
+	message := bytesOf(0x42, 32)
+
+	commitments := make([]nativeFROSTCommitment, 0, len(signers))
+	noncesBySigner := make(map[group.MemberIndex][]byte, len(signers))
+	for _, m := range signers {
+		kp := outcomes[m].result.KeyPackage
+		nonces, commitmentIdentifier, commitmentData, err := engine.GenerateNoncesAndCommitments(kp.Identifier, kp.Data)
+		if err != nil {
+			t.Fatalf("member %d nonce generation: %v", m, err)
+		}
+		commitments = append(commitments, nativeFROSTCommitment{Identifier: commitmentIdentifier, Data: commitmentData})
+		noncesBySigner[m] = nonces
+	}
+
+	signingPackage, err := engine.NewSigningPackage(message, commitments)
+	if err != nil {
+		t.Fatalf("new signing package: %v", err)
+	}
+
+	shares := make([]nativeFROSTSignatureShare, 0, len(signers))
+	for _, m := range signers {
+		kp := outcomes[m].result.KeyPackage
+		shareIdentifier, shareData, err := engine.Sign(signingPackage, noncesBySigner[m], kp.Identifier, kp.Data)
+		if err != nil {
+			t.Fatalf("member %d sign: %v", m, err)
+		}
+		shares = append(shares, nativeFROSTSignatureShare{Identifier: shareIdentifier, Data: shareData})
+	}
+
+	signatureBytes, err := engine.Aggregate(signingPackage, shares, outcomes[members[0]].result.PublicKeyPackage)
+	if err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+	if len(signatureBytes) != 64 {
+		t.Fatalf("aggregate signature length = %d, want 64", len(signatureBytes))
+	}
+
+	groupKeyBytes, err := hex.DecodeString(groupKey)
+	if err != nil {
+		t.Fatalf("decode group key: %v", err)
+	}
+	publicKey, err := schnorr.ParsePubKey(groupKeyBytes)
+	if err != nil {
+		t.Fatalf("parse group key: %v", err)
+	}
+	signature, err := schnorr.ParseSignature(signatureBytes)
+	if err != nil {
+		t.Fatalf("parse signature: %v", err)
+	}
+	if !signature.Verify(message, publicKey) {
+		t.Fatal("threshold signature does not verify under the distributed-DKG group key")
+	}
+	t.Logf("threshold signature by %d-of-%d verifies under the distributed-DKG group key", threshold, n)
+}

--- a/pkg/frost/signing/distributed_dkg_runner_real_cgo_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_runner_real_cgo_frost_native_test.go
@@ -63,7 +63,7 @@ func TestDistributedDKGRunner_ThreeSeatsAgreeOnGroupKeyWithDistinctShares(t *tes
 	// peer's round-1 broadcast is missed.
 	runners := make(map[group.MemberIndex]*distributedDKGRunner, n)
 	for _, m := range members {
-		runner, err := newDistributedDKGRunner(m, members, identifiers, threshold, engine, bus, pub, priv[m])
+		runner, err := newDistributedDKGRunner(m, testDKGSession, members, identifiers, threshold, engine, bus, pub, priv[m])
 		if err != nil {
 			t.Fatalf("new runner (member %d): %v", m, err)
 		}

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -39,6 +39,10 @@ typedef TbtcSignerResult (*tbtc_dkg_part3_fn)(
   const uint8_t* request_ptr,
   size_t request_len
 );
+typedef TbtcSignerResult (*tbtc_persist_distributed_dkg_key_package_fn)(
+  const uint8_t* request_ptr,
+  size_t request_len
+);
 typedef TbtcSignerResult (*tbtc_generate_nonces_and_commitments_fn)(
   const uint8_t* request_ptr,
   size_t request_len
@@ -179,6 +183,19 @@ static TbtcSignerResult tbtc_signer_dkg_part3(const uint8_t* request_ptr, size_t
   }
 
   return dkg_part3(request_ptr, request_len);
+}
+
+static TbtcSignerResult tbtc_signer_persist_distributed_dkg_key_package(const uint8_t* request_ptr, size_t request_len) {
+  tbtc_persist_distributed_dkg_key_package_fn persist =
+    (tbtc_persist_distributed_dkg_key_package_fn)dlsym(
+      RTLD_DEFAULT,
+      "frost_tbtc_persist_distributed_dkg_key_package"
+    );
+  if (persist == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return persist(request_ptr, request_len);
 }
 
 static TbtcSignerResult tbtc_signer_generate_nonces_and_commitments(const uint8_t* request_ptr, size_t request_len) {
@@ -468,6 +485,15 @@ type buildTaggedTBTCSignerNativeFROSTPublicKeyPackage struct {
 type buildTaggedTBTCSignerDKGPart3Response struct {
 	KeyPackage       *buildTaggedTBTCSignerNativeFROSTKeyPackage       `json:"key_package"`
 	PublicKeyPackage *buildTaggedTBTCSignerNativeFROSTPublicKeyPackage `json:"public_key_package"`
+}
+
+type buildTaggedTBTCSignerPersistDistributedDKGKeyPackageRequest struct {
+	SessionID             string                                            `json:"session_id"`
+	ParticipantIdentifier uint16                                            `json:"participant_identifier"`
+	Threshold             uint16                                            `json:"threshold"`
+	ParticipantCount      uint16                                            `json:"participant_count"`
+	KeyPackage            *buildTaggedTBTCSignerNativeFROSTKeyPackage       `json:"key_package"`
+	PublicKeyPackage      *buildTaggedTBTCSignerNativeFROSTPublicKeyPackage `json:"public_key_package"`
 }
 
 type buildTaggedTBTCSignerNativeFROSTCommitment struct {
@@ -777,6 +803,42 @@ func (bttse *buildTaggedTBTCSignerEngine) Part3(
 	defer zeroBytes(responsePayload)
 
 	return decodeBuildTaggedTBTCSignerDKGPart3Response(responsePayload)
+}
+
+// PersistDistributedDKGKeyPackage stores this node's Part3 key package plus the
+// group public key package as signing material the interactive signing path can
+// load (keyed by the returned key group). A distributed DKG - unlike the dealer
+// RunDKG - leaves each node with only its OWN secret key package, which Part3
+// returns; this persists it so the wallet can sign.
+func (bttse *buildTaggedTBTCSignerEngine) PersistDistributedDKGKeyPackage(
+	sessionID string,
+	participantIdentifier uint16,
+	threshold uint16,
+	participantCount uint16,
+	keyPackage *NativeFROSTKeyPackage,
+	publicKeyPackage *NativeFROSTPublicKeyPackage,
+) (*NativeTBTCSignerDKGResult, error) {
+	requestPayload, err := buildTaggedTBTCSignerPersistDistributedDKGKeyPackageRequestPayload(
+		sessionID,
+		participantIdentifier,
+		threshold,
+		participantCount,
+		keyPackage,
+		publicKeyPackage,
+	)
+	if err != nil {
+		return nil, err
+	}
+	// The request embeds this node's serialized key package (secret material);
+	// scrub the Go-side transport buffer on every return path, mirroring Sign/Part3.
+	defer zeroBytes(requestPayload)
+
+	responsePayload, err := callBuildTaggedTBTCSignerPersistDistributedDKGKeyPackage(requestPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeBuildTaggedTBTCSignerRunDKGResponse(responsePayload)
 }
 
 func (bttse *buildTaggedTBTCSignerEngine) GenerateNoncesAndCommitments(
@@ -1351,6 +1413,43 @@ func buildTaggedTBTCSignerDKGPart3RequestPayload(
 			SecretPackageHex: hex.EncodeToString(secretPackage.Data),
 			Round1Packages:   requestRound1Packages,
 			Round2Packages:   requestRound2Packages,
+		},
+	)
+}
+
+func buildTaggedTBTCSignerPersistDistributedDKGKeyPackageRequestPayload(
+	sessionID string,
+	participantIdentifier uint16,
+	threshold uint16,
+	participantCount uint16,
+	keyPackage *NativeFROSTKeyPackage,
+	publicKeyPackage *NativeFROSTPublicKeyPackage,
+) ([]byte, error) {
+	const op = "PersistDistributedDKGKeyPackage"
+	if keyPackage == nil {
+		return nil, buildTaggedTBTCSignerOperationError(op, "key package is nil")
+	}
+	if len(keyPackage.Data) == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(op, "key package data is empty")
+	}
+	if publicKeyPackage == nil {
+		return nil, buildTaggedTBTCSignerOperationError(op, "public key package is nil")
+	}
+	return buildTaggedTBTCSignerMarshalRequest(
+		op,
+		buildTaggedTBTCSignerPersistDistributedDKGKeyPackageRequest{
+			SessionID:             sessionID,
+			ParticipantIdentifier: participantIdentifier,
+			Threshold:             threshold,
+			ParticipantCount:      participantCount,
+			KeyPackage: &buildTaggedTBTCSignerNativeFROSTKeyPackage{
+				Identifier: keyPackage.Identifier,
+				DataHex:    hex.EncodeToString(keyPackage.Data),
+			},
+			PublicKeyPackage: &buildTaggedTBTCSignerNativeFROSTPublicKeyPackage{
+				VerifyingShares: publicKeyPackage.VerifyingShares,
+				VerifyingKey:    publicKeyPackage.VerifyingKey,
+			},
 		},
 	)
 }
@@ -2541,6 +2640,18 @@ func callBuildTaggedTBTCSignerDKGPart3(
 		requestPayload,
 		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
 			return C.tbtc_signer_dkg_part3(requestPtr, requestLen)
+		},
+	)
+}
+
+func callBuildTaggedTBTCSignerPersistDistributedDKGKeyPackage(
+	requestPayload []byte,
+) ([]byte, error) {
+	return callBuildTaggedTBTCSignerOperation(
+		"PersistDistributedDKGKeyPackage",
+		requestPayload,
+		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
+			return C.tbtc_signer_persist_distributed_dkg_key_package(requestPtr, requestLen)
 		},
 	)
 }

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -852,6 +852,11 @@ func (bttse *buildTaggedTBTCSignerEngine) GenerateNoncesAndCommitments(
 	if err != nil {
 		return nil, "", nil, err
 	}
+	// requestPayload serializes this seat's SECRET signing key package. Scrub the
+	// Go-side buffer after use (the C-heap copy is wiped in the call helper), matching
+	// Sign / Part2 / Part3 / PersistDistributedDKGKeyPackage - this was the lone
+	// secret-bearing op missing the request scrub.
+	defer zeroBytes(requestPayload)
 
 	responsePayload, err := callBuildTaggedTBTCSignerGenerateNoncesAndCommitments(
 		requestPayload,

--- a/pkg/frost/signing/native_tbtc_signer_abi_version.go
+++ b/pkg/frost/signing/native_tbtc_signer_abi_version.go
@@ -14,8 +14,12 @@ import (
 // fine and its extras are ignored). Bump these in lockstep with the Rust constants, in
 // the SAME PR that bumps ci/frost-signer-pin.env to the lib commit that provides them.
 const (
-	requiredTBTCSignerABIMajor    uint32 = 1
-	requiredTBTCSignerABIMinMinor uint32 = 0
+	requiredTBTCSignerABIMajor uint32 = 1
+	// Minor 1: this build's distributed-DKG path calls
+	// frost_tbtc_persist_distributed_dkg_key_package, added in signer ABI 1.1. A
+	// lib reporting 1.0 lacks the symbol, so require >= 1 to fail closed at the
+	// ABI preflight rather than mid-DKG at the dlsym.
+	requiredTBTCSignerABIMinMinor uint32 = 1
 )
 
 // ErrTBTCSignerABIIncompatible marks a linked libfrost_tbtc whose FFI contract version

--- a/pkg/frost/signing/native_tbtc_signer_abi_version_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_abi_version_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCheckABIContractCompatibility(t *testing.T) {
 	// req = major 1, min minor 2, to exercise every branch (the too-old-minor branch is
-	// unreachable against the real requiredTBTCSignerABIMinMinor of 0).
+	// unreachable against the real requiredTBTCSignerABIMinMinor of 1).
 	const reqMajor, reqMinMinor = uint32(1), uint32(2)
 	tests := []struct {
 		name           string

--- a/pkg/tbtc/frost_dkg_execution_frost_native.go
+++ b/pkg/tbtc/frost_dkg_execution_frost_native.go
@@ -144,7 +144,6 @@ func executeFrostDKGIfPossible(
 			nativeTBTCSignerEngine,
 			node,
 			channel,
-			membershipValidator,
 			activeMemberIndexes,
 			tbtcSignerMemberIndexes,
 			localActiveMemberIndexes,
@@ -262,7 +261,6 @@ func executeDistributedFrostDKG(
 	nativeEngine frostsigning.NativeTBTCSignerEngine,
 	node *node,
 	channel net.BroadcastChannel,
-	membershipValidator *group.MembershipValidator,
 	activeMemberIndexes []group.MemberIndex,
 	tbtcSignerMemberIndexes []group.MemberIndex,
 	localActiveMemberIndexes []group.MemberIndex,
@@ -292,7 +290,7 @@ func executeDistributedFrostDKG(
 	// compact DKG member space the runner and persist op operate in (the same
 	// mapping registerFrostSignerWithMaterial uses). finalSigningGroup sorts its
 	// operating-members argument in place, so pass a copy.
-	_, finalSigningGroupMembersIndexes, err := finalSigningGroup(
+	finalSigningGroupOperators, finalSigningGroupMembersIndexes, err := finalSigningGroup(
 		groupSelectionResult.OperatorsAddresses,
 		append([]group.MemberIndex{}, activeMemberIndexes...),
 		node.groupParameters,
@@ -309,6 +307,17 @@ func executeDistributedFrostDKG(
 		localDKGMemberIndexes = append(localDKGMemberIndexes, finalSeat)
 	}
 
+	// The runner broadcasts FINAL compact member indexes as the transport sender,
+	// so the DKG bus must authenticate them against a validator indexed by the SAME
+	// final space - not the original sortition-ordered membership (which would
+	// reject shifted seats when readiness compacts the active set, stalling the
+	// DKG). finalSigningGroupOperators[i] is the operator for final member i+1.
+	finalMembershipValidator := group.NewMembershipValidator(
+		logger,
+		finalSigningGroupOperators,
+		node.chain.Signing(),
+	)
+
 	// This node's operator key, shared by all its local seats.
 	operatorPrivateKey, _, err := node.chain.OperatorKeyPair()
 	if err != nil {
@@ -319,7 +328,7 @@ func executeDistributedFrostDKG(
 		dkgCtx,
 		logger,
 		channel,
-		membershipValidator,
+		finalMembershipValidator,
 		distributedEngine,
 		sessionID,
 		tbtcSignerMemberIndexes,

--- a/pkg/tbtc/frost_dkg_execution_frost_native.go
+++ b/pkg/tbtc/frost_dkg_execution_frost_native.go
@@ -334,12 +334,11 @@ func executeDistributedFrostDKG(
 		node.chain.Signing(),
 	)
 
-	// This node's operator key, shared by all its local seats.
-	operatorPrivateKey, _, err := node.chain.OperatorKeyPair()
-	if err != nil {
-		return nil, fmt.Errorf("cannot resolve the operator key pair: [%v]", err)
-	}
-
+	// Each seat's per-DKG round-2 sealing key is a fresh ephemeral generated inside
+	// the orchestration (not this node's operator key), so operator-key material
+	// never reaches the runner; the operator key stays bound to the channel, which
+	// authenticates every seat's round-1 broadcast (and the ephemeral key riding
+	// in it) via finalMembershipValidator.
 	persistBySeat, err := frostsigning.RunDistributedDKGForSeats(
 		dkgCtx,
 		logger,
@@ -351,7 +350,6 @@ func executeDistributedFrostDKG(
 		localDKGMemberIndexes,
 		identifierByID,
 		uint16(signatureThreshold),
-		operatorPrivateKey,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/tbtc/frost_dkg_execution_frost_native.go
+++ b/pkg/tbtc/frost_dkg_execution_frost_native.go
@@ -112,6 +112,16 @@ func executeFrostDKGIfPossible(
 		defer cancelDkgCtx()
 
 		sessionID := fmt.Sprintf("%s-%s", channelName, "attempt-1")
+
+		// Capture DKG round messages off the channel BEFORE the readiness barrier below.
+		// announceFrostDKGReadiness releases every peer once the quorum announces, but a
+		// node installs its DKG receiver only later, inside executeDistributedFrostDKG.
+		// A peer released ahead of a slower node can broadcast round-1 before that node
+		// is receiving; the transport would drop it (no subscriber) and not retransmit,
+		// stalling the DKG. The prebuffer catches those from before the barrier so they
+		// are replayed once the receiver is up.
+		dkgPrebuffer := frostsigning.StartDKGMessagePrebuffer(dkgCtx, channel)
+
 		activeMemberIndexes, misbehavedMembersIndices, err :=
 			announceFrostDKGReadiness(
 				dkgCtx,
@@ -166,6 +176,7 @@ func executeFrostDKGIfPossible(
 			groupSelectionResult,
 			signatureThreshold,
 			sessionID,
+			dkgPrebuffer,
 		)
 		if err != nil {
 			dkgLogger.Errorf("FROST DKG execution failed: [%v]", err)
@@ -283,6 +294,7 @@ func executeDistributedFrostDKG(
 	groupSelectionResult *GroupSelectionResult,
 	signatureThreshold int,
 	sessionID string,
+	prebuffer *frostsigning.DKGMessagePrebuffer,
 ) (*frostDKGExecutionResult, error) {
 	if nativeEngine == nil {
 		return nil, fmt.Errorf("native tbtc-signer engine is unavailable")
@@ -350,6 +362,7 @@ func executeDistributedFrostDKG(
 		localDKGMemberIndexes,
 		identifierByID,
 		uint16(signatureThreshold),
+		prebuffer,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/tbtc/frost_dkg_execution_frost_native.go
+++ b/pkg/tbtc/frost_dkg_execution_frost_native.go
@@ -43,6 +43,22 @@ func executeFrostDKGIfPossible(
 		return
 	}
 
+	// Distributed DKG produces signing material usable ONLY via the interactive
+	// path; with interactive signing disabled, signing would route to the coarse
+	// path, which cannot reconstruct a distributed key, and every signature would
+	// fail. Refuse to run rather than create an unsignable wallet, coupling the DKG
+	// switch to the signing switch.
+	if !frostsigning.InteractiveSigningOptInEnabled() {
+		logger.Errorf(
+			"FROST DKG with seed [0x%x] selected this operator, but the distributed "+
+				"DKG requires interactive signing (%s) to be enabled; refusing to run to "+
+				"avoid creating a wallet that cannot sign",
+			event.Seed,
+			frostsigning.InteractiveSigningOptInEnvVar,
+		)
+		return
+	}
+
 	membershipValidator := group.NewMembershipValidator(
 		logger,
 		groupSelectionResult.OperatorsAddresses,

--- a/pkg/tbtc/frost_dkg_execution_frost_native.go
+++ b/pkg/tbtc/frost_dkg_execution_frost_native.go
@@ -139,10 +139,16 @@ func executeFrostDKGIfPossible(
 			return
 		}
 
-		executionResult, err := executeFrostDKG(
+		executionResult, err := executeDistributedFrostDKG(
+			dkgCtx,
 			nativeTBTCSignerEngine,
-			event,
+			node,
+			channel,
+			membershipValidator,
+			activeMemberIndexes,
 			tbtcSignerMemberIndexes,
+			localActiveMemberIndexes,
+			groupSelectionResult,
 			signatureThreshold,
 			sessionID,
 		)
@@ -243,6 +249,130 @@ func executeFrostDKG(
 	}
 
 	return nil, fmt.Errorf("native tbtc-signer engine is unavailable")
+}
+
+// executeDistributedFrostDKG runs a real distributed FROST DKG for this node's
+// local seats over the wallet broadcast channel, persists each seat's key package
+// as signing material, and returns the shared group output key plus the signer
+// material (the same for every local seat; the differing secret key packages live
+// in the engine's per-seat session store). It replaces the transitional
+// trusted-dealer executeTBTCSignerFROSTDKG/RunDKGWithSeed.
+func executeDistributedFrostDKG(
+	dkgCtx context.Context,
+	nativeEngine frostsigning.NativeTBTCSignerEngine,
+	node *node,
+	channel net.BroadcastChannel,
+	membershipValidator *group.MembershipValidator,
+	activeMemberIndexes []group.MemberIndex,
+	tbtcSignerMemberIndexes []group.MemberIndex,
+	localActiveMemberIndexes []group.MemberIndex,
+	groupSelectionResult *GroupSelectionResult,
+	signatureThreshold int,
+	sessionID string,
+) (*frostDKGExecutionResult, error) {
+	if nativeEngine == nil {
+		return nil, fmt.Errorf("native tbtc-signer engine is unavailable")
+	}
+	distributedEngine, ok := nativeEngine.(frostsigning.NativeTBTCSignerDistributedDKGEngine)
+	if !ok {
+		return nil, fmt.Errorf("native tbtc-signer engine does not support distributed DKG")
+	}
+	if signatureThreshold <= 0 || signatureThreshold > int(^uint16(0)) {
+		return nil, fmt.Errorf("invalid tbtc-signer DKG threshold [%d]", signatureThreshold)
+	}
+
+	// Canonical FROST identifiers over the FULL participant set (the final compact
+	// DKG member space), matching what the persist op and the signing path expect.
+	identifierByID := make(map[group.MemberIndex]string, len(tbtcSignerMemberIndexes))
+	for _, memberIndex := range tbtcSignerMemberIndexes {
+		identifierByID[memberIndex] = frostsigning.CanonicalFROSTIdentifier(uint16(memberIndex))
+	}
+
+	// Remap this node's local seats from the ORIGINAL sortition space to the FINAL
+	// compact DKG member space the runner and persist op operate in (the same
+	// mapping registerFrostSignerWithMaterial uses). finalSigningGroup sorts its
+	// operating-members argument in place, so pass a copy.
+	_, finalSigningGroupMembersIndexes, err := finalSigningGroup(
+		groupSelectionResult.OperatorsAddresses,
+		append([]group.MemberIndex{}, activeMemberIndexes...),
+		node.groupParameters,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve the final signing group: [%v]", err)
+	}
+	localDKGMemberIndexes := make([]group.MemberIndex, 0, len(localActiveMemberIndexes))
+	for _, localSeat := range localActiveMemberIndexes {
+		finalSeat, ok := finalSigningGroupMembersIndexes[localSeat]
+		if !ok {
+			return nil, fmt.Errorf("local seat [%v] is missing from the final signing group", localSeat)
+		}
+		localDKGMemberIndexes = append(localDKGMemberIndexes, finalSeat)
+	}
+
+	// This node's operator key, shared by all its local seats.
+	operatorPrivateKey, _, err := node.chain.OperatorKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve the operator key pair: [%v]", err)
+	}
+
+	persistBySeat, err := frostsigning.RunDistributedDKGForSeats(
+		dkgCtx,
+		logger,
+		channel,
+		membershipValidator,
+		distributedEngine,
+		sessionID,
+		tbtcSignerMemberIndexes,
+		localDKGMemberIndexes,
+		identifierByID,
+		uint16(signatureThreshold),
+		operatorPrivateKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Every local seat shares the same group key; build the output key + material
+	// once from any persisted result.
+	var persisted *frostsigning.NativeTBTCSignerDKGResult
+	for _, seatResult := range persistBySeat {
+		persisted = seatResult
+		break
+	}
+	if persisted == nil {
+		return nil, fmt.Errorf("distributed DKG produced no persisted result")
+	}
+
+	outputKey, err := outputKeyFromTBTCSignerDKGResult(persisted)
+	if err != nil {
+		return nil, err
+	}
+
+	// A populated participant list + threshold are required for dkg-persisted
+	// signer material; there is no dealer seed for a distributed DKG.
+	participants, err := nativeTBTCSignerDKGParticipants(tbtcSignerMemberIndexes)
+	if err != nil {
+		return nil, err
+	}
+
+	payload, err := json.Marshal(frostsigning.NativeTBTCSignerMaterialPayload{
+		KeyGroup:         persisted.KeyGroup,
+		TaprootOutputKey: hex.EncodeToString(outputKey[:]),
+		KeyGroupSource:   frostsigning.NativeTBTCSignerKeyGroupSourceDKGPersisted,
+		DKGParticipants:  participants,
+		DKGThreshold:     uint16(signatureThreshold),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal tbtc-signer material: [%w]", err)
+	}
+
+	return &frostDKGExecutionResult{
+		outputKey: outputKey,
+		signerMaterial: &frostsigning.NativeSignerMaterial{
+			Format:  frostsigning.NativeSignerMaterialFormatFrostTBTCSignerV1,
+			Payload: payload,
+		},
+	}, nil
 }
 
 func finalFrostDKGMemberIndexes(


### PR DESCRIPTION
## What

Wires a real **distributed FROST DKG** into the node, replacing the transitional trusted-dealer keygen (`RunDKGWithSeed` → `generate_with_dealer`, seeded by the *public* on-chain seed) that the Rust signer hard-disables under `TBTC_SIGNER_PROFILE=production`. Each node ends with its **own secret share** of a t-of-n key that no node ever holds in full.

- **Orchestrator** (`RunDistributedDKGForSeats` / `distributedDKGRunner.Run`): drives `Part1/2/3` for every local seat — round-1 public package broadcast + collect; round-2 per-recipient sealed packages routed + collected; `Part3` → local secret share + the agreed group key. Every secret stays local; only public round-1 packages and per-recipient round-2 envelopes cross the wire.
- **Real transport + authentication**: runs over the real `pkg/net` wallet broadcast channel; every round message is membership-authenticated against the sender's operator key (in the final compact signing-group order). Peers learn each other's round-2 sealing key from the authenticated round-1 broadcast.
- **Two-sided forward secrecy**: round-2 shares are ECIES-sealed to a **fresh per-DKG ephemeral key per seat** (piggybacked on the already-authenticated round-1 broadcast — no extra round), opened with the ephemeral private key and scrubbed afterward. The operator key stays with the transport and never touches the seal. All per-seat secrets (part1/2/3 packages, round-2 shares, ephemeral keys, the persisted Part3 share) are zeroized after use.
- **Node wiring**: `executeFrostDKGIfPossible` runs the orchestrator (gated by `KEEP_CORE_FROST_INTERACTIVE_SIGNING_ENABLED`), persists each seat's key package as signing material, and feeds the existing on-chain result-agreement / inactivity-challenge flow.

## Test

- **Multi-node real-transport e2e**: `n` independent nodes, each with its own operator key, run the DKG over the real broadcast transport, agree on **one group key** with **distinct shares**, then interactive-sign a verifying **2-of-3 BIP-340 signature** — including under a **per-message session distinct from the DKG session** (the production ROAST shape).
- In-process-bus and 3-seat real-cgo orchestrator tests; net-bus authentication / dedup / wire-format tests (incl. that round-2 seals to the wire ephemeral key, not the operator key). Race-clean, stable across repeated runs.

## Status / companion

Covers the orchestrator through node wiring and cross-session signing. Remaining: multi-process e2e and deleting the dealer-DKG + deterministic-nonce scaffolds.

The Rust signer half — the persist op, wallet-keyed cross-session signing, and the policy-gate hardening — is #4136. The cgo integration gate builds `libfrost_tbtc` from a signer commit pinned in `ci/frost-signer-pin.env`, bumped in lockstep with the engine ABI. Draft until the signer half lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
