### PR TITLE
fix(tbtc): route wallet lifecycle by signing scheme

### DIFF
--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -2344,16 +2344,26 @@ func resolveWalletPublicKeyHashForWalletID(
 func (tc *TbtcChain) OnWalletClosed(
 	handler func(event *tbtc.WalletClosedEvent),
 ) subscription.EventSubscription {
-	onEvent := func(
+	onEcdsaEvent := func(
 		walletID [32]byte,
 		blockNumber uint64,
 	) {
 		handler(&tbtc.WalletClosedEvent{
 			WalletID:    walletID,
+			Scheme:      tbtc.WalletSchemeECDSA,
 			BlockNumber: blockNumber,
 		})
 	}
-	return tc.walletRegistry.WalletClosedEvent(nil, nil).OnEvent(onEvent)
+
+	ecdsaSubscription := tc.walletRegistry.WalletClosedEvent(nil, nil).OnEvent(
+		onEcdsaEvent,
+	)
+	frostSubscription := tc.onFrostWalletClosed(handler)
+
+	return subscription.NewEventSubscription(func() {
+		ecdsaSubscription.Unsubscribe()
+		frostSubscription.Unsubscribe()
+	})
 }
 
 func (tc *TbtcChain) ComputeMainUtxoHash(

--- a/pkg/chain/ethereum/tbtc_sortition_chain_views.go
+++ b/pkg/chain/ethereum/tbtc_sortition_chain_views.go
@@ -22,9 +22,9 @@ import (
 // views bind the sortition.Chain surface to one specific pool/registry with NO
 // hasFrostAuthorization() switch, so the caller can run one MonitorPool per pool.
 //
-// They are used ONLY by the pool-monitoring loops; TbtcChain's own
-// sortition.Chain methods (consumed by the heartbeat and other callers) are left
-// unchanged, so this introduces no behavior change outside the monitor loops.
+// The pool-monitoring loops use these views directly. Wallet heartbeat actions
+// also select the view matching the executing wallet, so a process-wide FROST
+// configuration cannot redirect a draining legacy wallet's authorization check.
 // GetOperatorID stays bound to whichever pool the view targets, matching the
 // per-pool member IDs (the legacy view's GetOperatorID equals TbtcChain's
 // deliberately-ECDSA-bound GetOperatorID).
@@ -214,8 +214,9 @@ func (c *frostSortitionChain) UpdateOperatorStatus() error {
 }
 
 // LegacyECDSASortitionChain returns a sortition.Chain bound explicitly to the
-// legacy ECDSA sortition pool, for ECDSA pool monitoring during the FROST
-// migration drain (independent of whether FROST authorization is configured).
+// legacy ECDSA sortition pool, for pool monitoring and legacy wallet actions
+// during the FROST migration drain (independent of whether FROST authorization
+// is configured).
 func (tc *TbtcChain) LegacyECDSASortitionChain() sortition.Chain {
 	return &ecdsaSortitionChain{
 		sortitionPoolView: sortitionPoolView{
@@ -229,7 +230,7 @@ func (tc *TbtcChain) LegacyECDSASortitionChain() sortition.Chain {
 // FrostSortitionChain returns a sortition.Chain bound explicitly to the FROST
 // sortition pool, and a flag reporting whether FROST authorization is configured
 // for this node. When the flag is false, the returned chain is nil and FROST
-// pool monitoring must not be started.
+// pool monitoring or wallet actions must not be started.
 func (tc *TbtcChain) FrostSortitionChain() (sortition.Chain, bool) {
 	if !tc.hasFrostAuthorization() {
 		return nil, false

--- a/pkg/chain/ethereum/tbtc_test.go
+++ b/pkg/chain/ethereum/tbtc_test.go
@@ -2,6 +2,7 @@ package ethereum
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
 	"errors"
@@ -285,6 +286,193 @@ func TestCalculateInactivityClaimHash(t *testing.T) {
 		expectedHash,
 		hex.EncodeToString(hash[:]),
 	)
+}
+
+func TestCalculateFrostInactivityClaimHash(t *testing.T) {
+	chainID := big.NewInt(31337)
+	nonce := big.NewInt(3)
+
+	xOnlyOutputKeyBytes, err := hex.DecodeString(
+		"9a0544440cc47779235ccb76d669590c2cd20c7e431f97e17a1093faf03291c4",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var xOnlyOutputKey [32]byte
+	copy(xOnlyOutputKey[:], xOnlyOutputKeyBytes)
+
+	inactiveMembersIndexes := []*big.Int{
+		big.NewInt(1), big.NewInt(2), big.NewInt(30),
+	}
+
+	hash, err := calculateFrostInactivityClaimHash(
+		chainID,
+		nonce,
+		xOnlyOutputKey,
+		inactiveMembersIndexes,
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Vector generated from FrostInactivity.verifyClaim's exact Solidity
+	// encoding: abi.encode(uint256,uint256,bytes32,uint256[],bool). The bytes32
+	// key is static; using the legacy dynamic bytes public key changes this hash.
+	expectedHash := "4e42a992e062421b59b57f6904544d68d65b6a8434a2d579b3d1d74a3f1a0b59"
+
+	testutils.AssertStringsEqual(
+		t,
+		"FROST inactivity hash",
+		expectedHash,
+		hex.EncodeToString(hash[:]),
+	)
+}
+
+func TestInactivityClaimChainForWalletBindsRegistryAndPool(t *testing.T) {
+	tc, ecdsaPool, frostPool, _ := newTbtcChainForSortitionViewTest(true)
+
+	legacyView, err := tc.InactivityClaimChainForWallet(tbtcpkg.WalletSchemeECDSA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacyView != tc {
+		t.Fatal("legacy inactivity view must remain bound to TbtcChain")
+	}
+	if tc.sortitionPool != ecdsaPool {
+		t.Fatal("legacy inactivity view must use the ECDSA operator ID pool")
+	}
+
+	frostView, err := tc.InactivityClaimChainForWallet(tbtcpkg.WalletSchemeFROST)
+	if err != nil {
+		t.Fatal(err)
+	}
+	typedFrostView, ok := frostView.(*frostInactivityClaimChain)
+	if !ok {
+		t.Fatalf("expected *frostInactivityClaimChain, got [%T]", frostView)
+	}
+	if typedFrostView.TbtcChain != tc {
+		t.Fatal("FROST inactivity view must reference the owning chain")
+	}
+	if typedFrostView.frostSortitionPool != frostPool {
+		t.Fatal("FROST inactivity view must use the FROST operator ID pool")
+	}
+	if typedFrostView.frostSortitionPool == ecdsaPool {
+		t.Fatal("FROST inactivity view must not use the ECDSA operator ID pool")
+	}
+}
+
+func TestConvertFrostWalletClosedEventMarksFrostScheme(t *testing.T) {
+	walletID := [32]byte{0xaa, 0xbb, 0xcc}
+	event := convertFrostWalletClosedEvent(
+		&frostabi.FrostWalletRegistryWalletClosed{
+			WalletID: walletID,
+			Raw: types.Log{
+				BlockNumber: 123,
+			},
+		},
+	)
+
+	if event.WalletID != walletID {
+		t.Fatalf("unexpected wallet ID [0x%x]", event.WalletID)
+	}
+	if event.Scheme != tbtcpkg.WalletSchemeFROST {
+		t.Fatalf("unexpected wallet scheme [%v]", event.Scheme)
+	}
+	if event.BlockNumber != 123 {
+		t.Fatalf("unexpected block number [%v]", event.BlockNumber)
+	}
+}
+
+func TestConvertFrostWalletClosedEventRejectsNil(t *testing.T) {
+	if event := convertFrostWalletClosedEvent(nil); event != nil {
+		t.Fatalf("expected nil event, got [%+v]", event)
+	}
+}
+
+func TestHandleFrostWalletClosedEventsStopsAfterCancellation(t *testing.T) {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	events := make(chan *tbtcpkg.WalletClosedEvent, 1)
+	events <- &tbtcpkg.WalletClosedEvent{WalletID: [32]byte{0xaa}}
+	cancelCtx()
+
+	handled := false
+	handleFrostWalletClosedEvents(
+		ctx,
+		events,
+		func(event *tbtcpkg.WalletClosedEvent) {
+			handled = true
+		},
+	)
+
+	if handled {
+		t.Fatal("handler invoked after cancellation")
+	}
+}
+
+func TestConvertFrostInactivityClaimedEvent(t *testing.T) {
+	walletID := [32]byte{0xaa, 0xbb, 0xcc}
+	nonce := big.NewInt(17)
+	notifier := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	event := convertFrostInactivityClaimedEvent(
+		&frostabi.FrostWalletRegistryInactivityClaimed{
+			WalletID: walletID,
+			Nonce:    nonce,
+			Notifier: notifier,
+			Raw: types.Log{
+				BlockNumber: 123,
+			},
+		},
+	)
+
+	if event.WalletID != walletID {
+		t.Fatalf("unexpected wallet ID [0x%x]", event.WalletID)
+	}
+	if event.Nonce.Cmp(nonce) != 0 {
+		t.Fatalf("unexpected nonce [%v]", event.Nonce)
+	}
+	if event.Notifier != chain.Address(notifier.Hex()) {
+		t.Fatalf("unexpected notifier [%v]", event.Notifier)
+	}
+	if event.BlockNumber != 123 {
+		t.Fatalf("unexpected block number [%v]", event.BlockNumber)
+	}
+}
+
+func TestConvertFrostInactivityClaimedEventRejectsNil(t *testing.T) {
+	if event := convertFrostInactivityClaimedEvent(nil); event != nil {
+		t.Fatalf("expected nil event, got [%+v]", event)
+	}
+}
+
+func TestEmitFrostInactivityClaimedEventStopsAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		emitFrostInactivityClaimedEvent(
+			ctx,
+			make(chan *tbtcpkg.InactivityClaimedEvent),
+			&tbtcpkg.InactivityClaimedEvent{},
+		)
+		close(done)
+	}()
+
+	<-done
+}
+
+func TestFrostInactivityClaimChainRejectsNilInputs(t *testing.T) {
+	if _, err := convertFrostInactivityClaimToABI(nil); err == nil {
+		t.Fatal("expected nil inactivity claim error")
+	}
+
+	view := &frostInactivityClaimChain{}
+	err := view.SubmitInactivityClaim(&tbtcpkg.InactivityClaim{}, nil, nil)
+	if err == nil || err.Error() != "inactivity claim nonce is nil" {
+		t.Fatalf("unexpected nil nonce error: [%v]", err)
+	}
 }
 
 func TestCalculateWalletID(t *testing.T) {

--- a/pkg/chain/ethereum/tbtc_wallet_registry_views.go
+++ b/pkg/chain/ethereum/tbtc_wallet_registry_views.go
@@ -1,0 +1,566 @@
+package ethereum
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/event"
+	chainutil "github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
+
+	"github.com/keep-network/keep-core/pkg/chain"
+	frostabi "github.com/keep-network/keep-core/pkg/chain/ethereum/frost/gen/abi"
+	"github.com/keep-network/keep-core/pkg/protocol/inactivity"
+	"github.com/keep-network/keep-core/pkg/subscription"
+	"github.com/keep-network/keep-core/pkg/tbtc"
+)
+
+var _ tbtc.WalletInactivityClaimChain = (*frostInactivityClaimChain)(nil)
+
+// frostInactivityClaimChain binds inactivity operations to the FROST wallet
+// registry and its independent sortition pool. The embedded TbtcChain supplies
+// common Bridge, block-counter, and operator-signing operations.
+type frostInactivityClaimChain struct {
+	*TbtcChain
+}
+
+// InactivityClaimChainForWallet returns a registry-bound inactivity chain for
+// the wallet scheme. The legacy TbtcChain implementation remains explicitly
+// ECDSA-bound; FROST uses a view overriding every registry-specific operation.
+func (tc *TbtcChain) InactivityClaimChainForWallet(
+	walletScheme tbtc.WalletScheme,
+) (tbtc.WalletInactivityClaimChain, error) {
+	switch walletScheme {
+	case tbtc.WalletSchemeECDSA:
+		return tc, nil
+	case tbtc.WalletSchemeFROST:
+		if tc.frostWalletRegistry == nil || tc.frostSortitionPool == nil {
+			return nil, fmt.Errorf("FrostWalletRegistry is not configured")
+		}
+
+		return &frostInactivityClaimChain{TbtcChain: tc}, nil
+	default:
+		return nil, fmt.Errorf("unsupported wallet scheme [%v]", walletScheme)
+	}
+}
+
+func (fic *frostInactivityClaimChain) GetOperatorID(
+	operatorAddress chain.Address,
+) (chain.OperatorID, error) {
+	return fic.GetFrostOperatorID(operatorAddress)
+}
+
+func (fic *frostInactivityClaimChain) OnInactivityClaimed(
+	handler func(event *tbtc.InactivityClaimedEvent),
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	sink := make(chan *frostabi.FrostWalletRegistryInactivityClaimed)
+	events := make(chan *tbtc.InactivityClaimedEvent)
+	sub := fic.watchFrostInactivityClaimed(sink)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event, ok := <-sink:
+				if !ok {
+					return
+				}
+				if event == nil {
+					logger.Warn("received nil FROST InactivityClaimed event")
+					continue
+				}
+
+				emitFrostInactivityClaimedEvent(
+					ctx,
+					events,
+					convertFrostInactivityClaimedEvent(event),
+				)
+			}
+		}
+	}()
+	go fic.monitorPastFrostInactivityClaimedEvents(ctx, events)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-events:
+				if ctx.Err() != nil {
+					return
+				}
+				handler(event)
+			}
+		}
+	}()
+
+	return subscription.NewEventSubscription(func() {
+		cancelCtx()
+		sub.Unsubscribe()
+	})
+}
+
+func convertFrostInactivityClaimedEvent(
+	event *frostabi.FrostWalletRegistryInactivityClaimed,
+) *tbtc.InactivityClaimedEvent {
+	if event == nil {
+		return nil
+	}
+
+	return &tbtc.InactivityClaimedEvent{
+		WalletID:    event.WalletID,
+		Nonce:       event.Nonce,
+		Notifier:    chain.Address(event.Notifier.Hex()),
+		BlockNumber: event.Raw.BlockNumber,
+	}
+}
+
+func (fic *frostInactivityClaimChain) watchFrostInactivityClaimed(
+	sink chan<- *frostabi.FrostWalletRegistryInactivityClaimed,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return fic.frostWalletRegistry.WatchInactivityClaimed(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+			nil,
+		)
+	}
+
+	return chainutil.WithResubscription(
+		chainutil.SubscriptionBackoffMax,
+		subscribeFn,
+		chainutil.SubscriptionAlertThreshold,
+		func(elapsed time.Duration) {
+			logger.Warnf(
+				"subscription to FROST InactivityClaimed had to be retried [%s] "+
+					"since the last attempt; please inspect host chain connectivity",
+				elapsed,
+			)
+		},
+		func(err error) {
+			logger.Errorf(
+				"subscription to FROST InactivityClaimed failed with error: [%v]; "+
+					"resubscription attempt will be performed",
+				err,
+			)
+		},
+	)
+}
+
+func (fic *frostInactivityClaimChain) monitorPastFrostInactivityClaimedEvents(
+	ctx context.Context,
+	events chan<- *tbtc.InactivityClaimedEvent,
+) {
+	ticker := time.NewTicker(chainutil.DefaultSubscribeOptsTick)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			lastBlock, err := fic.blockCounter.CurrentBlock()
+			if err != nil {
+				logger.Errorf(
+					"FROST InactivityClaimed subscription failed to pull events: [%v]",
+					err,
+				)
+				continue
+			}
+
+			iterator, err := fic.frostWalletRegistry.FilterInactivityClaimed(
+				&bind.FilterOpts{
+					Start:   frostSubscriptionMonitoringStartBlock(lastBlock),
+					Context: ctx,
+				},
+				nil,
+			)
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+
+				logger.Errorf(
+					"FROST InactivityClaimed subscription failed to pull events: [%v]",
+					err,
+				)
+				continue
+			}
+
+			for iterator.Next() {
+				emitFrostInactivityClaimedEvent(
+					ctx,
+					events,
+					convertFrostInactivityClaimedEvent(iterator.Event),
+				)
+			}
+			if err := iterator.Error(); err != nil {
+				logger.Errorf(
+					"FROST InactivityClaimed subscription iterator failed: [%v]",
+					err,
+				)
+			}
+			if err := iterator.Close(); err != nil {
+				logger.Warnf(
+					"failed to close FROST InactivityClaimed iterator: [%v]",
+					err,
+				)
+			}
+		}
+	}
+}
+
+func emitFrostInactivityClaimedEvent(
+	ctx context.Context,
+	events chan<- *tbtc.InactivityClaimedEvent,
+	event *tbtc.InactivityClaimedEvent,
+) {
+	select {
+	case <-ctx.Done():
+	case events <- event:
+	}
+}
+
+func (fic *frostInactivityClaimChain) SubmitInactivityClaim(
+	claim *tbtc.InactivityClaim,
+	nonce *big.Int,
+	groupMembers []uint32,
+) error {
+	if nonce == nil {
+		return fmt.Errorf("inactivity claim nonce is nil")
+	}
+
+	abiClaim, err := convertFrostInactivityClaimToABI(claim)
+	if err != nil {
+		return err
+	}
+
+	return fic.submitFrostWalletRegistryTransaction(
+		"notifyOperatorInactivity",
+		func(opts *bind.TransactOpts) (*types.Transaction, error) {
+			return fic.frostWalletRegistry.NotifyOperatorInactivity(
+				opts,
+				abiClaim,
+				nonce,
+				groupMembers,
+			)
+		},
+	)
+}
+
+func convertFrostInactivityClaimToABI(
+	claim *tbtc.InactivityClaim,
+) (frostabi.FrostInactivityClaim, error) {
+	if claim == nil {
+		return frostabi.FrostInactivityClaim{}, fmt.Errorf(
+			"inactivity claim is nil",
+		)
+	}
+
+	inactiveMembersIndices := make([]*big.Int, len(claim.InactiveMembersIndices))
+	for i, memberIndex := range claim.InactiveMembersIndices {
+		inactiveMembersIndices[i] = big.NewInt(int64(memberIndex))
+	}
+
+	signingMembersIndices := make([]*big.Int, len(claim.SigningMembersIndices))
+	for i, memberIndex := range claim.SigningMembersIndices {
+		signingMembersIndices[i] = big.NewInt(int64(memberIndex))
+	}
+
+	return frostabi.FrostInactivityClaim{
+		WalletID:               claim.WalletID,
+		InactiveMembersIndices: inactiveMembersIndices,
+		HeartbeatFailed:        claim.HeartbeatFailed,
+		Signatures:             claim.Signatures,
+		SigningMembersIndices:  signingMembersIndices,
+	}, nil
+}
+
+func (fic *frostInactivityClaimChain) CalculateInactivityClaimHash(
+	claim *inactivity.ClaimPreimage,
+) (inactivity.ClaimHash, error) {
+	if claim == nil || claim.WalletPublicKey == nil || claim.WalletPublicKey.X == nil {
+		return inactivity.ClaimHash{}, fmt.Errorf("wallet public key is nil")
+	}
+	if claim.Nonce == nil {
+		return inactivity.ClaimHash{}, fmt.Errorf("inactivity claim nonce is nil")
+	}
+
+	xBytes := claim.WalletPublicKey.X.Bytes()
+	if len(xBytes) > 32 {
+		return inactivity.ClaimHash{}, fmt.Errorf("wrong x-only output key length")
+	}
+
+	var xOnlyOutputKey [32]byte
+	copy(xOnlyOutputKey[32-len(xBytes):], xBytes)
+
+	inactiveMembersIndexes := make([]*big.Int, len(claim.InactiveMembersIndexes))
+	for i, index := range claim.InactiveMembersIndexes {
+		inactiveMembersIndexes[i] = big.NewInt(int64(index))
+	}
+
+	return calculateFrostInactivityClaimHash(
+		fic.chainID,
+		claim.Nonce,
+		xOnlyOutputKey,
+		inactiveMembersIndexes,
+		claim.HeartbeatFailed,
+	)
+}
+
+func calculateFrostInactivityClaimHash(
+	chainID *big.Int,
+	nonce *big.Int,
+	xOnlyOutputKey [32]byte,
+	inactiveMembersIndexes []*big.Int,
+	heartbeatFailed bool,
+) (inactivity.ClaimHash, error) {
+	uint256Type, err := abi.NewType("uint256", "uint256", nil)
+	if err != nil {
+		return inactivity.ClaimHash{}, err
+	}
+	bytes32Type, err := abi.NewType("bytes32", "bytes32", nil)
+	if err != nil {
+		return inactivity.ClaimHash{}, err
+	}
+	uint256SliceType, err := abi.NewType("uint256[]", "uint256[]", nil)
+	if err != nil {
+		return inactivity.ClaimHash{}, err
+	}
+	boolType, err := abi.NewType("bool", "bool", nil)
+	if err != nil {
+		return inactivity.ClaimHash{}, err
+	}
+
+	encoded, err := abi.Arguments{
+		{Type: uint256Type},
+		{Type: uint256Type},
+		{Type: bytes32Type},
+		{Type: uint256SliceType},
+		{Type: boolType},
+	}.Pack(
+		chainID,
+		nonce,
+		xOnlyOutputKey,
+		inactiveMembersIndexes,
+		heartbeatFailed,
+	)
+	if err != nil {
+		return inactivity.ClaimHash{}, err
+	}
+
+	return inactivity.ClaimHash(crypto.Keccak256Hash(encoded)), nil
+}
+
+func (fic *frostInactivityClaimChain) GetInactivityClaimNonce(
+	walletID [32]byte,
+) (*big.Int, error) {
+	nonce, err := fic.frostWalletRegistry.InactivityClaimNonce(
+		&bind.CallOpts{From: fic.key.Address},
+		walletID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get FROST inactivity claim nonce: [%w]",
+			err,
+		)
+	}
+
+	return nonce, nil
+}
+
+// onFrostWalletClosed subscribes to FROST WalletClosed events and marks their
+// source scheme so the node can confirm closure against the correct registry.
+func (tc *TbtcChain) onFrostWalletClosed(
+	handler func(event *tbtc.WalletClosedEvent),
+) subscription.EventSubscription {
+	if tc.frostWalletRegistry == nil {
+		return subscription.NewEventSubscription(func() {})
+	}
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	sink := make(chan *frostabi.FrostWalletRegistryWalletClosed)
+	events := make(chan *tbtc.WalletClosedEvent)
+	sub := tc.watchFrostWalletClosed(sink)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event, ok := <-sink:
+				if !ok {
+					return
+				}
+				if event == nil {
+					logger.Warn("received nil FROST WalletClosed event")
+					continue
+				}
+
+				emitFrostWalletClosedEvent(
+					ctx,
+					events,
+					convertFrostWalletClosedEvent(event),
+				)
+			}
+		}
+	}()
+	go tc.monitorPastFrostWalletClosedEvents(ctx, events)
+	go handleFrostWalletClosedEvents(ctx, events, handler)
+
+	return subscription.NewEventSubscription(func() {
+		cancelCtx()
+		sub.Unsubscribe()
+	})
+}
+
+func emitFrostWalletClosedEvent(
+	ctx context.Context,
+	events chan<- *tbtc.WalletClosedEvent,
+	event *tbtc.WalletClosedEvent,
+) {
+	select {
+	case <-ctx.Done():
+	case events <- event:
+	}
+}
+
+func handleFrostWalletClosedEvents(
+	ctx context.Context,
+	events <-chan *tbtc.WalletClosedEvent,
+	handler func(event *tbtc.WalletClosedEvent),
+) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-events:
+			if !ok {
+				return
+			}
+
+			// If cancellation raced with event delivery, do not invoke the
+			// subscriber after it has unsubscribed.
+			if ctx.Err() != nil {
+				return
+			}
+
+			handler(event)
+		}
+	}
+}
+
+func convertFrostWalletClosedEvent(
+	event *frostabi.FrostWalletRegistryWalletClosed,
+) *tbtc.WalletClosedEvent {
+	if event == nil {
+		return nil
+	}
+
+	return &tbtc.WalletClosedEvent{
+		WalletID:    event.WalletID,
+		Scheme:      tbtc.WalletSchemeFROST,
+		BlockNumber: event.Raw.BlockNumber,
+	}
+}
+
+func (tc *TbtcChain) watchFrostWalletClosed(
+	sink chan<- *frostabi.FrostWalletRegistryWalletClosed,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return tc.frostWalletRegistry.WatchWalletClosed(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+			nil,
+		)
+	}
+
+	return chainutil.WithResubscription(
+		chainutil.SubscriptionBackoffMax,
+		subscribeFn,
+		chainutil.SubscriptionAlertThreshold,
+		func(elapsed time.Duration) {
+			logger.Warnf(
+				"subscription to FROST WalletClosed had to be retried [%s] "+
+					"since the last attempt; please inspect host chain connectivity",
+				elapsed,
+			)
+		},
+		func(err error) {
+			logger.Errorf(
+				"subscription to FROST WalletClosed failed with error: [%v]; "+
+					"resubscription attempt will be performed",
+				err,
+			)
+		},
+	)
+}
+
+func (tc *TbtcChain) monitorPastFrostWalletClosedEvents(
+	ctx context.Context,
+	events chan<- *tbtc.WalletClosedEvent,
+) {
+	ticker := time.NewTicker(chainutil.DefaultSubscribeOptsTick)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			lastBlock, err := tc.blockCounter.CurrentBlock()
+			if err != nil {
+				logger.Errorf(
+					"FROST WalletClosed subscription failed to pull events: [%v]",
+					err,
+				)
+				continue
+			}
+
+			iterator, err := tc.frostWalletRegistry.FilterWalletClosed(
+				&bind.FilterOpts{
+					Start:   frostSubscriptionMonitoringStartBlock(lastBlock),
+					Context: ctx,
+				},
+				nil,
+			)
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+
+				logger.Errorf(
+					"FROST WalletClosed subscription failed to pull events: [%v]",
+					err,
+				)
+				continue
+			}
+
+			for iterator.Next() {
+				emitFrostWalletClosedEvent(
+					ctx,
+					events,
+					convertFrostWalletClosedEvent(iterator.Event),
+				)
+			}
+			if err := iterator.Error(); err != nil {
+				logger.Errorf(
+					"FROST WalletClosed subscription iterator failed: [%v]",
+					err,
+				)
+			}
+			if err := iterator.Close(); err != nil {
+				logger.Warnf(
+					"failed to close FROST WalletClosed iterator: [%v]",
+					err,
+				)
+			}
+		}
+	}
+}

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -174,6 +174,28 @@ type InactivityClaimChain interface {
 	GetInactivityClaimNonce(walletID [32]byte) (*big.Int, error)
 }
 
