### PR TITLE
feat(frost): member-keyed ROAST SignatureVerifier for the retry/blame layer

### DIFF
--- a/pkg/tbtc/roast_operator_signature_verifier_frost_native_roast_retry.go
+++ b/pkg/tbtc/roast_operator_signature_verifier_frost_native_roast_retry.go
@@ -1,0 +1,164 @@
+//go:build frost_native && frost_roast_retry
+
+package tbtc
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// The ROAST retry/blame layer authenticates evidence with operator-key
+// signatures: a signer signs its own LocalEvidenceSnapshot and the elected
+// coordinator signs the assembled TransitionMessage bundle (see
+// pkg/frost/roast/signature.go). The coordinator state machine treats a
+// signature as OPAQUE bytes and delegates all interpretation to the
+// SignatureVerifier, which owns the member-index -> operator-key mapping.
+//
+// The node only knows each seat's operator ADDRESS (wallet.signingGroupOperators),
+// not its public key, and chain.Signing.VerifyWithPublicKey needs the public key.
+// So the signature the Signer emits is a self-describing ENVELOPE that carries the
+// signing operator's public key alongside the raw operator-key signature. The
+// Verifier then, exactly like the FROST DKG-result-signing path
+// (frost_dkg_result_signing.go): (1) binds the carried public key to the claimed
+// member's seat via PublicKeyBytesToAddress == signingGroupOperators[member-1],
+// and (2) checks the raw signature against that public key. Both must hold, so a
+// valid signature under the wrong seat's key -- or a key that is not seated at the
+// claimed member -- is rejected.
+//
+// This envelope is a private contract between operatorKeyRoastSigner and
+// memberKeyedRoastSignatureVerifier; it must be adopted by the whole operator set
+// at once (a peer still emitting bare signatures would be rejected by an upgraded
+// verifier during a retry). The happy path never verifies evidence signatures, so
+// the switch is inert until an actual ROAST retry occurs.
+
+const (
+	// roastSignatureEnvelopeVersion is the leading byte of every envelope. It lets
+	// the format evolve (e.g. a future compressed-key layout) while letting an
+	// upgraded verifier reject an unrecognized layout deterministically instead of
+	// misparsing it.
+	roastSignatureEnvelopeVersion byte = 1
+
+	// roastSignatureEnvelopeHeaderLen is the fixed prefix length:
+	// version(1) + publicKeyLen(2, big-endian).
+	roastSignatureEnvelopeHeaderLen = 3
+)
+
+// encodeRoastSignatureEnvelope packs an operator public key and a raw operator-key
+// signature into the wire form the verifier expects:
+//
+//	[version:1][publicKeyLen: uint16 big-endian][publicKey][signature]
+//
+// Both parts must be non-empty: an empty public key cannot be bound to a seat and
+// an empty signature never verifies, so refusing them here surfaces a signer bug
+// at sign time rather than as an opaque verification failure on the retry path.
+func encodeRoastSignatureEnvelope(publicKey, signature []byte) ([]byte, error) {
+	if len(publicKey) == 0 {
+		return nil, fmt.Errorf("roast signature envelope: empty public key")
+	}
+	if len(signature) == 0 {
+		return nil, fmt.Errorf("roast signature envelope: empty signature")
+	}
+	if len(publicKey) > 0xFFFF {
+		return nil, fmt.Errorf(
+			"roast signature envelope: public key too long: %d bytes",
+			len(publicKey),
+		)
+	}
+
+	out := make([]byte, roastSignatureEnvelopeHeaderLen+len(publicKey)+len(signature))
+	out[0] = roastSignatureEnvelopeVersion
+	binary.BigEndian.PutUint16(out[1:3], uint16(len(publicKey)))
+	copy(out[roastSignatureEnvelopeHeaderLen:], publicKey)
+	copy(out[roastSignatureEnvelopeHeaderLen+len(publicKey):], signature)
+	return out, nil
+}
+
+// decodeRoastSignatureEnvelope reverses encodeRoastSignatureEnvelope. It fails
+// closed on any malformed input (wrong version, truncated header, length that
+// overruns the buffer, or an empty signature remainder) so a corrupt or
+// wrong-format envelope becomes a verification error rather than a panic or a
+// silently-accepted signature.
+func decodeRoastSignatureEnvelope(envelope []byte) (publicKey, signature []byte, err error) {
+	if len(envelope) < roastSignatureEnvelopeHeaderLen {
+		return nil, nil, fmt.Errorf(
+			"roast signature envelope: too short: %d bytes", len(envelope),
+		)
+	}
+	if envelope[0] != roastSignatureEnvelopeVersion {
+		return nil, nil, fmt.Errorf(
+			"roast signature envelope: unsupported version %d", envelope[0],
+		)
+	}
+	pubKeyLen := int(binary.BigEndian.Uint16(envelope[1:3]))
+	sigStart := roastSignatureEnvelopeHeaderLen + pubKeyLen
+	if pubKeyLen == 0 || sigStart >= len(envelope) {
+		return nil, nil, fmt.Errorf(
+			"roast signature envelope: declared public key length %d inconsistent with envelope size %d",
+			pubKeyLen, len(envelope),
+		)
+	}
+	return envelope[roastSignatureEnvelopeHeaderLen:sigStart], envelope[sigStart:], nil
+}
+
+// memberKeyedRoastSignatureVerifier is the production roast.SignatureVerifier. It
+// verifies that a signature attributed to a signing-group seat was produced by the
+// operator seated at that member index, using the wallet's seat -> operator-address
+// list and the chain's operator-key verification primitives.
+//
+// operatorAddresses is 0-indexed by seat: operatorAddresses[i] is the operator at
+// 1-based member index i+1, matching wallet.signingGroupOperators. Verify is safe
+// for concurrent use: it only reads immutable state and calls concurrency-safe
+// chain.Signing methods.
+type memberKeyedRoastSignatureVerifier struct {
+	signing           chain.Signing
+	operatorAddresses []chain.Address
+}
+
+// Verify implements roast.SignatureVerifier. It returns nil only when the envelope
+// decodes, the carried public key is seated at the claimed member index, and the
+// raw signature verifies against that public key over payload. Every failure path
+// returns a descriptive error; the caller (verifySnapshotSignature /
+// verifyBundleSignature) wraps it with roast.ErrSignatureInvalid.
+func (v memberKeyedRoastSignatureVerifier) Verify(
+	payload []byte,
+	signature []byte,
+	signer group.MemberIndex,
+) error {
+	if signer < 1 || int(signer) > len(v.operatorAddresses) {
+		return fmt.Errorf(
+			"member index %d out of range [1, %d]",
+			signer, len(v.operatorAddresses),
+		)
+	}
+
+	publicKey, rawSignature, err := decodeRoastSignatureEnvelope(signature)
+	if err != nil {
+		return fmt.Errorf("member %d: %w", signer, err)
+	}
+
+	// Bind the carried public key to the claimed seat BEFORE trusting the
+	// signature: a signature can be perfectly valid under some key yet be
+	// attributed to a member that key does not occupy. Deriving the address from
+	// the key and matching it to this seat's operator is what ties the signature
+	// to the member index the coordinator asked about.
+	expectedOperator := v.operatorAddresses[signer-1]
+	actualOperator := v.signing.PublicKeyBytesToAddress(publicKey)
+	if actualOperator != expectedOperator {
+		return fmt.Errorf(
+			"member %d: envelope public key maps to operator %s, seat holds %s",
+			signer, actualOperator, expectedOperator,
+		)
+	}
+
+	valid, err := v.signing.VerifyWithPublicKey(payload, rawSignature, publicKey)
+	if err != nil {
+		return fmt.Errorf("member %d: signature verification error: %w", signer, err)
+	}
+	if !valid {
+		return fmt.Errorf("member %d: signature does not verify against seat operator key", signer)
+	}
+	return nil
+}

