### PR TITLE
feat(frost): wire the ROAST-retry coordinator into live interactive signing

### DIFF
--- a/pkg/frost/signing/roast_interactive_signing_drive_frost_roast_retry_test.go
+++ b/pkg/frost/signing/roast_interactive_signing_drive_frost_roast_retry_test.go
@@ -98,6 +98,12 @@ func newDriveFixture(t *testing.T) driveFixture {
 	})
 	t.Cleanup(ResetRoastRetryRegistrationForTest)
 	t.Cleanup(ResetInteractiveSigningEngineProviderForTest)
+	// Every drive fixture reuses the same (roastSessionID, attemptSessionID), so it
+	// maps to one process-global aggregate-memo key. Clear it between drive tests or
+	// a prior case's memoized success leaks in and suppresses this case's own engine
+	// aggregate (e.g. an aggregateErr case would never reach its error). Real nodes
+	// mint a unique session id per attempt, so this collision is test-only.
+	t.Cleanup(ResetInteractiveAggregateMemoForTest)
 
 	// The handle is minted by the registered coordinator - exactly the handle
 	// the executor entry threads into the drive for this Execute.

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -64,6 +64,13 @@ type interactiveSigningRunner struct {
 	// sub is established at construction (before any Run broadcasts) so a node
 	// never misses a peer message broadcast before it subscribed.
 	sub *RunnerBusSubscriber
+	// aggregateOnce memoizes the interactive aggregation per (session, attempt)
+	// within the process so a multi-seat operator's local seats share one result
+	// instead of colliding on the engine's per-attempt anti-replay marker. Defaults
+	// to the process-global memo (aggregateInteractiveOnce); tests that simulate
+	// several operators in ONE process inject a pass-through so each runner
+	// aggregates against its own (separate) engine independently.
+	aggregateOnce func(key string, aggregate func() ([]byte, error)) ([]byte, error)
 }
 
 func newInteractiveSigningRunner(
@@ -125,6 +132,7 @@ func newInteractiveSigningRunner(
 		signer:          signer,
 		bus:             bus,
 		sub:             bus.Subscribe(),
+		aggregateOnce:   aggregateInteractiveOnce,
 	}, nil
 }
 
@@ -327,13 +335,25 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 	// the same signature; an observer aggregates against its own open session
 	// without having contributed a share. A share-verification failure surfaces
 	// the typed error with candidate culprits for the (separate) blame path.