+// WalletInactivityClaimChain defines the complete chain surface used while
+// executing an inactivity claim for a wallet. Implementations can bind this
+// surface to a specific wallet registry and sortition pool. This is important
+// during the ECDSA-to-FROST migration, when both registries are active and use
+// independent wallet and operator identifiers.
+type WalletInactivityClaimChain interface {
+	InactivityClaimChain
+
+	// GetOperatorID returns the operator identifier from the sortition pool
+	// associated with the wallet registry handling the inactivity claim.
+	GetOperatorID(operatorAddress chain.Address) (chain.OperatorID, error)
+
+	// BlockCounter returns the chain's block counter.
+	BlockCounter() (chain.BlockCounter, error)
+
+	// Signing returns the chain's signer.
+	Signing() chain.Signing
+
+	// GetWallet gets the Bridge data needed to resolve the registry wallet ID.
+	GetWallet(walletPublicKeyHash [20]byte) (*WalletChainData, error)
+}
+
 // DKGChainResultHash represents a hash of the DKGChainResult. The algorithm
 // used is specific to the chain.
 type DKGChainResultHash [32]byte
@@ -235,10 +257,21 @@ type DKGParameters struct {
 	ApprovePrecedencePeriodBlocks uint64
 }
 
+// WalletScheme identifies the registry and cryptographic scheme used by a
+// wallet.
+type WalletScheme uint8
+
+const (
+	WalletSchemeUnknown WalletScheme = iota
+	WalletSchemeECDSA
+	WalletSchemeFROST
+)
+
 // WalletClosedEvent represents a wallet closed event. It is emitted when the
 // wallet is closed in the wallet registry.
 type WalletClosedEvent struct {
 	WalletID    [32]byte
+	Scheme      WalletScheme
 	BlockNumber uint64
 }
 