--- a/pkg/tbtc/roast_operator_signature_verifier_frost_native_roast_retry_test.go
+++ b/pkg/tbtc/roast_operator_signature_verifier_frost_native_roast_retry_test.go
@@ -1,0 +1,273 @@
+//go:build frost_native && frost_roast_retry
+
+package tbtc
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/chain/local_v1"
+	"github.com/keep-network/keep-core/pkg/frost/roast"
+	"github.com/keep-network/keep-core/pkg/frost/roast/attempt"
+	"github.com/keep-network/keep-core/pkg/operator"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+// newTestOperatorSigning returns a real operator-key chain.Signing (secp256k1,
+// genuine sign/verify) so these tests exercise the actual crypto path the
+// production verifier relies on, not a stub.
+func newTestOperatorSigning(t *testing.T) chain.Signing {
+	t.Helper()
+	privateKey, _, err := operator.GenerateKeyPair(local_v1.DefaultCurve)
+	if err != nil {
+		t.Fatalf("generate operator key pair: %v", err)
+	}
+	return local_v1.NewSigner(privateKey)
+}
+
+// buildSeatSignings returns n distinct operator signings and the seat ->
+// operator-address list they induce (address[i] is the operator at member i+1).
+func buildSeatSignings(t *testing.T, n int) ([]chain.Signing, []chain.Address) {
+	t.Helper()
+	signings := make([]chain.Signing, n)
+	addresses := make([]chain.Address, n)
+	for i := 0; i < n; i++ {
+		signings[i] = newTestOperatorSigning(t)
+		addresses[i] = signings[i].Address()
+	}
+	return signings, addresses
+}
+
+func TestRoastSignatureEnvelope_RoundTrip(t *testing.T) {
+	pub := []byte{0x04, 0x11, 0x22, 0x33}
+	sig := []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee}
+
+	envelope, err := encodeRoastSignatureEnvelope(pub, sig)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	gotPub, gotSig, err := decodeRoastSignatureEnvelope(envelope)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !bytes.Equal(gotPub, pub) {
+		t.Errorf("public key round-trip mismatch: got %x want %x", gotPub, pub)
+	}
+	if !bytes.Equal(gotSig, sig) {
+		t.Errorf("signature round-trip mismatch: got %x want %x", gotSig, sig)
+	}
+}
+
+func TestRoastSignatureEnvelope_EncodeRejectsEmptyParts(t *testing.T) {
+	if _, err := encodeRoastSignatureEnvelope(nil, []byte{0x01}); err == nil {
+		t.Error("expected error for empty public key")
+	}
+	if _, err := encodeRoastSignatureEnvelope([]byte{0x01}, nil); err == nil {
+		t.Error("expected error for empty signature")
+	}
+}
+
+func TestRoastSignatureEnvelope_DecodeRejectsMalformed(t *testing.T) {
+	valid, err := encodeRoastSignatureEnvelope([]byte{0x04, 0x11}, []byte{0xaa})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	cases := map[string][]byte{
+		"empty":                  {},
+		"header only":            {roastSignatureEnvelopeVersion, 0x00},
+		"unsupported version":    append([]byte{0x02}, valid[1:]...),
+		"pubkey len overruns":    {roastSignatureEnvelopeVersion, 0xFF, 0xFF, 0x04},
+		"no signature remainder": {roastSignatureEnvelopeVersion, 0x00, 0x02, 0x04, 0x11},
+		"zero pubkey len":        {roastSignatureEnvelopeVersion, 0x00, 0x00, 0xaa},
+	}
+	for name, envelope := range cases {
+		if _, _, err := decodeRoastSignatureEnvelope(envelope); err == nil {
+			t.Errorf("%s: expected decode error, got nil", name)
+		}
+	}
+}
+
+func TestMemberKeyedVerifier_AcceptsCorrectSeat(t *testing.T) {
+	signings, addresses := buildSeatSignings(t, 3)
+	verifier := memberKeyedRoastSignatureVerifier{
+		signing:           signings[0], // verification uses pure methods; any signing works
+		operatorAddresses: addresses,
+	}
+
+	payload := []byte("roast evidence snapshot bytes")
+	for seat := 1; seat <= 3; seat++ {
+		signer := operatorKeyRoastSigner{signing: signings[seat-1]}
+		envelope, err := signer.Sign(payload)
+		if err != nil {
+			t.Fatalf("seat %d sign: %v", seat, err)
+		}
+		if err := verifier.Verify(payload, envelope, group.MemberIndex(seat)); err != nil {
+			t.Errorf("seat %d: expected valid, got %v", seat, err)
+		}
+	}
+}
+
+func TestMemberKeyedVerifier_RejectsWrongSeatAttribution(t *testing.T) {
+	signings, addresses := buildSeatSignings(t, 3)
+	verifier := memberKeyedRoastSignatureVerifier{
+		signing:           signings[0],
+		operatorAddresses: addresses,
+	}
+
+	payload := []byte("roast evidence snapshot bytes")
+	// A cryptographically VALID signature by seat 2's operator, but attributed to
+	// seat 1. The binding check (pubkey -> address != seat 1's operator) must
+	// reject it even though the signature itself verifies.
+	envelope, err := operatorKeyRoastSigner{signing: signings[1]}.Sign(payload)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if err := verifier.Verify(payload, envelope, 1); err == nil {
+		t.Fatal("expected rejection of seat-2 signature attributed to seat 1")
+	}
+	// Sanity: the same signature is accepted for its true seat.
+	if err := verifier.Verify(payload, envelope, 2); err != nil {
+		t.Fatalf("expected acceptance for true seat 2, got %v", err)
+	}
+}
+
+func TestMemberKeyedVerifier_RejectsOutsiderKey(t *testing.T) {
+	signings, addresses := buildSeatSignings(t, 3)
+	verifier := memberKeyedRoastSignatureVerifier{
+		signing:           signings[0],
+		operatorAddresses: addresses,
+	}
+
+	payload := []byte("roast evidence snapshot bytes")
+	// An operator NOT seated in the group signs and claims seat 2.
+	outsider := newTestOperatorSigning(t)
+	envelope, err := operatorKeyRoastSigner{signing: outsider}.Sign(payload)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if err := verifier.Verify(payload, envelope, 2); err == nil {
+		t.Fatal("expected rejection of an out-of-group operator key")
+	}
+}
+
+func TestMemberKeyedVerifier_RejectsTamperedPayload(t *testing.T) {
+	signings, addresses := buildSeatSignings(t, 3)
+	verifier := memberKeyedRoastSignatureVerifier{
+		signing:           signings[0],
+		operatorAddresses: addresses,
+	}
+
+	envelope, err := operatorKeyRoastSigner{signing: signings[1]}.Sign([]byte("original payload"))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	// Correct seat, correct key, but the payload the verifier checks differs.
+	if err := verifier.Verify([]byte("tampered payload"), envelope, 2); err == nil {
+		t.Fatal("expected rejection when the verified payload differs from the signed one")
+	}
+}
+
+func TestMemberKeyedVerifier_RejectsOutOfRangeMember(t *testing.T) {
+	signings, addresses := buildSeatSignings(t, 3)
+	verifier := memberKeyedRoastSignatureVerifier{
+		signing:           signings[0],
+		operatorAddresses: addresses,
+	}
+
+	envelope, err := operatorKeyRoastSigner{signing: signings[0]}.Sign([]byte("payload"))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	for _, seat := range []group.MemberIndex{0, 4, 255} {
+		if err := verifier.Verify([]byte("payload"), envelope, seat); err == nil {
+			t.Errorf("seat %d: expected out-of-range rejection", seat)
+		}
+	}
+}
+
+func TestMemberKeyedVerifier_RejectsBareSignature(t *testing.T) {
+	signings, addresses := buildSeatSignings(t, 3)
+	verifier := memberKeyedRoastSignatureVerifier{
+		signing:           signings[0],
+		operatorAddresses: addresses,
+	}
+
+	payload := []byte("payload")
+	// A pre-envelope (bare) operator signature — the format a not-yet-upgraded peer
+	// would emit. It must be rejected, not misparsed.
+	bare, err := signings[1].Sign(payload)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if err := verifier.Verify(payload, bare, 2); err == nil {
+		t.Fatal("expected rejection of a bare (non-enveloped) signature")
+	}
+}
+
+// TestMemberKeyedVerifier_IntegratesWithCoordinatorRecordEvidence drives the
+// production Signer and Verifier through a REAL roast coordinator's RecordEvidence
+// — the exact retry/blame seam that verifies a peer's evidence snapshot — proving
+// the switch from the no-op verifier authenticates evidence end to end.
+func TestMemberKeyedVerifier_IntegratesWithCoordinatorRecordEvidence(t *testing.T) {
+	signings, addresses := buildSeatSignings(t, 3)
+	verifier := memberKeyedRoastSignatureVerifier{
+		signing:           signings[0],
+		operatorAddresses: addresses,
+	}
+
+	// A real in-memory coordinator (self member 1) using the production Signer and
+	// the new member-keyed Verifier.
+	coord := roast.NewInMemoryCoordinatorWithSigning(
+		1,
+		operatorKeyRoastSigner{signing: signings[0]},
+		verifier,
+	)
+
+	included := []group.MemberIndex{1, 2, 3}
+	ctx, err := attempt.NewAttemptContext(
+		"session-1", "key-group-1", []byte{0x01, 0x02},
+		[attempt.MessageDigestLength]byte{0x42}, 0, included, nil,
+	)
+	if err != nil {
+		t.Fatalf("attempt context: %v", err)
+	}
+	handle, err := coord.BeginAttempt(ctx)
+	if err != nil {
+		t.Fatalf("begin attempt: %v", err)
+	}
+	attemptHash := ctx.Hash()
+
+	signSnapshot := func(seat group.MemberIndex, signingIdx int) *roast.LocalEvidenceSnapshot {
+		t.Helper()
+		snapshot := roast.NewLocalEvidenceSnapshot(seat, attemptHash, attempt.Evidence{})
+		payload, err := snapshot.SignableBytes()
+		if err != nil {
+			t.Fatalf("snapshot signable bytes: %v", err)
+		}
+		sig, err := operatorKeyRoastSigner{signing: signings[signingIdx]}.Sign(payload)
+		if err != nil {
+			t.Fatalf("sign snapshot: %v", err)
+		}
+		snapshot.OperatorSignature = sig
+		return snapshot
+	}
+
+	// Seat 2 authors and signs its own snapshot with seat 2's operator key.
+	if err := coord.RecordEvidence(handle, signSnapshot(2, 1)); err != nil {
+		t.Fatalf("valid seat-2 snapshot rejected by coordinator: %v", err)
+	}
+
+	// A snapshot attributed to seat 3 but signed with seat 1's key. Seat 3 has no
+	// prior record, so the only thing that can reject it is signature verification.
+	err = coord.RecordEvidence(handle, signSnapshot(3, 0))
+	if err == nil {
+		t.Fatal("coordinator accepted a snapshot signed by the wrong operator")
+	}
+	if !errors.Is(err, roast.ErrSignatureInvalid) {
+		t.Fatalf("expected ErrSignatureInvalid, got %v", err)
+	}
+}