-	signature, err := r.engine.InteractiveAggregate(
-		binding.SessionID(),
-		attemptID,
-		pkg.SigningPackageBytes,
-		toFrostSignatureShares(shares, frostIdentifiers),
-		binding.TaprootMerkleRoot(),
-	)
+	//
+	// A multi-seat operator runs one runner per LOCAL seat against the SHARED
+	// per-process engine session, so two local seats would both try to aggregate
+	// this attempt: the first succeeds, the second hits the engine's per-attempt
+	// anti-replay marker (InteractiveAttemptAlreadyAggregated) even though the
+	// deterministic signature already exists. Memoize per (session, attempt) so
+	// sibling local seats share one aggregation result and the coordinator seat
+	// obtains the signature regardless of which local seat computed it first. In a
+	// single-seat process this is a plain pass-through (one caller per key).
+	aggregateKey := binding.SessionID() + "|" + attemptID
+	signature, err := r.aggregateOnce(aggregateKey, func() ([]byte, error) {
+		return r.engine.InteractiveAggregate(
+			binding.SessionID(),
+			attemptID,
+			pkg.SigningPackageBytes,
+			toFrostSignatureShares(shares, frostIdentifiers),
+			binding.TaprootMerkleRoot(),
+		)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("roast runner: aggregate: %w", err)
 	}

--- a/pkg/frost/signing/roast_runner_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_frost_native_test.go
@@ -21,6 +21,16 @@ type fixedTestSigner struct{}
 
 func (fixedTestSigner) Sign(_ []byte) ([]byte, error) { return []byte{0x01}, nil }
 
+// passThroughAggregateOnce is the test injection for interactiveSigningRunner's
+// aggregateOnce. Each test runner simulates a SEPARATE operator process (its own
+// fake engine), so the process-global aggregate memo — which exists only to let a
+// multi-seat operator's local seats share one aggregation — must be bypassed so
+// each runner aggregates against its own engine. The memo's dedup behaviour is
+// covered directly by the TestAggregateInteractiveOnce_* cases.
+func passThroughAggregateOnce(_ string, aggregate func() ([]byte, error)) ([]byte, error) {
+	return aggregate()
+}
+
 type harness struct {
 	bus         RunnerBus
 	runners     []*interactiveSigningRunner
@@ -81,6 +91,12 @@ func buildInteractiveSigningHarness(t *testing.T, n int, threshold uint16) harne
 		if err != nil {
 			t.Fatalf("runner (member %d): %v", member, err)
 		}
+		// Each harness runner simulates a SEPARATE operator (its own engine); in
+		// production those would be separate processes with separate memos. Bypass
+		// the process-global aggregate memo so each runner aggregates against its
+		// own engine independently (the memo's own dedup behaviour is covered by
+		// TestAggregateInteractiveOnce_*).
+		runner.aggregateOnce = passThroughAggregateOnce
 		h.coords = append(h.coords, coord)
 		h.collectors = append(h.collectors, collector)
 		h.engines = append(h.engines, engine)
@@ -406,6 +422,10 @@ func TestInteractiveSigningRunner_AbortsNativeAttemptOnEarlyExit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runner: %v", err)
 	}
+	// See passThroughAggregateOnce: this single-runner test simulates one operator
+	// process; bypass the shared aggregate memo so it neither leaks a result to
+	// another test nor suppresses this test's own engine aggregate call.
+	runner.aggregateOnce = passThroughAggregateOnce
 
 	// No second node ever broadcasts, so Run blocks waiting for round 1 to reach
 	// the threshold (as coordinator) or for the coordinator's package (otherwise)
@@ -454,6 +474,10 @@ func TestInteractiveSigningRunner_RejectsEngineCoordinatorMismatch(t *testing.T)
 	if err != nil {
 		t.Fatalf("runner: %v", err)
 	}
+	// See passThroughAggregateOnce: this single-runner test simulates one operator
+	// process; bypass the shared aggregate memo so it neither leaks a result to
+	// another test nor suppresses this test's own engine aggregate call.
+	runner.aggregateOnce = passThroughAggregateOnce
 
 	runCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -634,6 +658,10 @@ func buildEquivocationRunner(t *testing.T, included []group.MemberIndex) (
 	if err != nil {
 		t.Fatalf("runner: %v", err)
 	}
+	// See passThroughAggregateOnce: this single-runner test simulates one operator
+	// process; bypass the shared aggregate memo so it neither leaks a result to
+	// another test nor suppresses this test's own engine aggregate call.
+	runner.aggregateOnce = passThroughAggregateOnce
 	return runner, collector, ctx.Hash(), ara.ElectedCoordinator()
 }
 
@@ -1063,6 +1091,10 @@ func TestInteractiveSigningRunner_ObserverAggregatesAndAbortsWithoutSigning(t *t
 	if err != nil {
 		t.Fatalf("runner: %v", err)
 	}
+	// See passThroughAggregateOnce: this single-runner test simulates one operator
+	// process; bypass the shared aggregate memo so it neither leaks a result to
+	// another test nor suppresses this test's own engine aggregate call.
+	runner.aggregateOnce = passThroughAggregateOnce
 
 	// Pre-inject the coordinator's signed package (signer_ids = the two signers,
 	// excluding the observer) plus both signers' shares, so the observer's await

--- a/pkg/frost/signing/roast_runner_interactive_aggregate_memo_frost_native.go
+++ b/pkg/frost/signing/roast_runner_interactive_aggregate_memo_frost_native.go
@@ -1,0 +1,86 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"sync"
+	"time"
+)
+
+// interactiveAggregateMemoTTL bounds how long a memoized aggregate result is
+// retained. It only needs to outlive the window in which a single signing
+// attempt's local seats race to aggregate (bounded by the attempt timeout, tens
+// of seconds), so a few minutes is safely conservative while keeping the memo
+// from growing over the node's lifetime.
+const interactiveAggregateMemoTTL = 5 * time.Minute
+
+type interactiveAggregateEntry struct {
+	once      sync.Once
+	signature []byte
+	err       error
+}
+
+var (
+	interactiveAggregateMemoMu sync.Mutex
+	interactiveAggregateMemo   = map[string]*interactiveAggregateEntry{}
+)
+
+// aggregateInteractiveOnce runs aggregate AT MOST ONCE per key within this
+// process and returns the same (signature, error) to every caller sharing that
+// key.
+//
+// Why it exists: a multi-seat operator runs one interactiveSigningRunner
+// goroutine per LOCAL seat, and they all drive the SAME per-process interactive
+// engine session for the wallet's key group. Step 9 of the runner has every
+// participating member aggregate — correct across SEPARATE processes, where each
+// aggregates against its own session. But two local seats in ONE process hit the
+// engine's per-attempt anti-replay marker: the first InteractiveAggregate
+// succeeds and the second fails with InteractiveAttemptAlreadyAggregated even
+// though the deterministic signature was already produced. Aggregation is a
+// public, deterministic operation over the same signing package and the same
+// subset shares, so returning the first execution's result to the sibling seats
+// is correct and lets the coordinator seat obtain the signature regardless of
+// which local seat computed it first.
+//
+// The key must uniquely identify one aggregation: the caller uses
+// sessionID + attemptID, which the engine's marker is derived from (attempt id +
+// message digest, with the message fixed for the attempt and the session pinned
+// to a single message + taproot root at open time).
+func aggregateInteractiveOnce(
+	key string,
+	aggregate func() ([]byte, error),
+) ([]byte, error) {
+	interactiveAggregateMemoMu.Lock()
+	entry, ok := interactiveAggregateMemo[key]
+	if !ok {
+		entry = &interactiveAggregateEntry{}
+		interactiveAggregateMemo[key] = entry
+		// Self-evict well after the attempt's signing window so the memo does not
+		// grow unbounded. Concurrent local seats share the entry via sync.Once long
+		// before this fires; a straggler that arrives after eviction simply
+		// re-aggregates (and, if the engine already consumed the marker, fails its
+		// own attempt into the existing retry path — never a wrong signature).
+		time.AfterFunc(interactiveAggregateMemoTTL, func() {
+			interactiveAggregateMemoMu.Lock()
+			delete(interactiveAggregateMemo, key)
+			interactiveAggregateMemoMu.Unlock()
+		})
+	}
+	interactiveAggregateMemoMu.Unlock()
+
+	entry.once.Do(func() {
+		entry.signature, entry.err = aggregate()
+	})
+	return entry.signature, entry.err
+}
+
+// ResetInteractiveAggregateMemoForTest clears the process-wide aggregate memo.
+// Tests that run multiple runners in a single process (each simulating a
+// separate operator, which in production would be its own process with its own
+// memo) must reset between cases so a memoized result does not leak across tests
+// or suppress a case's own engine aggregate call. Not for production use.
+func ResetInteractiveAggregateMemoForTest() {
+	interactiveAggregateMemoMu.Lock()
+	interactiveAggregateMemo = map[string]*interactiveAggregateEntry{}
+	interactiveAggregateMemoMu.Unlock()
+}

--- a/pkg/frost/signing/roast_runner_interactive_aggregate_memo_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_interactive_aggregate_memo_frost_native_test.go
@@ -1,0 +1,126 @@
+//go:build frost_native
+
+package signing
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestAggregateInteractiveOnce_RunsAtMostOncePerKey pins the core contract that
+// lets a multi-seat operator's local seats share one aggregation: for a given
+// key, aggregate executes at most once and every caller of that key observes the
+// same result. This is why the runner tests inject passThroughAggregateOnce -
+// they simulate SEPARATE operators and must not share an aggregation.
+func TestAggregateInteractiveOnce_RunsAtMostOncePerKey(t *testing.T) {
+	ResetInteractiveAggregateMemoForTest()
+	t.Cleanup(ResetInteractiveAggregateMemoForTest)
+
+	var calls int
+	first, err := aggregateInteractiveOnce("k", func() ([]byte, error) {
+		calls++
+		return []byte("sig-1"), nil
+	})
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	// A second call under the same key must NOT run its aggregate; it returns the
+	// first result even though this func would produce a different signature.
+	second, err := aggregateInteractiveOnce("k", func() ([]byte, error) {
+		calls++
+		return []byte("sig-2"), nil
+	})
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	if calls != 1 {
+		t.Fatalf("aggregate ran %d times, want exactly 1", calls)
+	}
+	if string(first) != "sig-1" || string(second) != "sig-1" {
+		t.Fatalf("siblings disagree: first=%q second=%q, want both sig-1", first, second)
+	}
+}
+
+// TestAggregateInteractiveOnce_PropagatesFirstErrorToSiblings shows the memo is
+// result-faithful, not success-only: if the first aggregation errors, siblings
+// get that same error rather than silently re-running and diverging.
+func TestAggregateInteractiveOnce_PropagatesFirstErrorToSiblings(t *testing.T) {
+	ResetInteractiveAggregateMemoForTest()
+	t.Cleanup(ResetInteractiveAggregateMemoForTest)
+
+	wantErr := fmt.Errorf("aggregate boom")
+	var calls int
+	_, err1 := aggregateInteractiveOnce("k", func() ([]byte, error) {
+		calls++
+		return nil, wantErr
+	})
+	_, err2 := aggregateInteractiveOnce("k", func() ([]byte, error) {
+		calls++
+		return []byte("should-not-run"), nil
+	})
+
+	if calls != 1 {
+		t.Fatalf("aggregate ran %d times, want exactly 1", calls)
+	}
+	if err1 != wantErr || err2 != wantErr {
+		t.Fatalf("siblings must share the first error: err1=%v err2=%v", err1, err2)
+	}
+}
+
+// TestAggregateInteractiveOnce_DistinctKeysRunIndependently confirms the memo
+// scopes to the key: separate (session,attempt) pairs each aggregate once, so
+// distinct signing attempts never suppress one another.
+func TestAggregateInteractiveOnce_DistinctKeysRunIndependently(t *testing.T) {
+	ResetInteractiveAggregateMemoForTest()
+	t.Cleanup(ResetInteractiveAggregateMemoForTest)
+
+	a, _ := aggregateInteractiveOnce("k1", func() ([]byte, error) { return []byte("a"), nil })
+	b, _ := aggregateInteractiveOnce("k2", func() ([]byte, error) { return []byte("b"), nil })
+	if string(a) != "a" || string(b) != "b" {
+		t.Fatalf("distinct keys must run independently: k1=%q k2=%q", a, b)
+	}
+}
+
+// TestAggregateInteractiveOnce_ConcurrentCallersDedup exercises the real
+// multi-seat race: many goroutines hit the same key at once and exactly one
+// aggregation runs, with every caller getting that result. Run under -race.
+func TestAggregateInteractiveOnce_ConcurrentCallersDedup(t *testing.T) {
+	ResetInteractiveAggregateMemoForTest()
+	t.Cleanup(ResetInteractiveAggregateMemoForTest)
+
+	const goroutines = 32
+	var mu sync.Mutex
+	var calls int
+
+	results := make([][]byte, goroutines)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			sig, _ := aggregateInteractiveOnce("shared", func() ([]byte, error) {
+				mu.Lock()
+				calls++
+				mu.Unlock()
+				return []byte("winner"), nil
+			})
+			results[idx] = sig
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if calls != 1 {
+		t.Fatalf("aggregate ran %d times under contention, want exactly 1", calls)
+	}
+	for i, r := range results {
+		if string(r) != "winner" {
+			t.Fatalf("goroutine %d got %q, want winner", i, r)
+		}
+	}
+}

--- a/pkg/frost/signing/roast_runner_real_cgo_dropout_retry_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_real_cgo_dropout_retry_frost_native_test.go
@@ -3,6 +3,7 @@
 package signing
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sort"
@@ -288,29 +289,35 @@ func TestRealCgoInteractiveSigning_DropoutForcesNextAttemptAndReshuffledSubsetFi
 		results[i] = seatResult{sig: dones[i].sig, err: dones[i].err}
 	}
 