@@ -263,7 +296,8 @@ type BridgeChain interface {
 
 	// OnWalletClosed registers a callback that is invoked when an on-chain
 	// notification of the wallet closed is seen. The notification occurs when
-	// the wallet is closed or terminated.
+	// the wallet is closed or terminated. The event identifies the registry
+	// scheme that emitted it.
 	OnWalletClosed(
 		func(event *WalletClosedEvent),
 	) subscription.EventSubscription

--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -71,6 +71,10 @@ type localChain struct {
 	walletsMutex sync.Mutex
 	wallets      map[[20]byte]*WalletChainData
 
+	walletRegistrationChecksMutex sync.Mutex
+	ecdsaWalletRegistrationChecks int
+	frostWalletRegistrationChecks int
+
 	inactivityNonceMutex sync.Mutex
 	inactivityNonces     map[[32]byte]uint64
 
@@ -953,6 +957,10 @@ func (lc *localChain) WalletPublicKeyHashForWalletID(
 }
 
 func (lc *localChain) IsWalletRegistered(EcdsaWalletID [32]byte) (bool, error) {
+	lc.walletRegistrationChecksMutex.Lock()
+	lc.ecdsaWalletRegistrationChecks++
+	lc.walletRegistrationChecksMutex.Unlock()
+
 	lc.walletsMutex.Lock()
 	defer lc.walletsMutex.Unlock()
 
@@ -974,6 +982,10 @@ func (lc *localChain) FrostWalletRegistryAvailable() bool {
 }
 
 func (lc *localChain) IsFrostWalletRegistered(walletID [32]byte) (bool, error) {
+	lc.walletRegistrationChecksMutex.Lock()
+	lc.frostWalletRegistrationChecks++
+	lc.walletRegistrationChecksMutex.Unlock()
+
 	lc.walletsMutex.Lock()
 	defer lc.walletsMutex.Unlock()
 
@@ -987,7 +999,7 @@ func (lc *localChain) IsFrostWalletRegistered(walletID [32]byte) (bool, error) {
 		}
 	}
 
-	return false, fmt.Errorf("wallet not found")
+	return false, nil
 }
 
 func (lc *localChain) setWallet(

--- a/pkg/tbtc/deduplicator.go
+++ b/pkg/tbtc/deduplicator.go
@@ -41,8 +41,9 @@ type deduplicator struct {
 	dkgResultHashCache *cache.TimeCache
 	walletClosedCache  *cache.TimeCache
 
-	mutex      sync.Mutex
-	inProgress map[string]struct{}
+	mutex          sync.Mutex
+	inProgress     map[string]struct{}
+	pendingReplays map[string]struct{}
 }
 
 func newDeduplicator() *deduplicator {
@@ -51,6 +52,7 @@ func newDeduplicator() *deduplicator {
 		dkgResultHashCache: cache.NewTimeCache(DKGResultHashCachePeriod),
 		walletClosedCache:  cache.NewTimeCache(WalletClosedCachePeriod),
 		inProgress:         make(map[string]struct{}),
+		pendingReplays:     make(map[string]struct{}),
 	}
 }
 
@@ -73,6 +75,7 @@ func (d *deduplicator) beginDKGStarted(
 		d.dkgSeedCache,
 		cacheKey,
 		"dkg-started:"+cacheKey,
+		false,
 	)
 }
 
@@ -86,6 +89,20 @@ func (d *deduplicator) beginDKGResultSubmitted(
 		d.dkgResultHashCache,
 		cacheKey,
 		"dkg-result-submitted:"+cacheKey,
+		false,
+	)
+}
+
+func (d *deduplicator) beginWalletClosed(
+	walletScheme WalletScheme,
+	walletID [32]byte,
+) (*deduplicationLease, bool) {
+	cacheKey := walletClosedCacheKey(walletScheme, walletID)
+	return d.begin(
+		d.walletClosedCache,
+		cacheKey,
+		"wallet-closed:"+cacheKey,
+		true,
 	)
 }
 
@@ -93,6 +110,7 @@ func (d *deduplicator) begin(
 	completedCache *cache.TimeCache,
 	cacheKey string,
 	inProgressKey string,
+	preserveConcurrentReplay bool,
 ) (*deduplicationLease, bool) {
 	completedCache.Sweep()
 
@@ -103,6 +121,12 @@ func (d *deduplicator) begin(
 		return nil, false
 	}
 	if _, ok := d.inProgress[inProgressKey]; ok {
+		if preserveConcurrentReplay {
+			if d.pendingReplays == nil {
+				d.pendingReplays = make(map[string]struct{})
+			}
+			d.pendingReplays[inProgressKey] = struct{}{}
+		}
 		return nil, false
 	}
 	if d.inProgress == nil {
@@ -118,18 +142,38 @@ func (d *deduplicator) begin(
 	}, true
 }
 
-func (dl *deduplicationLease) finish(completed bool) {
+// finish releases the lease. When handling failed and a concurrent replay was
+// recorded, it keeps the lease active and asks the owner to retry immediately.
+func (dl *deduplicationLease) finish(completed bool) bool {
 	dl.owner.mutex.Lock()
 	defer dl.owner.mutex.Unlock()
 
 	if _, ok := dl.owner.inProgress[dl.inProgressKey]; !ok {
-		return
+		return false
+	}
+
+	if completed {
+		delete(dl.owner.inProgress, dl.inProgressKey)
+		delete(dl.owner.pendingReplays, dl.inProgressKey)
+		dl.cache.Add(dl.cacheKey)
+		return false
+	}
+
+	if _, ok := dl.owner.pendingReplays[dl.inProgressKey]; ok {
+		delete(dl.owner.pendingReplays, dl.inProgressKey)
+		return true
 	}
 
 	delete(dl.owner.inProgress, dl.inProgressKey)
-	if completed {
-		dl.cache.Add(dl.cacheKey)
-	}
+	return false
+}
+
+func (dl *deduplicationLease) release() {
+	dl.owner.mutex.Lock()
+	defer dl.owner.mutex.Unlock()
+
+	delete(dl.owner.inProgress, dl.inProgressKey)
+	delete(dl.owner.pendingReplays, dl.inProgressKey)
 }
 
 // notifyDKGStarted notifies the client wants to start the distributed key
@@ -177,22 +221,10 @@ func dkgResultSubmittedCacheKey(
 		strconv.FormatUint(block, 10)
 }
 
-func (d *deduplicator) notifyWalletClosed(
-	WalletID [32]byte,
-) bool {
-	d.walletClosedCache.Sweep()
-
-	// Use wallet ID converted to string as the cache key.
-	cacheKey := hex.EncodeToString(WalletID[:])
-
-	// If the key is not in the cache, that means the wallet closure was not
-	// handled yet and the client should proceed with the execution.
-	if !d.walletClosedCache.Has(cacheKey) {
-		d.walletClosedCache.Add(cacheKey)
-		return true
-	}
-
-	// Otherwise, the wallet closure is a duplicate and the client should not
-	// proceed with the execution.
-	return false
+func walletClosedCacheKey(
+	walletScheme WalletScheme,
+	walletID [32]byte,
+) string {
+	return strconv.Itoa(int(normalizeWalletScheme(walletScheme))) + ":" +
+		hex.EncodeToString(walletID[:])
 }

--- a/pkg/tbtc/deduplicator_test.go
+++ b/pkg/tbtc/deduplicator_test.go
@@ -12,7 +12,6 @@ import (
 const (
 	testDKGSeedCachePeriod       = 1 * time.Second
 	testDKGResultHashCachePeriod = 1 * time.Second
-	testWalletClosedCachePeriod  = 1 * time.Second
 )
 
 func TestNotifyDKGStarted(t *testing.T) {
@@ -136,42 +135,6 @@ func TestNotifyDKGResultSubmitted(t *testing.T) {
 
 	// Add the original parameters again.
 	canProcess = deduplicator.notifyDKGResultSubmitted(big.NewInt(100), hash1, 500)
-	if !canProcess {
-		t.Fatal("should be allowed to process")
-	}
-}
-
-func TestNotifyWalletClosed(t *testing.T) {
-	deduplicator := deduplicator{
-		walletClosedCache: cache.NewTimeCache(testWalletClosedCachePeriod),
-	}
-
-	wallet1 := [32]byte{1}
-	wallet2 := [32]byte{2}
-
-	// Add the first wallet ID.
-	canProcess := deduplicator.notifyWalletClosed(wallet1)
-	if !canProcess {
-		t.Fatal("should be allowed to process")
-	}
-
-	// Add the second wallet ID.
-	canProcess = deduplicator.notifyWalletClosed(wallet2)
-	if !canProcess {
-		t.Fatal("should be allowed to process")
-	}
-
-	// Add the first wallet ID before caching period elapses.
-	canProcess = deduplicator.notifyWalletClosed(wallet1)
-	if canProcess {
-		t.Fatal("should not be allowed to process")
-	}
-
-	// Wait until caching period elapses.
-	time.Sleep(testWalletClosedCachePeriod)
-
-	// Add the first wallet ID again.
-	canProcess = deduplicator.notifyWalletClosed(wallet1)
 	if !canProcess {
 		t.Fatal("should be allowed to process")
 	}

--- a/pkg/tbtc/heartbeat.go
+++ b/pkg/tbtc/heartbeat.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/frost"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
+	"github.com/keep-network/keep-core/pkg/sortition"
 )
 
 const (
@@ -75,14 +76,24 @@ type heartbeatInactivityClaimExecutor interface {
 	) error
 }
 
+// walletSortitionChainProvider supplies sortition views pinned to one wallet
+// scheme. It prevents a process-wide FROST configuration switch from changing
+// the authorization checks performed for legacy ECDSA wallets during the
+// migration drain.
+type walletSortitionChainProvider interface {
+	LegacyECDSASortitionChain() sortition.Chain
+	FrostSortitionChain() (sortition.Chain, bool)
+}
+
 // heartbeatAction is a walletAction implementation handling heartbeat requests
 // from the wallet coordinator.
 type heartbeatAction struct {
 	logger log.StandardLogger
 	chain  Chain
 
-	executingWallet wallet
-	signingExecutor heartbeatSigningExecutor
+	executingWallet      wallet
+	signingExecutor      heartbeatSigningExecutor
+	minimumActiveMembers int
 
 	proposal       *HeartbeatProposal
 	failureCounter *heartbeatFailureCounter
@@ -100,6 +111,7 @@ func newHeartbeatAction(
 	chain Chain,
 	executingWallet wallet,
 	signingExecutor heartbeatSigningExecutor,
+	minimumActiveMembers int,
 	proposal *HeartbeatProposal,
 	failureCounter *heartbeatFailureCounter,
 	inactivityClaimExecutor heartbeatInactivityClaimExecutor,
@@ -112,6 +124,7 @@ func newHeartbeatAction(
 		chain:                   chain,
 		executingWallet:         executingWallet,
 		signingExecutor:         signingExecutor,
+		minimumActiveMembers:    minimumActiveMembers,
 		proposal:                proposal,
 		failureCounter:          failureCounter,
 		inactivityClaimExecutor: inactivityClaimExecutor,
@@ -185,7 +198,7 @@ func (ha *heartbeatAction) execute() error {
 	// If the number of active members during signing was enough, we can
 	// consider the heartbeat procedure as successful.
 	activeMembersCount := len(activityReport.activeMembers)
-	if activeMembersCount >= heartbeatSigningMinimumActiveMembers {
+	if activeMembersCount >= ha.minimumActiveMembers {
 		ha.logger.Infof(
 			"heartbeat generated signature [%s] for message [0x%x]",
 			signature,
@@ -205,7 +218,7 @@ func (ha *heartbeatAction) execute() error {
 			"threshold was not met ([%d/%d] members participated); "+
 			"counting it as inactivity failure",
 		activeMembersCount,
-		heartbeatSigningMinimumActiveMembers,
+		ha.minimumActiveMembers,
 	)
 
 	// Increment the heartbeat inactivity failure counter.
@@ -268,7 +281,12 @@ func (ha *heartbeatAction) actionType() WalletActionType {
 }
 
 func (ha *heartbeatAction) isOperatorUnstaking() (bool, error) {
-	stakingProvider, isRegistered, err := ha.chain.OperatorToStakingProvider()
+	stakingChain, err := ha.sortitionChain()
+	if err != nil {
+		return false, err
+	}
+
+	stakingProvider, isRegistered, err := stakingChain.OperatorToStakingProvider()
 	if err != nil {
 		return false, fmt.Errorf(
 			"failed to get staking provider for operator [%v]",
@@ -282,7 +300,7 @@ func (ha *heartbeatAction) isOperatorUnstaking() (bool, error) {
 
 	// Eligible stake is defined as the currently authorized stake minus the
 	// pending authorization decrease.
-	eligibleStake, err := ha.chain.EligibleStake(stakingProvider)
+	eligibleStake, err := stakingChain.EligibleStake(stakingProvider)
 	if err != nil {
 		return false, fmt.Errorf(
 			"failed to check eligible stake for operator [%v]",
@@ -292,6 +310,46 @@ func (ha *heartbeatAction) isOperatorUnstaking() (bool, error) {
 
 	// The operator is considered unstaking if their eligible stake is `0`.
 	return eligibleStake.Cmp(big.NewInt(0)) == 0, nil
+}
+
+func (ha *heartbeatAction) sortitionChain() (sortition.Chain, error) {
+	provider, ok := ha.chain.(walletSortitionChainProvider)
+	if !ok {
+		// Backward compatibility for non-Ethereum chains and test chains that
+		// expose only one registry.
+		return ha.chain, nil
+	}
+
+	walletPublicKeyHash := bitcoin.PublicKeyHash(ha.executingWallet.publicKey)
+	walletData, err := ha.chain.GetWallet(walletPublicKeyHash)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get wallet data for authorization check [%v]",
+			err,
+		)
+	}
+
+	walletScheme, _, err := walletSchemeAndRegistryID(walletData)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to resolve wallet scheme for authorization check [%v]",
+			err,
+		)
+	}
+
+	switch walletScheme {
+	case WalletSchemeECDSA:
+		return provider.LegacyECDSASortitionChain(), nil
+	case WalletSchemeFROST:
+		frostChain, configured := provider.FrostSortitionChain()
+		if !configured || frostChain == nil {
+			return nil, fmt.Errorf("FROST sortition chain is not configured")
+		}
+
+		return frostChain, nil
+	default:
+		return nil, fmt.Errorf("unsupported wallet scheme [%v]", walletScheme)
+	}
 }
 
 // heartbeatFailureCounter holds counters keeping track of consecutive

--- a/pkg/tbtc/heartbeat_test.go
+++ b/pkg/tbtc/heartbeat_test.go
@@ -10,8 +10,11 @@ import (
 	"testing"
 
 	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/frost"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
+	"github.com/keep-network/keep-core/pkg/sortition"
 )
 
 func TestHeartbeatAction_HappyPath(t *testing.T) {
@@ -50,9 +53,11 @@ func TestHeartbeatAction_HappyPath(t *testing.T) {
 	hostChain.setOperatorsEligibleStake(big.NewInt(100000))
 	hostChain.setHeartbeatProposalValidationResult(proposal, true)
 
-	// Set the active operators count to the minimum required value.
+	// Use a small, FROST-sized activity threshold to verify the action does not
+	// retain the legacy 70-member floor.
+	minimumActiveMembers := 3
 	mockExecutor := &mockHeartbeatSigningExecutor{}
-	mockExecutor.activeOperatorsCount = heartbeatSigningMinimumActiveMembers
+	mockExecutor.activeOperatorsCount = uint32(minimumActiveMembers)
 
 	inactivityClaimExecutor := &mockInactivityClaimExecutor{}
 
@@ -63,6 +68,7 @@ func TestHeartbeatAction_HappyPath(t *testing.T) {
 			publicKey: unmarshalPublicKey(walletPublicKeyHex),
 		},
 		mockExecutor,
+		minimumActiveMembers,
 		proposal,
 		heartbeatFailureCounter,
 		inactivityClaimExecutor,
@@ -142,6 +148,7 @@ func TestHeartbeatAction_OperatorUnstaking(t *testing.T) {
 			publicKey: unmarshalPublicKey(walletPublicKeyHex),
 		},
 		mockExecutor,
+		heartbeatSigningMinimumActiveMembers,
 		proposal,
 		heartbeatFailureCounter,
 		inactivityClaimExecutor,
@@ -163,6 +170,151 @@ func TestHeartbeatAction_OperatorUnstaking(t *testing.T) {
 		nil, // sign not called
 		mockExecutor.requestedMessage,
 	)
+}
+
+func TestHeartbeatAction_LegacyWalletUsesEcdsaStakeInDualStack(t *testing.T) {
+	walletPublicKeyHex, err := hex.DecodeString(
+		"0471e30bca60f6548d7b42582a478ea37ada63b402af7b3ddd57f0c95bb6843175" +
+			"aa0d2053a91a050a6797d85c38f2909cb7027f2344a01986aa2f9f8ca7a0c289",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	walletPublicKey := unmarshalPublicKey(walletPublicKeyHex)
+
+	baseChain := Connect()
+	baseChain.setWallet(
+		bitcoin.PublicKeyHash(walletPublicKey),
+		&WalletChainData{
+			WalletID:      [32]byte{0x01},
+			EcdsaWalletID: [32]byte{0x02},
+			State:         StateLive,
+		},
+	)
+
+	ecdsaView := &heartbeatSortitionView{
+		localChain:    baseChain,
+		eligibleStake: big.NewInt(100),
+	}
+	frostView := &heartbeatSortitionView{
+		localChain:    baseChain,
+		eligibleStake: big.NewInt(0),
+	}
+	dualStackChain := &dualStackHeartbeatChain{
+		localChain: baseChain,
+		ecdsaView:  ecdsaView,
+		frostView:  frostView,
+	}
+
+	action := &heartbeatAction{
+		chain:           dualStackChain,
+		executingWallet: wallet{publicKey: walletPublicKey},
+	}
+
+	isUnstaking, err := action.isOperatorUnstaking()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isUnstaking {
+		t.Fatal("legacy wallet must use its non-zero ECDSA stake")
+	}
+	if ecdsaView.operatorToStakingProviderCalls != 1 || ecdsaView.eligibleStakeCalls != 1 {
+		t.Fatalf("ECDSA stake view was not used: %+v", ecdsaView)
+	}
+	if frostView.operatorToStakingProviderCalls != 0 || frostView.eligibleStakeCalls != 0 {
+		t.Fatalf("FROST stake view must not be used for a legacy wallet: %+v", frostView)
+	}
+}
+
+func TestHeartbeatAction_FrostWalletUsesFrostStakeInDualStack(t *testing.T) {
+	walletPublicKeyHex, err := hex.DecodeString(
+		"0471e30bca60f6548d7b42582a478ea37ada63b402af7b3ddd57f0c95bb6843175" +
+			"aa0d2053a91a050a6797d85c38f2909cb7027f2344a01986aa2f9f8ca7a0c289",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	walletPublicKey := unmarshalPublicKey(walletPublicKeyHex)
+
+	baseChain := Connect()
+	baseChain.setWallet(
+		bitcoin.PublicKeyHash(walletPublicKey),
+		&WalletChainData{
+			WalletID: [32]byte{0x03},
+			State:    StateLive,
+		},
+	)
+
+	ecdsaView := &heartbeatSortitionView{
+		localChain:    baseChain,
+		eligibleStake: big.NewInt(100),
+	}
+	frostView := &heartbeatSortitionView{
+		localChain:    baseChain,
+		eligibleStake: big.NewInt(0),
+	}
+	dualStackChain := &dualStackHeartbeatChain{
+		localChain: baseChain,
+		ecdsaView:  ecdsaView,
+		frostView:  frostView,
+	}
+
+	action := &heartbeatAction{
+		chain:           dualStackChain,
+		executingWallet: wallet{publicKey: walletPublicKey},
+	}
+
+	isUnstaking, err := action.isOperatorUnstaking()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isUnstaking {
+		t.Fatal("FROST wallet must use its zero FROST stake")
+	}
+	if frostView.operatorToStakingProviderCalls != 1 || frostView.eligibleStakeCalls != 1 {
+		t.Fatalf("FROST stake view was not used: %+v", frostView)
+	}
+	if ecdsaView.operatorToStakingProviderCalls != 0 || ecdsaView.eligibleStakeCalls != 0 {
+		t.Fatalf("ECDSA stake view must not be used for a FROST wallet: %+v", ecdsaView)
+	}
+}
+
+type dualStackHeartbeatChain struct {
+	*localChain
+	ecdsaView sortition.Chain
+	frostView sortition.Chain
+}
+
+func (dshc *dualStackHeartbeatChain) LegacyECDSASortitionChain() sortition.Chain {
+	return dshc.ecdsaView
+}
+
+func (dshc *dualStackHeartbeatChain) FrostSortitionChain() (sortition.Chain, bool) {
+	return dshc.frostView, dshc.frostView != nil
+}
+
+type heartbeatSortitionView struct {
+	*localChain
+	eligibleStake *big.Int
+
+	operatorToStakingProviderCalls int
+	eligibleStakeCalls             int
+}
+
+func (hsv *heartbeatSortitionView) OperatorToStakingProvider() (
+	chain.Address,
+	bool,
+	error,
+) {
+	hsv.operatorToStakingProviderCalls++
+	return stakingProvider, true, nil
+}
+
+func (hsv *heartbeatSortitionView) EligibleStake(
+	stakingProvider chain.Address,
+) (*big.Int, error) {
+	hsv.eligibleStakeCalls++
+	return new(big.Int).Set(hsv.eligibleStake), nil
 }
 
 func TestHeartbeatAction_Failure_SigningError(t *testing.T) {
@@ -205,6 +357,7 @@ func TestHeartbeatAction_Failure_SigningError(t *testing.T) {
 			publicKey: unmarshalPublicKey(walletPublicKeyHex),
 		},
 		mockExecutor,
+		heartbeatSigningMinimumActiveMembers,
 		proposal,
 		heartbeatFailureCounter,
 		inactivityClaimExecutor,
@@ -271,9 +424,11 @@ func TestHeartbeatAction_Failure_TooFewActiveOperators(t *testing.T) {
 	hostChain.setOperatorsEligibleStake(big.NewInt(100000))
 	hostChain.setHeartbeatProposalValidationResult(proposal, true)
 
-	// Set the active operators count just below the required number.
+	// Use a small, FROST-sized threshold and set the active operators count just
+	// below the required number.
+	minimumActiveMembers := 4
 	mockExecutor := &mockHeartbeatSigningExecutor{}
-	mockExecutor.activeOperatorsCount = heartbeatSigningMinimumActiveMembers - 1
+	mockExecutor.activeOperatorsCount = uint32(minimumActiveMembers - 1)
 
 	inactivityClaimExecutor := &mockInactivityClaimExecutor{}
 
@@ -284,6 +439,7 @@ func TestHeartbeatAction_Failure_TooFewActiveOperators(t *testing.T) {
 			publicKey: unmarshalPublicKey(walletPublicKeyHex),
 		},
 		mockExecutor,
+		minimumActiveMembers,
 		proposal,
 		heartbeatFailureCounter,
 		inactivityClaimExecutor,
@@ -364,6 +520,7 @@ func TestHeartbeatAction_Failure_CounterExceeded(t *testing.T) {
 			publicKey: unmarshalPublicKey(walletPublicKeyHex),
 		},
 		mockExecutor,
+		heartbeatSigningMinimumActiveMembers,
 		proposal,
 		heartbeatFailureCounter,
 		inactivityClaimExecutor,
@@ -445,6 +602,7 @@ func TestHeartbeatAction_Failure_InactivityExecutionFailure(t *testing.T) {
 			publicKey: unmarshalPublicKey(walletPublicKeyHex),
 		},
 		mockExecutor,
+		heartbeatSigningMinimumActiveMembers,
 		proposal,
 		heartbeatFailureCounter,
 		inactivityClaimExecutor,

--- a/pkg/tbtc/inactivity.go
+++ b/pkg/tbtc/inactivity.go
@@ -32,6 +32,16 @@ const (
 // execution in progress.
 var errInactivityClaimExecutorBusy = fmt.Errorf("inactivity claim executor is busy")
 
+// walletInactivityClaimChainProvider supplies a wallet-scheme-bound inactivity
+// chain. Ethereum implements this interface with separate ECDSA and FROST
+// registry/sortition-pool views. Chains that do not implement it retain the
+// legacy ECDSA behavior.
+type walletInactivityClaimChainProvider interface {
+	InactivityClaimChainForWallet(
+		walletScheme WalletScheme,
+	) (WalletInactivityClaimChain, error)
+}
+
 type inactivityClaimExecutor struct {
 	lock *semaphore.Weighted
 
@@ -95,9 +105,28 @@ func (ice *inactivityClaimExecutor) claimInactivity(
 		return fmt.Errorf("could not get registry data on wallet: [%v]", err)
 	}
 
-	nonce, err := ice.chain.GetInactivityClaimNonce(
-		walletRegistryData.EcdsaWalletID,
-	)
+	walletScheme, walletID, err := walletSchemeAndRegistryID(walletRegistryData)
+	if err != nil {
+		return fmt.Errorf("could not resolve wallet registry: [%v]", err)
+	}
+	if walletScheme == WalletSchemeFROST {
+		var xOnlyOutputKey [32]byte
+		wallet.publicKey.X.FillBytes(xOnlyOutputKey[:])
+		if walletID != xOnlyOutputKey {
+			return fmt.Errorf(
+				"FROST wallet ID [0x%x] does not match x-only output key [0x%x]",
+				walletID,
+				xOnlyOutputKey,
+			)
+		}
+	}
+
+	inactivityChain, err := ice.inactivityChain(walletScheme)
+	if err != nil {
+		return fmt.Errorf("could not resolve inactivity claim chain: [%v]", err)
+	}
+
+	nonce, err := inactivityChain.GetInactivityClaimNonce(walletID)
 	if err != nil {
 		return fmt.Errorf("could not get nonce for wallet: [%v]", err)
 	}
@@ -109,7 +138,7 @@ func (ice *inactivityClaimExecutor) claimInactivity(
 		heartbeatFailed,
 	)
 
-	groupMembers, err := ice.getWalletOperatorsIDs()
+	groupMembers, err := ice.getWalletOperatorsIDs(inactivityChain)
 	if err != nil {
 		return fmt.Errorf("could not get wallet members info: [%v]", err)
 	}
@@ -132,8 +161,13 @@ func (ice *inactivityClaimExecutor) claimInactivity(
 			signerCtx, cancelSignerCtx := context.WithCancel(ctx)
 			defer cancelSignerCtx()
 
-			subscription := ice.chain.OnInactivityClaimed(
+			subscription := inactivityChain.OnInactivityClaimed(
 				func(event *InactivityClaimedEvent) {
+					if event == nil || event.Nonce == nil ||
+						event.WalletID != walletID || event.Nonce.Cmp(nonce) < 0 {
+						return
+					}
+
 					defer cancelSignerCtx()
 
 					execLogger.Infof(
@@ -160,6 +194,8 @@ func (ice *inactivityClaimExecutor) claimInactivity(
 				),
 				groupMembers,
 				ice.membershipValidator,
+				inactivityChain,
+				walletID,
 				claim,
 			)
 			if err != nil {
@@ -188,7 +224,37 @@ func (ice *inactivityClaimExecutor) claimInactivity(
 	return nil
 }
 
-func (ice *inactivityClaimExecutor) getWalletOperatorsIDs() ([]uint32, error) {
+func (ice *inactivityClaimExecutor) inactivityChain(
+	walletScheme WalletScheme,
+) (WalletInactivityClaimChain, error) {
+	provider, ok := ice.chain.(walletInactivityClaimChainProvider)
+	if ok {
+		inactivityChain, err := provider.InactivityClaimChainForWallet(walletScheme)
+		if err != nil {
+			return nil, err
+		}
+		if inactivityChain == nil {
+			return nil, fmt.Errorf(
+				"wallet inactivity claim chain is nil for scheme [%v]",
+				walletScheme,
+			)
+		}
+
+		return inactivityChain, nil
+	}
+
+	if walletScheme == WalletSchemeFROST {
+		return nil, fmt.Errorf(
+			"chain does not provide a FROST inactivity claim view",
+		)
+	}
+
+	return ice.chain, nil
+}
+
+func (ice *inactivityClaimExecutor) getWalletOperatorsIDs(
+	inactivityChain WalletInactivityClaimChain,
+) ([]uint32, error) {
 	// Cache mapping operator addresses to their wallet member IDs. It helps to
 	// limit the number of calls to the ETH client if some operator addresses
 	// occur on the list multiple times.
@@ -200,7 +266,7 @@ func (ice *inactivityClaimExecutor) getWalletOperatorsIDs() ([]uint32, error) {
 		// Search for the operator address in the cache. Store the operator
 		// address in the cache if it's not there.
 		if operatorID, found := operatorIDCache[operatorAddress]; !found {
-			fetchedOperatorID, err := ice.chain.GetOperatorID(operatorAddress)
+			fetchedOperatorID, err := inactivityChain.GetOperatorID(operatorAddress)
 			if err != nil {
 				return nil, fmt.Errorf("could not get operator ID: [%w]", err)
 			}
@@ -223,6 +289,8 @@ func (ice *inactivityClaimExecutor) publishInactivityClaim(
 	dishonestThreshold int,
 	groupMembers []uint32,
 	membershipValidator *group.MembershipValidator,
+	inactivityChain WalletInactivityClaimChain,
+	walletID [32]byte,
 	inactivityClaim *inactivity.ClaimPreimage,
 ) error {
 	return inactivity.PublishClaim(
@@ -234,12 +302,13 @@ func (ice *inactivityClaimExecutor) publishInactivityClaim(
 		groupSize,
 		dishonestThreshold,
 		membershipValidator,
-		newInactivityClaimSigner(ice.chain),
-		newInactivityClaimSubmitter(
+		newInactivityClaimSigner(inactivityChain),
+		newInactivityClaimSubmitterForWallet(
 			inactivityLogger,
-			ice.chain,
+			inactivityChain,
 			ice.groupParameters,
 			groupMembers,
+			walletID,
 			ice.waitForBlockFn,
 		),
 		inactivityClaim,
@@ -255,11 +324,11 @@ func (ice *inactivityClaimExecutor) wallet() wallet {
 // inactivityClaimSigner is responsible for signing the inactivity claim and
 // verification of signatures generated by other group members.
 type inactivityClaimSigner struct {
-	chain Chain
+	chain WalletInactivityClaimChain
 }
 
 func newInactivityClaimSigner(
-	chain Chain,
+	chain WalletInactivityClaimChain,
 ) *inactivityClaimSigner {
 	return &inactivityClaimSigner{
 		chain: chain,
@@ -317,9 +386,10 @@ func (ics *inactivityClaimSigner) VerifySignature(
 type inactivityClaimSubmitter struct {
 	inactivityLogger log.StandardLogger
 
-	chain           Chain
+	chain           WalletInactivityClaimChain
 	groupParameters *GroupParameters
 	groupMembers    []uint32
+	walletID        [32]byte
 
 	waitForBlockFn waitForBlockFn
 }
@@ -331,11 +401,30 @@ func newInactivityClaimSubmitter(
 	groupMembers []uint32,
 	waitForBlockFn waitForBlockFn,
 ) *inactivityClaimSubmitter {
+	return newInactivityClaimSubmitterForWallet(
+		inactivityLogger,
+		chain,
+		groupParameters,
+		groupMembers,
+		[32]byte{},
+		waitForBlockFn,
+	)
+}
+
+func newInactivityClaimSubmitterForWallet(
+	inactivityLogger log.StandardLogger,
+	chain WalletInactivityClaimChain,
+	groupParameters *GroupParameters,
+	groupMembers []uint32,
+	walletID [32]byte,
+	waitForBlockFn waitForBlockFn,
+) *inactivityClaimSubmitter {
 	return &inactivityClaimSubmitter{
 		inactivityLogger: inactivityLogger,
 		chain:            chain,
 		groupParameters:  groupParameters,
 		groupMembers:     groupMembers,
+		walletID:         walletID,
 		waitForBlockFn:   waitForBlockFn,
 	}
 }
@@ -358,17 +447,23 @@ func (ics *inactivityClaimSubmitter) SubmitClaim(
 	// The inactivity nonce at the beginning of the execution process.
 	inactivityNonce := claim.Nonce
 
-	walletPublicKeyHash := bitcoin.PublicKeyHash(claim.WalletPublicKey)
+	walletID := ics.walletID
+	if walletID == ([32]byte{}) {
+		// Backward-compatible constructor path used by legacy callers and tests.
+		walletPublicKeyHash := bitcoin.PublicKeyHash(claim.WalletPublicKey)
+		walletRegistryData, err := ics.chain.GetWallet(walletPublicKeyHash)
+		if err != nil {
+			return fmt.Errorf("could not get registry data on wallet: [%v]", err)
+		}
 
-	walletRegistryData, err := ics.chain.GetWallet(walletPublicKeyHash)
-	if err != nil {
-		return fmt.Errorf("could not get registry data on wallet: [%v]", err)
+		_, walletID, err = walletSchemeAndRegistryID(walletRegistryData)
+		if err != nil {
+			return fmt.Errorf("could not resolve wallet registry: [%v]", err)
+		}
 	}
 
-	ecdsaWalletID := walletRegistryData.EcdsaWalletID
-
 	currentNonce, err := ics.chain.GetInactivityClaimNonce(
-		ecdsaWalletID,
+		walletID,
 	)
 	if err != nil {
 		return fmt.Errorf("could not get nonce for wallet: [%v]", err)
@@ -385,7 +480,7 @@ func (ics *inactivityClaimSubmitter) SubmitClaim(
 	}
 
 	chainClaim, err := ics.chain.AssembleInactivityClaim(
-		ecdsaWalletID,
+		walletID,
 		claim.InactiveMembersIndexes,
 		signatures,
 		claim.HeartbeatFailed,
@@ -438,7 +533,7 @@ func (ics *inactivityClaimSubmitter) SubmitClaim(
 
 	// Re-check the nonce after the delay wait. Another member may have
 	// submitted the claim while we were waiting.
-	currentNonce, err = ics.chain.GetInactivityClaimNonce(ecdsaWalletID)
+	currentNonce, err = ics.chain.GetInactivityClaimNonce(walletID)
 	if err != nil {
 		return fmt.Errorf("could not get nonce for wallet: [%v]", err)
 	}
@@ -472,7 +567,7 @@ func (ics *inactivityClaimSubmitter) SubmitClaim(
 	// submission if another member submits the same claim first. In that
 	// case, treat this as expected and return without error.
 	currentNonce, nonceErr := ics.chain.GetInactivityClaimNonce(
-		ecdsaWalletID,
+		walletID,
 	)
 	if nonceErr == nil && currentNonce.Cmp(inactivityNonce) > 0 {
 		ics.inactivityLogger.Infof(

--- a/pkg/tbtc/inactivity_test.go
+++ b/pkg/tbtc/inactivity_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/keep-network/keep-core/pkg/operator"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/protocol/inactivity"
+	"github.com/keep-network/keep-core/pkg/subscription"
 	"github.com/keep-network/keep-core/pkg/tecdsa"
 )
 
@@ -61,6 +63,304 @@ func TestInactivityClaimExecutor_ClaimInactivity(t *testing.T) {
 		expectedNonceDiff,
 		nonceDiff,
 	)
+}
+
+func TestInactivityClaimExecutor_ClaimInactivity_FrostRegistry(t *testing.T) {
+	operatorPrivateKey, operatorPublicKey, err := operator.GenerateKeyPair(
+		local_v1.DefaultCurve,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	baseChain := ConnectWithKey(operatorPrivateKey)
+	frostChain := &recordingFrostInactivityChain{localChain: baseChain}
+	dualStackChain := &dualStackInactivityChain{
+		localChain: baseChain,
+		frostChain: frostChain,
+	}
+
+	localProvider := local.ConnectWithKey(operatorPublicKey)
+	operatorAddress, err := baseChain.Signing().PublicKeyToAddress(operatorPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testData, err := tecdsatest.LoadPrivateKeyShareTestFixtures(1)
+	if err != nil {
+		t.Fatalf("failed to load test data: [%v]", err)
+	}
+	privateKeyShare := tecdsa.NewPrivateKeyShare(testData[0])
+	walletSigner := &signer{
+		wallet: wallet{
+			publicKey:             privateKeyShare.PublicKey(),
+			signingGroupOperators: []chain.Address{operatorAddress},
+		},
+		signingGroupMemberIndex: 1,
+		privateKeyShare:         privateKeyShare,
+	}
+
+	var frostWalletID [32]byte
+	walletSigner.wallet.publicKey.X.FillBytes(frostWalletID[:])
+	baseChain.setWallet(
+		bitcoin.PublicKeyHash(walletSigner.wallet.publicKey),
+		&WalletChainData{
+			WalletID: frostWalletID,
+			State:    StateLive,
+		},
+	)
+
+	broadcastChannel, err := localProvider.BroadcastChannelFor(
+		"test-frost-inactivity",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inactivity.RegisterUnmarshallers(broadcastChannel)
+
+	membershipValidator := group.NewMembershipValidator(
+		logger,
+		walletSigner.wallet.signingGroupOperators,
+		baseChain.Signing(),
+	)
+	if err := broadcastChannel.SetFilter(membershipValidator.IsInGroup); err != nil {
+		t.Fatal(err)
+	}
+
+	executor := newInactivityClaimExecutor(
+		dualStackChain,
+		[]*signer{walletSigner},
+		broadcastChannel,
+		membershipValidator,
+		&GroupParameters{
+			GroupSize:       1,
+			GroupQuorum:     1,
+			HonestThreshold: 1,
+		},
+		generator.NewProtocolLatch(),
+		func(context.Context, uint64) error { return nil },
+	)
+
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelCtx()
+
+	err = executor.claimInactivity(
+		ctx,
+		[]group.MemberIndex{1},
+		true,
+		big.NewInt(100),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nonce, err := baseChain.GetInactivityClaimNonce(frostWalletID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nonce.Uint64() != 1 {
+		t.Fatalf("expected FROST inactivity nonce 1, got [%v]", nonce)
+	}
+
+	dualStackChain.mutex.Lock()
+	requestedSchemes := append([]WalletScheme{}, dualStackChain.requestedSchemes...)
+	dualStackChain.mutex.Unlock()
+	if !reflect.DeepEqual(requestedSchemes, []WalletScheme{WalletSchemeFROST}) {
+		t.Fatalf("unexpected inactivity chain requests: [%v]", requestedSchemes)
+	}
+
+	frostChain.mutex.Lock()
+	defer frostChain.mutex.Unlock()
+	if frostChain.operatorIDCalls == 0 ||
+		frostChain.hashCalls == 0 ||
+		frostChain.subscriptionCalls == 0 ||
+		frostChain.assembleCalls == 0 ||
+		frostChain.submitCalls == 0 {
+		t.Fatalf(
+			"FROST backend was not used for every inactivity operation: %+v",
+			frostChain,
+		)
+	}
+	if !reflect.DeepEqual(frostChain.submittedGroupMembers, []uint32{777}) {
+		t.Fatalf(
+			"unexpected FROST group member IDs: [%v]",
+			frostChain.submittedGroupMembers,
+		)
+	}
+	for _, walletID := range frostChain.walletIDs {
+		if walletID != frostWalletID {
+			t.Fatalf(
+				"inactivity operation used wallet ID [0x%x], expected [0x%x]",
+				walletID,
+				frostWalletID,
+			)
+		}
+	}
+}
+
+type dualStackInactivityChain struct {
+	*localChain
+	frostChain *recordingFrostInactivityChain
+
+	mutex            sync.Mutex
+	requestedSchemes []WalletScheme
+}
+
+type inactivityClaimChainProviderStub struct {
+	Chain
+	inactivityClaimChain WalletInactivityClaimChain
+	err                  error
+}
+
+func (iccp *inactivityClaimChainProviderStub) InactivityClaimChainForWallet(
+	walletScheme WalletScheme,
+) (WalletInactivityClaimChain, error) {
+	return iccp.inactivityClaimChain, iccp.err
+}
+
+func TestInactivityClaimExecutor_InactivityChainRoutingGuards(t *testing.T) {
+	legacyChain := &localChain{}
+	executor := &inactivityClaimExecutor{chain: legacyChain}
+
+	selectedChain, err := executor.inactivityChain(WalletSchemeECDSA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selectedChain != legacyChain {
+		t.Fatal("legacy chain fallback returned a different chain")
+	}
+
+	_, err = executor.inactivityChain(WalletSchemeFROST)
+	if err == nil ||
+		err.Error() != "chain does not provide a FROST inactivity claim view" {
+		t.Fatalf("unexpected missing FROST view error: [%v]", err)
+	}
+
+	executor.chain = &inactivityClaimChainProviderStub{Chain: legacyChain}
+	_, err = executor.inactivityChain(WalletSchemeFROST)
+	expectedError := fmt.Sprintf(
+		"wallet inactivity claim chain is nil for scheme [%v]",
+		WalletSchemeFROST,
+	)
+	if err == nil || err.Error() != expectedError {
+		t.Fatalf("unexpected nil FROST view error: [%v]", err)
+	}
+
+	providerErr := fmt.Errorf("provider failed")
+	executor.chain = &inactivityClaimChainProviderStub{
+		Chain: legacyChain,
+		err:   providerErr,
+	}
+	_, err = executor.inactivityChain(WalletSchemeFROST)
+	if err != providerErr {
+		t.Fatalf("expected provider error, got [%v]", err)
+	}
+}
+
+func (dsic *dualStackInactivityChain) InactivityClaimChainForWallet(
+	walletScheme WalletScheme,
+) (WalletInactivityClaimChain, error) {
+	dsic.mutex.Lock()
+	dsic.requestedSchemes = append(dsic.requestedSchemes, walletScheme)
+	dsic.mutex.Unlock()
+
+	switch walletScheme {
+	case WalletSchemeECDSA:
+		return dsic.localChain, nil
+	case WalletSchemeFROST:
+		return dsic.frostChain, nil
+	default:
+		return nil, fmt.Errorf("unsupported wallet scheme [%v]", walletScheme)
+	}
+}
+
+type recordingFrostInactivityChain struct {
+	*localChain
+
+	mutex                 sync.Mutex
+	operatorIDCalls       int
+	hashCalls             int
+	subscriptionCalls     int
+	assembleCalls         int
+	submitCalls           int
+	walletIDs             [][32]byte
+	submittedGroupMembers []uint32
+}
+
+func (rfic *recordingFrostInactivityChain) GetOperatorID(
+	operatorAddress chain.Address,
+) (chain.OperatorID, error) {
+	rfic.mutex.Lock()
+	rfic.operatorIDCalls++
+	rfic.mutex.Unlock()
+
+	return 777, nil
+}
+
+func (rfic *recordingFrostInactivityChain) CalculateInactivityClaimHash(
+	claim *inactivity.ClaimPreimage,
+) (inactivity.ClaimHash, error) {
+	rfic.mutex.Lock()
+	rfic.hashCalls++
+	rfic.mutex.Unlock()
+
+	return rfic.localChain.CalculateInactivityClaimHash(claim)
+}
+
+func (rfic *recordingFrostInactivityChain) OnInactivityClaimed(
+	handler func(event *InactivityClaimedEvent),
+) subscription.EventSubscription {
+	rfic.mutex.Lock()
+	rfic.subscriptionCalls++
+	rfic.mutex.Unlock()
+
+	return rfic.localChain.OnInactivityClaimed(handler)
+}
+
+func (rfic *recordingFrostInactivityChain) GetInactivityClaimNonce(
+	walletID [32]byte,
+) (*big.Int, error) {
+	rfic.recordWalletID(walletID)
+	return rfic.localChain.GetInactivityClaimNonce(walletID)
+}
+
+func (rfic *recordingFrostInactivityChain) AssembleInactivityClaim(
+	walletID [32]byte,
+	inactiveMembersIndices []group.MemberIndex,
+	signatures map[group.MemberIndex][]byte,
+	heartbeatFailed bool,
+) (*InactivityClaim, error) {
+	rfic.mutex.Lock()
+	rfic.assembleCalls++
+	rfic.walletIDs = append(rfic.walletIDs, walletID)
+	rfic.mutex.Unlock()
+
+	return rfic.localChain.AssembleInactivityClaim(
+		walletID,
+		inactiveMembersIndices,
+		signatures,
+		heartbeatFailed,
+	)
+}
+
+func (rfic *recordingFrostInactivityChain) SubmitInactivityClaim(
+	claim *InactivityClaim,
+	nonce *big.Int,
+	groupMembers []uint32,
+) error {
+	rfic.mutex.Lock()
+	rfic.submitCalls++
+	rfic.walletIDs = append(rfic.walletIDs, claim.WalletID)
+	rfic.submittedGroupMembers = append([]uint32{}, groupMembers...)
+	rfic.mutex.Unlock()
+
+	return rfic.localChain.SubmitInactivityClaim(claim, nonce, groupMembers)
+}
+
+func (rfic *recordingFrostInactivityChain) recordWalletID(walletID [32]byte) {
+	rfic.mutex.Lock()
+	defer rfic.mutex.Unlock()
+	rfic.walletIDs = append(rfic.walletIDs, walletID)
 }
 
 func TestInactivityClaimExecutor_ClaimInactivity_Busy(t *testing.T) {

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -768,6 +768,29 @@ func (n *node) groupParametersForSigners(
 	return n.groupParameters, nil
 }
 
+// heartbeatMinimumActiveMembers selects the activity threshold for the wallet
+// scheme handled by the signing executor. Legacy ECDSA heartbeats retain their
+// historical fixed threshold while FROST heartbeats use the independent
+// activeThreshold configured on FrostDkgValidator. The validator configuration
+// may change after a wallet is created, making the current active threshold
+// larger than the persisted wallet's signing group, so cap the threshold at
+// that wallet's actual member count.
+func heartbeatMinimumActiveMembers(
+	signingExecutor *signingExecutor,
+	signingGroupMembersCount int,
+) int {
+	if signingExecutor.usesSchnorrSignatures() {
+		minimumActiveMembers := signingExecutor.groupParameters.GroupQuorum
+		if signingGroupMembersCount < minimumActiveMembers {
+			return signingGroupMembersCount
+		}
+
+		return minimumActiveMembers
+	}
+
+	return heartbeatSigningMinimumActiveMembers
+}
+
 // handleHeartbeatProposal handles an incoming heartbeat proposal by
 // orchestrating and dispatching an appropriate wallet action.
 func (n *node) handleHeartbeatProposal(
@@ -838,6 +861,10 @@ func (n *node) handleHeartbeatProposal(
 		n.chain,
 		wallet,
 		signingExecutor,
+		heartbeatMinimumActiveMembers(
+			signingExecutor,
+			len(wallet.signingGroupOperators),
+		),
 		proposal,
 		n.heartbeatFailureCounter,
 		inactivityClaimExecutor,
@@ -1519,6 +1546,10 @@ type frostWalletRegistryAvailability interface {
 	FrostWalletRegistryAvailable() bool
 }
 
+type frostWalletRegistrationChain interface {
+	IsFrostWalletRegistered(walletID [32]byte) (bool, error)
+}
+
 func (n *node) frostWalletRegistryAvailable() bool {
 	frostChain, ok := n.chain.(frostWalletRegistryAvailability)
 
@@ -1526,7 +1557,12 @@ func (n *node) frostWalletRegistryAvailable() bool {
 }
 
 // handleWalletClosure handles the wallet termination or closing process.
-func (n *node) handleWalletClosure(walletID [32]byte) error {
+func (n *node) handleWalletClosure(
+	walletID [32]byte,
+	walletScheme WalletScheme,
+) error {
+	walletScheme = normalizeWalletScheme(walletScheme)
+
 	blockCounter, err := n.chain.BlockCounter()
 	if err != nil {
 		return fmt.Errorf("error getting block counter [%w]", err)
@@ -1537,11 +1573,27 @@ func (n *node) handleWalletClosure(walletID [32]byte) error {
 		return fmt.Errorf("error getting current block [%w]", err)
 	}
 
-	// To verify there was no chain reorg and the wallet is really closed check
-	// if it is registered. Both terminated and closed wallets are removed
-	// from the ECDSA registry.
+	// To verify there was no chain reorg and the wallet is really closed, check
+	// registration in the registry that emitted the closure event.
 	stateCheck := func() (bool, error) {
-		isRegistered, err := n.chain.IsWalletRegistered(walletID)
+		var isRegistered bool
+		var err error
+
+		switch walletScheme {
+		case WalletSchemeECDSA:
+			isRegistered, err = n.chain.IsWalletRegistered(walletID)
+		case WalletSchemeFROST:
+			frostChain, ok := n.chain.(frostWalletRegistrationChain)
+			if !ok {
+				return false, fmt.Errorf(
+					"chain does not support FROST wallet registration checks",
+				)
+			}
+
+			isRegistered, err = frostChain.IsFrostWalletRegistered(walletID)
+		default:
+			return false, fmt.Errorf("unsupported wallet scheme [%v]", walletScheme)
+		}
 		if err != nil {
 			return false, err
 		}
@@ -1570,10 +1622,10 @@ func (n *node) handleWalletClosure(walletID [32]byte) error {
 
 	walletPublicKeyHash, err := n.chain.WalletPublicKeyHashForWalletID(walletID)
 	if err != nil {
-		// WalletClosed events still carry ECDSA wallet IDs from the legacy
-		// registry path. Until closure events are emitted with canonical IDs,
-		// canonical wallet-ID resolution is expected to miss and we use the
-		// local registry fallback below.
+		// Legacy WalletClosed events carry ECDSA registry IDs rather than
+		// canonical Bridge IDs, and canonical resolution can therefore miss.
+		// The local registry fallback also protects custom chain adapters that
+		// cannot resolve a FROST ID through the Bridge.
 		logger.Debugf(
 			"cannot resolve wallet public key hash for wallet ID [0x%x]: [%v]; "+
 				"falling back to local wallet ID matching",

--- a/pkg/tbtc/node_test.go
+++ b/pkg/tbtc/node_test.go
@@ -79,6 +79,90 @@ func TestNode_GroupParametersForSignersUsesWalletScheme(t *testing.T) {
 	}
 }
 
+func TestHeartbeatMinimumActiveMembersUsesWalletScheme(t *testing.T) {
+	tests := map[string]struct {
+		executor                 *signingExecutor
+		signingGroupMembersCount int
+		expected                 int
+	}{
+		"legacy ECDSA wallet": {
+			executor: &signingExecutor{
+				signers: []*signer{
+					{privateKeyShare: &tecdsa.PrivateKeyShare{}},
+				},
+				groupParameters: &GroupParameters{
+					GroupSize:       100,
+					GroupQuorum:     90,
+					HonestThreshold: 51,
+				},
+			},
+			// A small actual group must not alter the legacy fixed threshold.
+			signingGroupMembersCount: 5,
+			expected:                 heartbeatSigningMinimumActiveMembers,
+		},
+		"native FROST wallet uses active threshold": {
+			executor: &signingExecutor{
+				signers: []*signer{
+					{
+						signerMaterial: &frostsigning.NativeSignerMaterial{
+							Format: frostsigning.NativeSignerMaterialFormatFrostTBTCSignerV1,
+							Payload: []byte(`{
+								"keyGroup":"key-group",
+								"keyGroupSource":"dkg-persisted"
+							}`),
+						},
+					},
+				},
+				groupParameters: &GroupParameters{
+					GroupSize:       5,
+					GroupQuorum:     4,
+					HonestThreshold: 3,
+				},
+			},
+			signingGroupMembersCount: 5,
+			expected:                 4,
+		},
+		"native FROST wallet caps threshold at actual group size": {
+			executor: &signingExecutor{
+				signers: []*signer{
+					{
+						signerMaterial: &frostsigning.NativeSignerMaterial{
+							Format: frostsigning.NativeSignerMaterialFormatFrostTBTCSignerV1,
+							Payload: []byte(`{
+								"keyGroup":"key-group",
+								"keyGroupSource":"dkg-persisted"
+							}`),
+						},
+					},
+				},
+				groupParameters: &GroupParameters{
+					GroupSize:       5,
+					GroupQuorum:     4,
+					HonestThreshold: 3,
+				},
+			},
+			signingGroupMembersCount: 3,
+			expected:                 3,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := heartbeatMinimumActiveMembers(
+				test.executor,
+				test.signingGroupMembersCount,
+			)
+			if actual != test.expected {
+				t.Errorf(
+					"unexpected minimum active members\nexpected: [%d]\nactual:   [%d]",
+					test.expected,
+					actual,
+				)
+			}
+		})
+	}
+}
+
 func TestNode_GetSigningExecutor(t *testing.T) {
 	groupParameters := &GroupParameters{
 		GroupSize:       5,
@@ -1342,12 +1426,74 @@ func TestHandleWalletClosure_ArchivesWallet(t *testing.T) {
 		State:         StateClosed,
 	})
 
-	if err := n.handleWalletClosure(walletID); err != nil {
+	if err := n.handleWalletClosure(walletID, WalletSchemeECDSA); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if keys := n.walletRegistry.getWalletsPublicKeys(); len(keys) != 0 {
 		t.Errorf("expected empty registry after closure handling, got %d wallets", len(keys))
+	}
+}
+
+func TestHandleWalletClosure_FrostEventChecksFrostRegistry(t *testing.T) {
+	n, signer, lc := setupNodeForClosureTests(t)
+
+	walletPublicKeyHash := bitcoin.PublicKeyHash(signer.wallet.publicKey)
+	frostWalletID := [32]byte{0xaa, 0xbb, 0xcc}
+	lc.setWallet(walletPublicKeyHash, &WalletChainData{
+		WalletID: frostWalletID,
+		State:    StateClosed,
+	})
+
+	lc.walletRegistrationChecksMutex.Lock()
+	lc.ecdsaWalletRegistrationChecks = 0
+	lc.frostWalletRegistrationChecks = 0
+	lc.walletRegistrationChecksMutex.Unlock()
+
+	if err := n.handleWalletClosure(
+		frostWalletID,
+		WalletSchemeFROST,
+	); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lc.walletRegistrationChecksMutex.Lock()
+	ecdsaChecks := lc.ecdsaWalletRegistrationChecks
+	frostChecks := lc.frostWalletRegistrationChecks
+	lc.walletRegistrationChecksMutex.Unlock()
+	if frostChecks == 0 {
+		t.Fatal("FROST closure must be confirmed against FrostWalletRegistry")
+	}
+	if ecdsaChecks != 0 {
+		t.Fatalf(
+			"FROST closure must not query the ECDSA registry; got [%d] checks",
+			ecdsaChecks,
+		)
+	}
+
+	if keys := n.walletRegistry.getWalletsPublicKeys(); len(keys) != 0 {
+		t.Errorf("expected empty registry after FROST closure, got %d wallets", len(keys))
+	}
+}
+
+func TestHandleWalletClosure_UnknownSchemeDefaultsToEcdsa(t *testing.T) {
+	n, signer, lc := setupNodeForClosureTests(t)
+
+	walletPublicKeyHash := bitcoin.PublicKeyHash(signer.wallet.publicKey)
+	walletID, err := lc.CalculateWalletID(signer.wallet.publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lc.setWallet(walletPublicKeyHash, &WalletChainData{
+		EcdsaWalletID: walletID,
+		State:         StateClosed,
+	})
+
+	if err := n.handleWalletClosure(
+		walletID,
+		WalletSchemeUnknown,
+	); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -1369,7 +1515,10 @@ func TestHandleWalletClosure_SkipsUncontrolledWallet(t *testing.T) {
 		State:         StateClosed,
 	})
 
-	if err := n.handleWalletClosure(uncontrolledID); err != nil {
+	if err := n.handleWalletClosure(
+		uncontrolledID,
+		WalletSchemeECDSA,
+	); err != nil {
 		t.Fatalf("unexpected error for uncontrolled wallet: %v", err)
 	}
 
@@ -1391,7 +1540,7 @@ func TestHandleWalletClosure_ReturnsErrorWhenNotConfirmed(t *testing.T) {
 	}
 
 	// wallet is StateLive → IsWalletRegistered returns true → stateCheck = false
-	if err := n.handleWalletClosure(walletID); err == nil {
+	if err := n.handleWalletClosure(walletID, WalletSchemeECDSA); err == nil {
 		t.Fatal("expected error for unconfirmed closure, got nil")
 	}
 }

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -494,28 +494,34 @@ func Initialize(
 
 	_ = chain.OnWalletClosed(func(event *WalletClosedEvent) {
 		go func() {
-			if ok := deduplicator.notifyWalletClosed(
-				event.WalletID,
-			); !ok {
+			if event == nil {
+				logger.Error("received nil WalletClosed event")
+				return
+			}
+
+			processed, err := processWalletClosureEvent(
+				deduplicator,
+				event,
+				func(walletID [32]byte, walletScheme WalletScheme) error {
+					logger.Infof(
+						"Wallet with ID [0x%x] has been closed at block [%v]; "+
+							"proceeding with handling wallet closure",
+						walletID,
+						event.BlockNumber,
+					)
+
+					return node.handleWalletClosure(walletID, walletScheme)
+				},
+			)
+			if !processed {
 				logger.Warnf(
 					"Wallet closure for wallet with ID [0x%x] at block [%v] "+
-						"has been already processed",
+						"is already being processed or has been processed",
 					event.WalletID,
 					event.BlockNumber,
 				)
 				return
 			}
-
-			logger.Infof(
-				"Wallet with ID [0x%x] has been closed at block [%v]; "+
-					"proceeding with handling wallet closure",
-				event.WalletID,
-				event.BlockNumber,
-			)
-
-			err := node.handleWalletClosure(
-				event.WalletID,
-			)
 			if err != nil {
 				logger.Errorf(
 					"Failure while handling wallet closure with ID [0x%x]: [%v]",
@@ -527,6 +533,56 @@ func Initialize(
 	})
 
 	return nil
+}
+
+// processWalletClosureEvent suppresses concurrent live/polled duplicates while
+// allowing a replay to retry failed closure handling. A closure is retained in
+// the long-lived deduplication cache only after handling succeeds.
+func processWalletClosureEvent(
+	deduplicator *deduplicator,
+	event *WalletClosedEvent,
+	handle func(walletID [32]byte, walletScheme WalletScheme) error,
+) (bool, error) {
+	if event == nil {
+		return false, fmt.Errorf("wallet closure event is nil")
+	}
+
+	if event.Scheme == WalletSchemeUnknown {
+		logger.Debugf(
+			"wallet closure event for wallet [0x%x] has no scheme; "+
+				"treating it as a legacy ECDSA wallet",
+			event.WalletID,
+		)
+	}
+
+	walletScheme := normalizeWalletScheme(event.Scheme)
+	lease, ok := deduplicator.beginWalletClosed(walletScheme, event.WalletID)
+	if !ok {
+		return false, nil
+	}
+
+	leaseActive := true
+	// Release the lease if handling panics while a pending replay is keeping it
+	// active. Successful and ordinary error paths finish it explicitly.
+	defer func() {
+		if leaseActive {
+			lease.release()
+		}
+	}()
+
+	for {
+		err := handle(event.WalletID, walletScheme)
+		if err == nil {
+			lease.finish(true)
+			leaseActive = false
+			return true, nil
+		}
+
+		if !lease.finish(false) {
+			leaseActive = false
+			return true, err
+		}
+	}
 }
 
 func shouldMonitorLegacySortitionPool(config Config) bool {

--- a/pkg/tbtc/tbtc_test.go
+++ b/pkg/tbtc/tbtc_test.go
@@ -1,6 +1,10 @@
 package tbtc
 
-import "testing"
+import (
+	"errors"
+	"testing"
+	"time"
+)
 
 func TestShouldMonitorLegacySortitionPool(t *testing.T) {
 	if !shouldMonitorLegacySortitionPool(Config{}) {
@@ -27,5 +31,140 @@ func TestShouldRunLegacyECDSA(t *testing.T) {
 
 	if shouldRunLegacyECDSA(Config{DisableLegacyECDSA: true}) {
 		t.Fatal("expected legacy ECDSA to be disabled")
+	}
+}
+
+func TestProcessWalletClosureEventRetriesAfterFailure(t *testing.T) {
+	deduplicator := newDeduplicator()
+	event := &WalletClosedEvent{
+		WalletID: [32]byte{0xaa},
+		Scheme:   WalletSchemeFROST,
+	}
+
+	attempts := 0
+	handle := func(_ [32]byte, scheme WalletScheme) error {
+		attempts++
+		if scheme != WalletSchemeFROST {
+			t.Fatalf("unexpected wallet scheme [%v]", scheme)
+		}
+		if attempts == 1 {
+			return errors.New("transient failure")
+		}
+
+		return nil
+	}
+
+	processed, err := processWalletClosureEvent(deduplicator, event, handle)
+	if !processed || err == nil {
+		t.Fatalf("expected first handling attempt to fail, got [%v, %v]", processed, err)
+	}
+
+	processed, err = processWalletClosureEvent(deduplicator, event, handle)
+	if !processed || err != nil {
+		t.Fatalf("expected replay to succeed, got [%v, %v]", processed, err)
+	}
+
+	processed, err = processWalletClosureEvent(deduplicator, event, handle)
+	if processed || err != nil {
+		t.Fatalf("expected successful event to be deduplicated, got [%v, %v]", processed, err)
+	}
+	if attempts != 2 {
+		t.Fatalf("unexpected handling attempts [%v]", attempts)
+	}
+}
+
+func TestProcessWalletClosureEventScopesDeduplicationByScheme(t *testing.T) {
+	deduplicator := newDeduplicator()
+	walletID := [32]byte{0xbb}
+	handledSchemes := make([]WalletScheme, 0, 2)
+	handle := func(_ [32]byte, scheme WalletScheme) error {
+		handledSchemes = append(handledSchemes, scheme)
+		return nil
+	}
+
+	for _, scheme := range []WalletScheme{WalletSchemeFROST, WalletSchemeUnknown} {
+		processed, err := processWalletClosureEvent(
+			deduplicator,
+			&WalletClosedEvent{WalletID: walletID, Scheme: scheme},
+			handle,
+		)
+		if !processed || err != nil {
+			t.Fatalf("expected scheme [%v] to be processed, got [%v, %v]", scheme, processed, err)
+		}
+	}
+
+	expected := []WalletScheme{WalletSchemeFROST, WalletSchemeECDSA}
+	for i := range expected {
+		if handledSchemes[i] != expected[i] {
+			t.Fatalf(
+				"unexpected handled scheme at index [%v]: expected [%v], got [%v]",
+				i,
+				expected[i],
+				handledSchemes[i],
+			)
+		}
+	}
+}
+
+func TestProcessWalletClosureEventPreservesConcurrentReplay(t *testing.T) {
+	deduplicator := newDeduplicator()
+	event := &WalletClosedEvent{
+		WalletID: [32]byte{0xcc},
+		Scheme:   WalletSchemeFROST,
+	}
+
+	firstAttemptStarted := make(chan struct{})
+	releaseFirstAttempt := make(chan struct{})
+	attempts := 0
+	handle := func(_ [32]byte, _ WalletScheme) error {
+		attempts++
+		if attempts == 1 {
+			close(firstAttemptStarted)
+			<-releaseFirstAttempt
+			return errors.New("transient failure")
+		}
+
+		return nil
+	}
+
+	type processingResult struct {
+		processed bool
+		err       error
+	}
+	result := make(chan processingResult, 1)
+	go func() {
+		processed, err := processWalletClosureEvent(deduplicator, event, handle)
+		result <- processingResult{processed: processed, err: err}
+	}()
+
+	<-firstAttemptStarted
+	processed, err := processWalletClosureEvent(
+		deduplicator,
+		event,
+		func(_ [32]byte, _ WalletScheme) error {
+			t.Fatal("concurrent replay must not start a second handler")
+			return nil
+		},
+	)
+	if processed || err != nil {
+		t.Fatalf("expected concurrent replay to be queued, got [%v, %v]", processed, err)
+	}
+
+	close(releaseFirstAttempt)
+	select {
+	case actual := <-result:
+		if !actual.processed || actual.err != nil {
+			t.Fatalf(
+				"expected queued replay to recover the failure, got [%v, %v]",
+				actual.processed,
+				actual.err,
+			)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for queued wallet closure replay")
+	}
+
+	if attempts != 2 {
+		t.Fatalf("expected two handling attempts, got [%v]", attempts)
 	}
 }

--- a/pkg/tbtc/wallet_scheme.go
+++ b/pkg/tbtc/wallet_scheme.go
@@ -1,0 +1,38 @@
+package tbtc
+
+import "fmt"
+
+// normalizeWalletScheme preserves compatibility with chain adapters created
+// before WalletClosedEvent carried a scheme. Their zero value represents the
+// legacy ECDSA registry.
+func normalizeWalletScheme(walletScheme WalletScheme) WalletScheme {
+	if walletScheme == WalletSchemeUnknown {
+		return WalletSchemeECDSA
+	}
+
+	return walletScheme
+}
+
+// walletSchemeAndRegistryID resolves the wallet scheme and the identifier used
+// by that scheme's wallet registry. During the migration, Bridge data carries
+// both a canonical WalletID and the legacy ECDSA registry ID. FROST wallets do
+// not have an ECDSA registry entry, so their EcdsaWalletID is zero.
+func walletSchemeAndRegistryID(
+	walletData *WalletChainData,
+) (WalletScheme, [32]byte, error) {
+	if walletData == nil {
+		return WalletSchemeUnknown, [32]byte{}, fmt.Errorf("wallet data is nil")
+	}
+
+	if walletData.EcdsaWalletID != ([32]byte{}) {
+		return WalletSchemeECDSA, walletData.EcdsaWalletID, nil
+	}
+
+	if walletData.WalletID != ([32]byte{}) {
+		return WalletSchemeFROST, walletData.WalletID, nil
+	}
+
+	return WalletSchemeUnknown, [32]byte{}, fmt.Errorf(
+		"wallet has neither an ECDSA nor a FROST registry ID",
+	)
+}


### PR DESCRIPTION
## Stack

2 of 3. Depends on #4144, is followed by #4146, and targets `fix/pr3866-dkg-review`.

## What changed

- route FROST inactivity claims through FrostWalletRegistry and FrostSortitionPool, including the FROST claim hash and operator IDs
- keep legacy heartbeat stake and registration checks bound to the ECDSA registry during dual-stack migration
- subscribe to and recover recent FROST wallet-closure and inactivity-claim events through cancellation-aware delivery; in-flight log filters stop on unsubscribe
- confirm wallet closure and remove signer material against the wallet's signing scheme
- make closure deduplication scheme-scoped, retryable after failures, and safe when a replay arrives during active handling
- remove the obsolete eager ECDSA-only closure helper and align local-chain FROST registration behavior with production

## Verification

- `go test ./pkg/tbtc ./pkg/chain/ethereum`
- `go test -tags=frost_native ./pkg/tbtc ./pkg/chain/ethereum`
- focused `-race` tests for wallet-closure deduplication and FROST inactivity event delivery