--- a/pkg/tbtc/signing_loop_roast_coordinator_registration_frost_native_roast_retry.go
+++ b/pkg/tbtc/signing_loop_roast_coordinator_registration_frost_native_roast_retry.go
@@ -18,10 +18,19 @@ type operatorKeyRoastSigner struct {
 	signing chain.Signing
 }
 
-// Sign returns the operator-key signature over the canonical ROAST payload. The
-// coordinator treats the bytes as opaque; the SignatureVerifier interprets them.
+// Sign returns a self-describing envelope carrying this operator's public key
+// alongside the raw operator-key signature over the canonical ROAST payload. The
+// coordinator treats the bytes as opaque; memberKeyedRoastSignatureVerifier is the
+// only component that interprets them, using the embedded public key to bind the
+// signature to a member seat (the node knows seats by operator ADDRESS, not public
+// key, so the key must travel with the signature). See
+// roast_operator_signature_verifier_frost_native_roast_retry.go.
 func (s operatorKeyRoastSigner) Sign(payload []byte) ([]byte, error) {
-	return s.signing.Sign(payload)
+	rawSignature, err := s.signing.Sign(payload)
+	if err != nil {
+		return nil, err
+	}
+	return encodeRoastSignatureEnvelope(s.signing.PublicKey(), rawSignature)
 }
 
 // registerRoastRetryCoordinatorForSeats registers a ROAST-retry coordinator for