+	// With the per-(session,attempt) aggregate memo, the first co-resident seat runs
+	// the single real engine aggregate and every sibling receives that same result, so
+	// EVERY participating attempt-2 seat succeeds with the identical signature and none
+	// surfaces interactive_attempt_already_aggregated (that error now fails the test).
 	winners := 0
+	var sharedSignature []byte
 	for i, r := range results {
-		switch {
-		case r.err == nil:
-			if len(r.sig) != 64 {
-				t.Fatalf("attempt 2 seat %d: want a 64-byte BIP-340 signature, got %d bytes", seats2[i].member, len(r.sig))
-			}
-			winners++
-			state, err := seats2[i].coord.State(seats2[i].handle)
-			if err != nil {
-				t.Fatalf("attempt 2 seat %d state: %v", seats2[i].member, err)
-			}
-			if state != roast.AttemptStateSucceeded {
-				t.Fatalf("attempt 2 seat %d aggregated but is not Succeeded: %v", seats2[i].member, state)
-			}
-		case isInteractiveAlreadyAggregated(r.err):
-			// Co-resident seat: the shared engine already finalized this attempt.
-		default:
-			t.Fatalf("attempt 2 seat %d failed unexpectedly: %v", seats2[i].member, r.err)
+		if r.err != nil {
+			t.Fatalf("attempt 2 seat %d failed: %v", seats2[i].member, r.err)
+		}
+		if len(r.sig) != 64 {
+			t.Fatalf("attempt 2 seat %d: want a 64-byte BIP-340 signature, got %d bytes", seats2[i].member, len(r.sig))
+		}
+		if sharedSignature == nil {
+			sharedSignature = r.sig
+		} else if !bytes.Equal(r.sig, sharedSignature) {
+			t.Fatalf("attempt 2 seat %d produced a different signature than another aggregating seat", seats2[i].member)
+		}
+		winners++
+		state, err := seats2[i].coord.State(seats2[i].handle)
+		if err != nil {
+			t.Fatalf("attempt 2 seat %d state: %v", seats2[i].member, err)
+		}
+		if state != roast.AttemptStateSucceeded {
+			t.Fatalf("attempt 2 seat %d aggregated but is not Succeeded: %v", seats2[i].member, state)
 		}
 	}
-	if winners != 1 {
-		t.Fatalf("attempt 2: expected exactly one seat to aggregate the reshuffled-subset signature, got %d", winners)
+	if winners != len(seats2) {
+		t.Fatalf("attempt 2: expected every reshuffled-subset seat to aggregate the shared signature, got %d of %d", winners, len(seats2))
 	}
 }
 

--- a/pkg/frost/signing/roast_runner_real_cgo_invalid_share_exclusion_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_real_cgo_invalid_share_exclusion_frost_native_test.go
@@ -3,6 +3,7 @@
 package signing
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -253,29 +254,36 @@ func TestRealCgoInteractiveSigning_InvalidShareBlameForcesPermanentExclusion(t *
 	for i, s := range seats2 {
 		dones[i] = runSeatAsync(s, ctx2)
 	}
+	// With the per-(session,attempt) aggregate memo, every co-resident surviving-subset
+	// seat receives the single real engine aggregate's result, so ALL succeed with the
+	// identical signature and none surfaces interactive_attempt_already_aggregated (that
+	// error now fails the test).
 	winners := 0
+	var sharedSignature []byte
 	for i := range dones {
 		<-dones[i].done
-		switch {
-		case dones[i].err == nil:
-			if len(dones[i].sig) != 64 {
-				t.Fatalf("attempt 2 seat %d: want a 64-byte signature, got %d", seats2[i].member, len(dones[i].sig))
-			}
-			winners++
-			state, err := seats2[i].coord.State(seats2[i].handle)
-			if err != nil {
-				t.Fatalf("attempt 2 seat %d state: %v", seats2[i].member, err)
-			}
-			if state != roast.AttemptStateSucceeded {
-				t.Fatalf("attempt 2 seat %d not Succeeded: %v", seats2[i].member, state)
-			}
-		case isInteractiveAlreadyAggregated(dones[i].err):
-		default:
-			t.Fatalf("attempt 2 seat %d failed unexpectedly: %v", seats2[i].member, dones[i].err)
+		if dones[i].err != nil {
+			t.Fatalf("attempt 2 seat %d failed: %v", seats2[i].member, dones[i].err)
+		}
+		if len(dones[i].sig) != 64 {
+			t.Fatalf("attempt 2 seat %d: want a 64-byte signature, got %d", seats2[i].member, len(dones[i].sig))
+		}
+		if sharedSignature == nil {
+			sharedSignature = dones[i].sig
+		} else if !bytes.Equal(dones[i].sig, sharedSignature) {
+			t.Fatalf("attempt 2 seat %d produced a different signature than another aggregating seat", seats2[i].member)
+		}
+		winners++
+		state, err := seats2[i].coord.State(seats2[i].handle)
+		if err != nil {
+			t.Fatalf("attempt 2 seat %d state: %v", seats2[i].member, err)
+		}
+		if state != roast.AttemptStateSucceeded {
+			t.Fatalf("attempt 2 seat %d not Succeeded: %v", seats2[i].member, state)
 		}
 	}
-	if winners != 1 {
-		t.Fatalf("attempt 2: expected exactly one seat to aggregate the surviving-subset signature, got %d", winners)
+	if winners != len(seats2) {
+		t.Fatalf("attempt 2: expected every surviving-subset seat to aggregate the shared signature, got %d of %d", winners, len(seats2))
 	}
 }
 

--- a/pkg/frost/signing/roast_runner_real_cgo_multinode_e2e_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_real_cgo_multinode_e2e_frost_native_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -170,23 +169,23 @@ func buildRealCgoNetHarness(
 }
 
 // runAllAndAssertRealSignature runs every seat's runner concurrently against the shared
-// engine and asserts the shape-(A) outcome.
+// engine and asserts every co-resident seat obtains the SAME real BIP-340 signature.
 //
-// Because all seats share ONE engine and the engine's aggregate completion marker is
-// per-ATTEMPT (keyed by attempt_id, message, and taproot root - NOT per member), the
-// first seat to reach InteractiveAggregate produces the signature and marks the attempt
-// finalized; every co-resident seat then observes interactive_attempt_already_aggregated.
-// That is the shared-engine boundary, not a protocol failure: in production each node has
-// its own engine and aggregates the shares it collected independently. Crucially, every
-// seat still drives its FULL transport (broadcasting its commitments and share, and
-// collecting peers' commitments/package/shares over the real pkg/net bus) BEFORE the
-// aggregate step - so the transport seam this test exists for is exercised by all seats
-// regardless of which one wins the aggregate.
+// All seats share ONE process-global engine session AND the runner's per-(session,attempt)
+// aggregate memo (aggregateInteractiveOnce). The first seat to reach InteractiveAggregate
+// runs the single real engine aggregate and marks the attempt finalized; every sibling seat
+// then receives that same result from the memo instead of hitting the engine's per-attempt
+// idempotency marker. So NO seat surfaces interactive_attempt_already_aggregated any more
+// (the memo intercepts the co-resident collision) - all seats reach Succeeded with the
+// identical signature. In production each node has its own engine and aggregates the shares
+// it collected independently; the memo only dedups the co-resident seats of ONE operator.
+// Crucially, every seat still drives its FULL transport (broadcasting its commitments and
+// share, and collecting peers' commitments/package/shares over the real pkg/net bus) BEFORE
+// the aggregate step - so the transport seam this test exists for is exercised by all seats.
 //
-// So the assertions are: exactly one seat aggregates a real 64-byte BIP-340 signature and
-// reaches Succeeded (the engine produced the signature once, through the full runner +
-// transport stack), and every other seat reached aggregate and observed the per-attempt
-// idempotency marker - no seat fails for any other reason.
+// So the assertion is: EVERY seat aggregates the same real 64-byte BIP-340 signature and
+// reaches Succeeded, and no seat fails for any reason (an aggregate error - including the
+// idempotency marker - would fail the test, asserting the memo prevented the collision).
 func (h realCgoNetSigningHarness) runAllAndAssertRealSignature(t *testing.T, ctx context.Context) {
 	t.Helper()
 	sigs := make([][]byte, len(h.runners))
@@ -201,51 +200,34 @@ func (h realCgoNetSigningHarness) runAllAndAssertRealSignature(t *testing.T, ctx
 	}
 	wg.Wait()
 
-	var winningSignature []byte
-	winners := 0
+	var sharedSignature []byte
 	for i := range h.runners {
 		member := i + 1
-		switch {
-		case errs[i] == nil:
-			if len(sigs[i]) != 64 {
-				t.Fatalf("seat %d: expected a 64-byte BIP-340 signature, got %d bytes", member, len(sigs[i]))
-			}
-			winners++
-			if winningSignature == nil {
-				winningSignature = sigs[i]
-			} else if !bytes.Equal(sigs[i], winningSignature) {
-				t.Fatalf("seat %d produced a different signature than another aggregating seat", member)
-			}
-			state, err := h.coords[i].State(h.handles[i])
-			if err != nil {
-				t.Fatalf("seat %d state: %v", member, err)
-			}
-			if state != roast.AttemptStateSucceeded {
-				t.Fatalf("seat %d aggregated but did not reach Succeeded, got %v", member, state)
-			}
-		case isInteractiveAlreadyAggregated(errs[i]):
-			// Expected shared-engine outcome: this seat completed all transport and
-			// reached aggregate, where a co-resident seat had already finalized the
-			// attempt. The per-attempt idempotency marker is exactly what rejects it.
-		default:
-			t.Fatalf("seat %d run failed for an unexpected reason: %v", member, errs[i])
+		// With the per-(session,attempt) aggregate memo, the first local seat to reach
+		// step 9 runs the single real engine aggregate and every co-resident seat
+		// receives that same result, so ALL seats succeed with the identical BIP-340
+		// signature and none surfaces interactive_attempt_already_aggregated. An
+		// aggregate error here (idempotency marker or otherwise) fails the test,
+		// asserting the memo intercepted the shared-engine collision.
+		if errs[i] != nil {
+			t.Fatalf("seat %d run failed: %v", member, errs[i])
+		}
+		if len(sigs[i]) != 64 {
+			t.Fatalf("seat %d: expected a 64-byte BIP-340 signature, got %d bytes", member, len(sigs[i]))
+		}
+		if sharedSignature == nil {
+			sharedSignature = sigs[i]
+		} else if !bytes.Equal(sigs[i], sharedSignature) {
+			t.Fatalf("seat %d produced a different signature than another aggregating seat", member)
+		}
+		state, err := h.coords[i].State(h.handles[i])
+		if err != nil {
+			t.Fatalf("seat %d state: %v", member, err)
+		}
+		if state != roast.AttemptStateSucceeded {
+			t.Fatalf("seat %d aggregated but did not reach Succeeded, got %v", member, state)
 		}
 	}
-	if winners != 1 {
-		t.Fatalf(
-			"expected exactly one seat to aggregate the signature against the shared engine, got %d",
-			winners,
-		)
-	}
-}
-
-// isInteractiveAlreadyAggregated reports whether an aggregate error is the engine's
-// per-attempt idempotency refusal - the expected outcome when a co-resident seat (sharing
-// the single process-global engine) already finalized the attempt. Matched on the error
-// text surfaced through the FFI bridge; test-only shared-engine detection, not production
-// control flow.
-func isInteractiveAlreadyAggregated(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "interactive_attempt_already_aggregated")
 }
 
 // TestRealCgoInteractiveSigning_NetTransport_FullIncludedRound runs a complete interactive

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -493,6 +493,14 @@ func (n *node) getSigningExecutor(
 		len(signers),
 	)
 
+	// Register a ROAST-retry coordinator for each local seat of this wallet so
+	// the interactive FROST signing path can run for it. This must happen before
+	// the executor is used: the executor entry's BeginOrchestrationForSession
+	// looks the coordinator up per member, and an absent coordinator makes the
+	// interactive drive fall through (fail-closed under interactive-only mode).
+	// No-op unless built with frost_native && frost_roast_retry.
+	registerRoastRetryCoordinatorForSeats(n, signers)
+
 	blockCounter, err := n.chain.BlockCounter()
 	if err != nil {
 		return nil, false, fmt.Errorf(

--- a/pkg/tbtc/signing_loop_roast_coordinator_registration_default.go
+++ b/pkg/tbtc/signing_loop_roast_coordinator_registration_default.go
@@ -1,0 +1,11 @@
+//go:build !(frost_native && frost_roast_retry)
+
+package tbtc
+
+// registerRoastRetryCoordinatorForSeats is a no-op in builds without the
+// frost_native && frost_roast_retry tags. The ROAST-retry coordinator registry
+// only takes effect under those tags (the interactive engine needs frost_native
+// and the real registry needs frost_roast_retry), so there is nothing to wire in
+// other builds. Kept as a plain function so node.getSigningExecutor can call it
+// unconditionally, mirroring the newRoastTransitionController default/tagged split.
+func registerRoastRetryCoordinatorForSeats(_ *node, _ []*signer) {}

--- a/pkg/tbtc/signing_loop_roast_coordinator_registration_frost_native_roast_retry.go
+++ b/pkg/tbtc/signing_loop_roast_coordinator_registration_frost_native_roast_retry.go
@@ -1,0 +1,76 @@
+//go:build frost_native && frost_roast_retry
+
+package tbtc
+
+import (
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/signing"
+)
+
+// operatorKeyRoastSigner adapts the node's operator chain signer to the
+// roast.Signer interface. It signs the RFC-21 ROAST coordination evidence
+// (transition bundles and local snapshots) with the same operator key the node
+// uses for FROST DKG-result signing (see frost_dkg_result_signing.go). It does
+// NOT sign the FROST threshold signature itself — that is produced by the
+// interactive engine; this only authenticates the retry/blame layer.
+type operatorKeyRoastSigner struct {
+	signing chain.Signing
+}
+
+// Sign returns the operator-key signature over the canonical ROAST payload. The
+// coordinator treats the bytes as opaque; the SignatureVerifier interprets them.
+func (s operatorKeyRoastSigner) Sign(payload []byte) ([]byte, error) {
+	return s.signing.Sign(payload)
+}
+
+// registerRoastRetryCoordinatorForSeats registers a ROAST-retry coordinator for
+// every local seat of a wallet's signing group so the interactive FROST signing
+// path (driveInteractiveRoastSigningIfEnabled) can run on a live node. Without
+// this, the executor's BeginOrchestrationForSession finds no coordinator, the
+// interactive drive never starts, and interactive-only signing fails closed.
+//
+// Each seat gets its OWN coordinator bound to that seat's member index — the
+// registrar enforces deps.SelfMember == member and drops any mismatch, so a
+// mis-bound seat safely stays on legacy rather than aggregating as the wrong
+// member. The operator-key Signer is shared across seats (one operator identity).
+//
+// The Verifier is currently a no-op. On the happy path the coordinator never
+// verifies evidence signatures (BeginAttempt -> engine.InteractiveAggregate ->
+// MarkSucceeded touches neither Signer nor Verifier), so a valid BIP-340
+// signature is produced without it. A real member-keyed verifier
+// (member index -> operator public key -> chain.Signing().VerifyWithPublicKey)
+// is a required follow-up before the retry/blame path's integrity can be
+// trusted, and it must be flipped from no-op to real atomically across the
+// operator set so the retry-path signature format stays consistent.
+//
+// KNOWN LIMITATION (single-wallet only): the retry registry is keyed by member
+// index alone (RegisterRoastRetryCoordinatorForMember), not by wallet+member. A
+// node controlling more than one FROST wallet would register overlapping seat
+// indices (each wallet's group is 1..N), and the later registration replaces the
+// earlier — so this wiring is correct only while a node controls a single FROST
+// wallet, which matches the current experimental deployment. Making the registry
+// wallet-scoped is a prerequisite for multi-wallet FROST and is tracked with the
+// verifier follow-up.
+func registerRoastRetryCoordinatorForSeats(n *node, signers []*signer) {
+	operatorSigner := operatorKeyRoastSigner{signing: n.chain.Signing()}
+	verifier := roast.NoOpSignatureVerifier()
+
+	for _, s := range signers {
+		member := s.signingGroupMemberIndex
+		coordinator := roast.NewInMemoryCoordinatorWithSigning(
+			member,
+			operatorSigner,
+			verifier,
+		)
+		signing.RegisterRoastRetryCoordinatorForMember(
+			member,
+			signing.RoastRetryDeps{
+				Coordinator: coordinator,
+				Signer:      operatorSigner,
+				Verifier:    verifier,
+				SelfMember:  uint32(member),
+			},
+		)
+	}
+}


### PR DESCRIPTION
## What

Wires `RegisterRoastRetryCoordinator` into the live signing loop so the interactive FROST (ROAST/RFC-21) signing path actually runs on a production node, and fixes a multi-seat aggregation collision found while proving it live. Stacked on top of #4138 (coarse-path deletion).

## Why

Before this change `RegisterRoastRetryCoordinator` had **no production caller** — it was only ever registered from tests. On a live node the executor entry's `BeginOrchestrationForSession` looked up a coordinator per member, found none, and the interactive drive fell through. With the coarse path deleted (#4138), interactive-only signing therefore failed closed: a FROST wallet could not sign.

## What changed

- **`node.getSigningExecutor`** now calls `registerRoastRetryCoordinatorForSeats(n, signers)` once per wallet, after the executor-cache early return and before the executor is used.
- **`signing_loop_roast_coordinator_registration_frost_native_roast_retry.go`** (`//go:build frost_native && frost_roast_retry`): builds an operator-key `roast.Signer` and one per-seat in-memory coordinator, registering each via `RegisterRoastRetryCoordinatorForMember`. Mirrors the `newRoastTransitionController` default/tagged split.
- **`signing_loop_roast_coordinator_registration_default.go`**: no-op under all other build tags so `getSigningExecutor` can call it unconditionally.

### Multi-seat aggregation fix

A multi-seat operator runs one interactive runner per **local** seat against the **shared** per-process engine session. Both seats reach runner step 9 and try to aggregate: the first succeeds, the second hits the engine's per-attempt anti-replay marker (`InteractiveAttemptAlreadyAggregated`) even though the deterministic signature already exists. The runner now memoizes the aggregation per `(session, attempt)` so sibling local seats share the first result. `aggregateOnce` is injectable (defaulting to the process-global memo) so unit tests that simulate several operators in one process aggregate against their own engines; the memo's dedup contract is pinned by `TestAggregateInteractiveOnce_*` (incl. a `-race` concurrency case).

## Verification

- `go test -race -tags "frost_native frost_roast_retry" ./pkg/frost/signing/ ./pkg/tbtc/` — green.
- Full cgo node binary (`frost_native frost_tbtc_signer frost_roast_retry cgo`) links.
- **Live on the anvil + Bitcoin testnet4 FROST rehearsal**: one node held seats 2 and 3; the signing subset was `{2,3}` (coordinator 2, member 1 excluded); both seats produced the **identical** BIP-340 signature with **zero** `InteractiveAttemptAlreadyAggregated` errors — proving the multi-seat path end-to-end.

## Known follow-ups (separate PR)

- The `SignatureVerifier` is still a **no-op**. The happy path never verifies evidence signatures (`BeginAttempt → InteractiveAggregate → MarkSucceeded` touches neither Signer nor Verifier), so a valid signature is produced without it — but the retry/blame path needs a real member-keyed verifier (`member index → operator public key → VerifyWithPublicKey`), flipped from no-op to real atomically across the operator set.
- The retry registry is keyed by **member index alone**, so this wiring is correct only while a node controls a **single** FROST wallet (the current experimental deployment). A wallet-scoped registry key is a prerequisite for multi-wallet FROST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Htk7v5FLAZrYwEkw88Dv9