@@ -33,16 +42,20 @@ func (s operatorKeyRoastSigner) Sign(payload []byte) ([]byte, error) {
 // Each seat gets its OWN coordinator bound to that seat's member index — the
 // registrar enforces deps.SelfMember == member and drops any mismatch, so a
 // mis-bound seat safely stays on legacy rather than aggregating as the wrong
-// member. The operator-key Signer is shared across seats (one operator identity).
+// member. The operator-key Signer and the member-keyed Verifier are shared across
+// seats: one operator identity signs, and verification is a pure function of the
+// wallet's seat -> operator-address list plus the chain verification primitives.
 //
-// The Verifier is currently a no-op. On the happy path the coordinator never
-// verifies evidence signatures (BeginAttempt -> engine.InteractiveAggregate ->
-// MarkSucceeded touches neither Signer nor Verifier), so a valid BIP-340
-// signature is produced without it. A real member-keyed verifier
-// (member index -> operator public key -> chain.Signing().VerifyWithPublicKey)
-// is a required follow-up before the retry/blame path's integrity can be
-// trusted, and it must be flipped from no-op to real atomically across the
-// operator set so the retry-path signature format stays consistent.
+// The Verifier authenticates the retry/blame layer: it decodes the signer's
+// public-key envelope, binds it to the claimed seat via
+// PublicKeyBytesToAddress == signingGroupOperators[member-1], and checks the
+// signature with chain.Signing().VerifyWithPublicKey (see
+// roast_operator_signature_verifier_frost_native_roast_retry.go). The happy path
+// never verifies evidence signatures (BeginAttempt -> engine.InteractiveAggregate
+// -> MarkSucceeded touches neither Signer nor Verifier), so this switch from the
+// former no-op verifier is inert until an actual ROAST retry occurs — but it must
+// be adopted by the whole operator set together, because an upgraded verifier
+// rejects a peer that still emits bare (non-enveloped) signatures.
 //
 // KNOWN LIMITATION (single-wallet only): the retry registry is keyed by member
 // index alone (RegisterRoastRetryCoordinatorForMember), not by wallet+member. A
@@ -50,11 +63,24 @@ func (s operatorKeyRoastSigner) Sign(payload []byte) ([]byte, error) {
 // indices (each wallet's group is 1..N), and the later registration replaces the
 // earlier — so this wiring is correct only while a node controls a single FROST
 // wallet, which matches the current experimental deployment. Making the registry
-// wallet-scoped is a prerequisite for multi-wallet FROST and is tracked with the
-// verifier follow-up.
+// wallet-scoped is a prerequisite for multi-wallet FROST.
 func registerRoastRetryCoordinatorForSeats(n *node, signers []*signer) {
+	if len(signers) == 0 {
+		return
+	}
+
 	operatorSigner := operatorKeyRoastSigner{signing: n.chain.Signing()}
-	verifier := roast.NoOpSignatureVerifier()
+	// All signers belong to one wallet, so any signer's seat -> operator-address
+	// list is the whole group's. Copy it so the verifier can never be affected by
+	// later mutation of the wallet's slice.
+	operatorAddresses := append(
+		[]chain.Address(nil),
+		signers[0].wallet.signingGroupOperators...,
+	)
+	verifier := memberKeyedRoastSignatureVerifier{
+		signing:           n.chain.Signing(),
+		operatorAddresses: operatorAddresses,
+	}
 
 	for _, s := range signers {
 		member := s.signingGroupMemberIndex


### PR DESCRIPTION
## What

Replaces the no-op `roast.SignatureVerifier` wired in #4139 with a **real member-keyed verifier**, so the ROAST retry/blame path actually authenticates evidence. Stacked on #4139.

## Why

With a no-op verifier, a valid-looking `LocalEvidenceSnapshot` or `TransitionMessage` from **any** source was accepted — the coordinator could not tell whether a signature really came from the operator seated at the claimed member index. The happy path never verifies evidence signatures, but the retry/blame path's integrity depends on this check.

## Design

Mirrors the existing FROST DKG-result-signing verification (`frost_dkg_result_signing.go`). The node knows each seat only by operator **address** (`wallet.signingGroupOperators`), while `chain.Signing.VerifyWithPublicKey` needs the public key. So:

- **`operatorKeyRoastSigner`** now emits a self-describing envelope — `[version][pubKeyLen][publicKey][signature]` — carrying the signer's operator public key alongside the raw operator-key signature.
- **`memberKeyedRoastSignatureVerifier`**:
  1. decodes the envelope,
  2. binds the carried public key to the claimed seat via `PublicKeyBytesToAddress(pubKey) == signingGroupOperators[member-1]`,
  3. verifies the raw signature against that public key with `VerifyWithPublicKey`.

All three must hold, so a signature valid under the **wrong** seat's key — or a key not seated at the claimed member — is rejected. The envelope is a private contract between the Signer and Verifier; the coordinator treats signatures as opaque bytes (per `pkg/frost/roast`).

## Deployment note (atomic flip)

The switch is **inert on the happy path** (`BeginAttempt → InteractiveAggregate → MarkSucceeded` touches neither Signer nor Verifier) but must be adopted by the whole operator set at once: an upgraded verifier rejects a peer that still emits bare (non-enveloped) signatures during a retry. This is fine for the current single-wallet experimental deployment.

## Tests

Real secp256k1 operator crypto via `local_v1` (not stubs):
- envelope round-trip + malformed/empty rejection;
- verifier accepts the correct seat; rejects wrong-seat attribution, an out-of-group key, a tampered payload, an out-of-range member index, and a bare signature;
- **integration through a real `roast` coordinator's `RecordEvidence`**: a valid seat snapshot is recorded; a snapshot signed by the wrong operator is rejected with `roast.ErrSignatureInvalid`.

`go test -race -tags "frost_native frost_roast_retry" ./pkg/tbtc/ ./pkg/frost/signing/` — green. All build-tag combos compile; full cgo node binary links.

## Remaining follow-up

Still keyed by member index alone, so single-wallet-per-node remains a prerequisite for multi-wallet FROST (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Htk7v5FLAZrYwEkw88Dv9