### PR TITLE
fix(tbtc): bind native signing to BIP-341 policy

### DIFF
--- a/ci/frost-signer-pin.env
+++ b/ci/frost-signer-pin.env
@@ -15,4 +15,4 @@
 #
 # After the scaffold and mirror branches merge into one, replace the cross-branch
 # checkout with an in-tree cargo build and retire this pin (keep the gate).
-FROST_SIGNER_MIRROR_REF=ac2f32ab72dd3b37d0df102eca7afdc42a7d0b9f
+FROST_SIGNER_MIRROR_REF=6e0fa9741ffb6b0bb5603eabe26fb4cc1b13ecd9

--- a/ci/frost-signer-pin.env
+++ b/ci/frost-signer-pin.env
@@ -15,4 +15,4 @@
 #
 # After the scaffold and mirror branches merge into one, replace the cross-branch
 # checkout with an in-tree cargo build and retire this pin (keep the gate).
-FROST_SIGNER_MIRROR_REF=0172c6d033f978a33150334c7091213b94968ee7
+FROST_SIGNER_MIRROR_REF=ac2f32ab72dd3b37d0df102eca7afdc42a7d0b9f

--- a/pkg/bitcoin/transaction_builder.go
+++ b/pkg/bitcoin/transaction_builder.go
@@ -665,9 +665,10 @@ func (tb *TransactionBuilder) UnsignedTransaction() *Transaction {
 // UnsignedTransactionInput carries canonical unsigned input metadata extracted
 // from the builder state.
 type UnsignedTransactionInput struct {
-	TxIDHex   string
-	Vout      uint32
-	ValueSats uint64
+	TxIDHex         string
+	Vout            uint32
+	ValueSats       uint64
+	ScriptPubKeyHex string
 }
 
 // UnsignedTransactionOutput carries canonical unsigned output metadata
@@ -707,6 +708,9 @@ func (tb *TransactionBuilder) UnsignedTransactionIO() (
 				TxIDHex:   input.PreviousOutPoint.Hash.String(),
 				Vout:      input.PreviousOutPoint.Index,
 				ValueSats: uint64(value),
+				ScriptPubKeyHex: hex.EncodeToString(
+					tb.sigHashArgs[i].publicKeyScript,
+				),
 			},
 		)
 	}

--- a/pkg/bitcoin/transaction_builder_test.go
+++ b/pkg/bitcoin/transaction_builder_test.go
@@ -1162,7 +1162,10 @@ func TestTransactionBuilder_UnsignedTransactionIO(t *testing.T) {
 	const expectedTxIDHex = "201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"
 
 	builder.internal.AddTxIn(wire.NewTxIn(wire.NewOutPoint(&txHash, 7), nil, nil))
-	builder.sigHashArgs = append(builder.sigHashArgs, &inputSigHashArgs{value: 1234})
+	builder.sigHashArgs = append(builder.sigHashArgs, &inputSigHashArgs{
+		value:           1234,
+		publicKeyScript: hexToSlice(t, "5120"+strings.Repeat("22", 32)),
+	})
 	builder.AddOutput(&TransactionOutput{
 		Value:           1000,
 		PublicKeyScript: hexToSlice(t, "0014deadbeef"),
@@ -1191,6 +1194,14 @@ func TestTransactionBuilder_UnsignedTransactionIO(t *testing.T) {
 
 	if inputs[0].ValueSats != 1234 {
 		t.Fatalf("unexpected input value: [%d]", inputs[0].ValueSats)
+	}
+
+	if inputs[0].ScriptPubKeyHex != "5120"+strings.Repeat("22", 32) {
+		t.Fatalf(
+			"unexpected input script\nexpected: [%v]\nactual:   [%v]",
+			"5120"+strings.Repeat("22", 32),
+			inputs[0].ScriptPubKeyHex,
+		)
 	}
 
 	if len(outputs) != 1 {

--- a/pkg/frost/signing/distributed_dkg_multinode_net_e2e_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_multinode_net_e2e_frost_native_test.go
@@ -179,7 +179,7 @@ func TestDistributedDKG_MultiNode_NetTransport(t *testing.T) {
 	commitments := make([]nativeFROSTCommitment, 0, len(signingMembers))
 	for _, m := range signingMembers {
 		open, err := engine.InteractiveSessionOpen(
-			signingSession, uint16(m), message, keyGroup, threshold, nil, derived.AttemptContext,
+			signingSession, uint16(m), message, keyGroup, threshold, nil, nil, derived.AttemptContext,
 		)
 		if err != nil {
 			t.Fatalf("interactive session open (member %d): %v", m, err)

--- a/pkg/frost/signing/distributed_dkg_persist_interactive_e2e_frost_native_test.go
+++ b/pkg/frost/signing/distributed_dkg_persist_interactive_e2e_frost_native_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -30,11 +31,10 @@ import (
 //	  -> InteractiveSessionOpen / Round1 / Round2 / Aggregate
 //	  -> a BIP-340 signature that verifies under the DKG group key.
 //
-// Crucially, each seat runs on its OWN engine with its OWN persisted state -
-// exactly how nodes deploy, and unlike the dealer path (and the multi-seat
-// interactive test) where every key package lives in one engine. A distributed
-// node holds only its own secret key package; that this still opens, releases a
-// share, and aggregates into a valid threshold signature is the whole point.
+// The in-process engine handles share one Rust state, so the test accumulates
+// seats under one canonical wallet session. It also proves that attempting to
+// create a second owner for that key group fails closed; real nodes naturally
+// hold one local seat in separate processes/state files.
 func TestDistributedDKG_PersistThenInteractiveSign(t *testing.T) {
 	setupRealCgoSignerState(t)
 
@@ -49,8 +49,8 @@ func TestDistributedDKG_PersistThenInteractiveSign(t *testing.T) {
 	// package into one shared session - that is what lets the seats sign together
 	// here, and it exercises the multi-seat-operator accumulate path. In
 	// production each node is a separate process with its own state holding only
-	// its own seat; that single-seat case (a node opening a session whose included
-	// set spans peers it does not hold) is covered separately at the end.
+	// its own seat. The duplicate-owner assertion at the end protects that wallet
+	// ownership invariant inside this shared-state harness.
 	engines := make(map[group.MemberIndex]*buildTaggedTBTCSignerEngine, n)
 	for _, m := range members {
 		engines[m] = &buildTaggedTBTCSignerEngine{}
@@ -188,7 +188,7 @@ func TestDistributedDKG_PersistThenInteractiveSign(t *testing.T) {
 	commitments := make([]nativeFROSTCommitment, 0, len(signingMembers))
 	for _, m := range signingMembers {
 		open, err := engines[m].InteractiveSessionOpen(
-			sessionID, uint16(m), message, keyGroup, threshold, nil, derived.AttemptContext,
+			sessionID, uint16(m), message, keyGroup, threshold, nil, nil, derived.AttemptContext,
 		)
 		if err != nil {
 			t.Fatalf("interactive session open (member %d): %v", m, err)
@@ -262,14 +262,14 @@ func TestDistributedDKG_PersistThenInteractiveSign(t *testing.T) {
 		threshold, n, keyGroup[:16],
 	)
 
-	// ---- Single-seat-node coverage: a node that persisted ONLY its own key
-	// package must still OPEN a session whose included set spans OTHER members it
-	// does not hold - OPEN validates the included set against the public key
-	// package's verifying shares, not the local key-package map. This is the real
-	// distributed-node scenario the all-seats-accumulated path above does not
-	// exercise (there every included member is already in dkg_key_packages). ----
+	// A key group has exactly one wallet-session owner. Re-persisting the same
+	// distributed package under another session used to create two nondeterministic
+	// owners; Open/Round2 could then resolve different lifecycle state after reload.
+	// The single-seat production topology is one process/state file per node, so it
+	// does not need (and must not manufacture) a duplicate owner in this shared-state
+	// in-process harness.
 	soloSession := sessionID + "-solo"
-	soloResult, err := engines[members[0]].PersistDistributedDKGKeyPackage(
+	_, err = engines[members[0]].PersistDistributedDKGKeyPackage(
 		soloSession,
 		uint16(members[0]),
 		threshold,
@@ -277,22 +277,11 @@ func TestDistributedDKG_PersistThenInteractiveSign(t *testing.T) {
 		outcomes[members[0]].result.KeyPackage,
 		outcomes[members[0]].result.PublicKeyPackage,
 	)
-	if err != nil {
-		t.Fatalf("persist single seat into a fresh session: %v", err)
+	if err == nil {
+		t.Fatal("persisting a duplicate key-group owner must fail closed")
 	}
-	soloDerived, err := engines[members[0]].DeriveInteractiveAttemptContext(
-		soloSession, message, soloResult.KeyGroup, threshold, 0, includedParticipants,
-	)
-	if err != nil {
-		t.Fatalf("derive single-seat attempt context: %v", err)
+	if !strings.Contains(err.Error(), "session_conflict") {
+		t.Fatalf("duplicate key-group owner returned an unexpected error: %v", err)
 	}
-	// members[1] is a DKG participant (present in the public key package) but was
-	// NOT persisted into soloSession, so its member entry is absent from that
-	// session's key-package map; the open must still succeed.
-	if _, err := engines[members[0]].InteractiveSessionOpen(
-		soloSession, uint16(members[0]), message, soloResult.KeyGroup, threshold, nil, soloDerived.AttemptContext,
-	); err != nil {
-		t.Fatalf("single-seat open with an included set spanning peers must succeed: %v", err)
-	}
-	t.Logf("single-seat node (only its own key package) opened a session spanning peers via the public key package")
+	t.Log("duplicate distributed key-group owner rejected")
 }

--- a/pkg/frost/signing/native_ffi_executor_adapter.go
+++ b/pkg/frost/signing/native_ffi_executor_adapter.go
@@ -17,6 +17,7 @@ type NativeExecutionFFISigningRequest struct {
 	Message             *big.Int
 	SessionID           string
 	RoastSessionID      string
+	SigningIntent       *SigningIntent
 	MemberIndex         group.MemberIndex
 	GroupSize           int
 	DishonestThreshold  int
@@ -104,6 +105,7 @@ func (nefea *nativeExecutionFFIExecutorAdapter) Execute(
 		Message:             request.Message,
 		SessionID:           request.SessionID,
 		RoastSessionID:      request.RoastSessionID,
+		SigningIntent:       cloneSigningIntent(request.SigningIntent),
 		MemberIndex:         request.MemberIndex,
 		GroupSize:           request.GroupSize,
 		DishonestThreshold:  request.DishonestThreshold,

--- a/pkg/frost/signing/native_ffi_executor_adapter_test.go
+++ b/pkg/frost/signing/native_ffi_executor_adapter_test.go
@@ -199,6 +199,8 @@ func TestNativeExecutionFFIExecutorAdapter_Execute_DelegatesToPrimitive(
 		IncludedMembersIndexes: []group.MemberIndex{1, 2, 3},
 		ExcludedMembersIndexes: []group.MemberIndex{4},
 	}
+	heartbeatMessage := [16]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01}
+	signingIntent := NewHeartbeatSigningIntent(heartbeatMessage)
 
 	result, err := executor.Execute(context.Background(), nil, &Request{
 		Message:            big.NewInt(123),
@@ -210,7 +212,8 @@ func TestNativeExecutionFFIExecutorAdapter_Execute_DelegatesToPrimitive(
 			Format:  NativeSignerMaterialFormatFrostUniFFIV1,
 			Payload: []byte{0xaa},
 		},
-		Attempt: attempt,
+		SigningIntent: signingIntent,
+		Attempt:       attempt,
 	})
 	if err != nil {
 		t.Fatalf("unexpected execute error: [%v]", err)
@@ -238,6 +241,50 @@ func TestNativeExecutionFFIExecutorAdapter_Execute_DelegatesToPrimitive(
 
 	if primitive.lastRequest.Attempt == attempt {
 		t.Fatal("expected attempt clone in primitive request")
+	}
+	if primitive.lastRequest.SigningIntent == signingIntent {
+		t.Fatal("expected signing intent clone in primitive request")
+	}
+	gotHeartbeatMessage, ok := primitive.lastRequest.SigningIntent.HeartbeatMessage()
+	if !ok || gotHeartbeatMessage != heartbeatMessage {
+		t.Fatalf(
+			"unexpected heartbeat signing intent: got [%x], present [%v], want [%x]",
+			gotHeartbeatMessage,
+			ok,
+			heartbeatMessage,
+		)
+	}
+}
+
+func TestNativeExecutionFFIExecutorAdapter_Execute_GenericSigningIntentIsNil(
+	t *testing.T,
+) {
+	primitive := &mockNativeExecutionFFISigningPrimitive{
+		signature: &frost.Signature{},
+	}
+	executor, err := NewNativeExecutionFFIExecutorAdapter(primitive)
+	if err != nil {
+		t.Fatalf("unexpected adapter setup error: [%v]", err)
+	}
+
+	_, err = executor.Execute(context.Background(), nil, &Request{
+		Message: big.NewInt(1),
+		SignerMaterial: &NativeSignerMaterial{
+			Format:  NativeSignerMaterialFormatFrostUniFFIV1,
+			Payload: []byte{0xaa},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected execute error: [%v]", err)
+	}
+	if primitive.lastRequest == nil {
+		t.Fatal("expected primitive request")
+	}
+	if primitive.lastRequest.SigningIntent != nil {
+		t.Fatalf(
+			"generic signing must keep signing intent nil, got [%+v]",
+			primitive.lastRequest.SigningIntent,
+		)
 	}
 }
 

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -426,9 +426,10 @@ type buildTaggedTBTCSignerBuildTaprootTxRequest struct {
 }
 
 type buildTaggedTBTCSignerBuildTaprootTxInput struct {
-	TxIDHex   string `json:"txid_hex"`
-	Vout      uint32 `json:"vout"`
-	ValueSats uint64 `json:"value_sats"`
+	TxIDHex         string `json:"txid_hex"`
+	Vout            uint32 `json:"vout"`
+	ValueSats       uint64 `json:"value_sats"`
+	ScriptPubKeyHex string `json:"script_pubkey_hex"`
 }
 
 type buildTaggedTBTCSignerBuildTaprootTxOutput struct {
@@ -437,8 +438,9 @@ type buildTaggedTBTCSignerBuildTaprootTxOutput struct {
 }
 
 type buildTaggedTBTCSignerBuildTaprootTxResponse struct {
-	SessionID string `json:"session_id"`
-	TxHex     string `json:"tx_hex"`
+	SessionID                   string   `json:"session_id"`
+	TxHex                       string   `json:"tx_hex"`
+	TaprootKeySpendSighashesHex []string `json:"taproot_key_spend_sighashes_hex"`
 }
 
 const buildTaggedTBTCSignerUnavailableStatusCode = -1
@@ -1478,13 +1480,20 @@ func buildTaggedTBTCSignerBuildTaprootTxRequestPayload(
 				fmt.Sprintf("input [%d] txid hex is empty", i),
 			)
 		}
+		if input.ScriptPubKeyHex == "" {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"BuildTaprootTx",
+				fmt.Sprintf("input [%d] script pubkey hex is empty", i),
+			)
+		}
 
 		requestInputs = append(
 			requestInputs,
 			buildTaggedTBTCSignerBuildTaprootTxInput{
-				TxIDHex:   input.TxIDHex,
-				Vout:      input.Vout,
-				ValueSats: input.ValueSats,
+				TxIDHex:         input.TxIDHex,
+				Vout:            input.Vout,
+				ValueSats:       input.ValueSats,
+				ScriptPubKeyHex: input.ScriptPubKeyHex,
 			},
 		)
 	}
@@ -1573,10 +1582,26 @@ func decodeBuildTaggedTBTCSignerBuildTaprootTxResponse(
 			fmt.Sprintf("response tx hex is invalid: %v", err),
 		)
 	}
+	if len(response.TaprootKeySpendSighashesHex) == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(
+			"BuildTaprootTx",
+			"response taproot key-spend sighashes are empty",
+		)
+	}
+	for i, sighashHex := range response.TaprootKeySpendSighashesHex {
+		sighash, err := hex.DecodeString(sighashHex)
+		if err != nil || len(sighash) != 32 {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"BuildTaprootTx",
+				fmt.Sprintf("response taproot key-spend sighash [%d] is not 32-byte hex", i),
+			)
+		}
+	}
 
 	return &NativeTBTCSignerTxResult{
-		SessionID: response.SessionID,
-		TxHex:     response.TxHex,
+		SessionID:                   response.SessionID,
+		TxHex:                       response.TxHex,
+		TaprootKeySpendSighashesHex: append([]string(nil), response.TaprootKeySpendSighashesHex...),
 	}, nil
 }
 
@@ -1852,7 +1877,13 @@ type buildTaggedTBTCSignerInteractiveSessionOpenRequest struct {
 	KeyGroup             string                                         `json:"key_group"`
 	Threshold            uint16                                         `json:"threshold"`
 	TaprootMerkleRootHex *string                                        `json:"taproot_merkle_root_hex,omitempty"`
+	SigningIntent        *buildTaggedTBTCSignerSigningIntent            `json:"signing_intent,omitempty"`
 	AttemptContext       buildTaggedTBTCSignerInteractiveAttemptContext `json:"attempt_context"`
+}
+
+type buildTaggedTBTCSignerSigningIntent struct {
+	Type       string `json:"type"`
+	MessageHex string `json:"message_hex"`
 }
 
 type buildTaggedTBTCSignerInteractiveSessionOpenResponse struct {
@@ -1901,6 +1932,7 @@ func (bttse *buildTaggedTBTCSignerEngine) InteractiveSessionOpen(
 	keyGroup string,
 	threshold uint16,
 	taprootMerkleRoot *[32]byte,
+	signingIntent *SigningIntent,
 	attemptContext NativeInteractiveAttemptContext,
 ) (*NativeInteractiveSessionOpenResult, error) {
 	requestPayload, err := buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
@@ -1910,6 +1942,7 @@ func (bttse *buildTaggedTBTCSignerEngine) InteractiveSessionOpen(
 		keyGroup,
 		threshold,
 		taprootMerkleRoot,
+		signingIntent,
 		attemptContext,
 	)
 	if err != nil {
@@ -1997,6 +2030,7 @@ func buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
 	keyGroup string,
 	threshold uint16,
 	taprootMerkleRoot *[32]byte,
+	signingIntent *SigningIntent,
 	attemptContext NativeInteractiveAttemptContext,
 ) ([]byte, error) {
 	if sessionID == "" {
@@ -2043,6 +2077,21 @@ func buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
 		taprootMerkleRootHex = &encoded
 	}
 
+	var wireSigningIntent *buildTaggedTBTCSignerSigningIntent
+	if signingIntent != nil {
+		heartbeatMessage, ok := signingIntent.HeartbeatMessage()
+		if !ok {
+			return nil, buildTaggedTBTCSignerOperationError(
+				"InteractiveSessionOpen",
+				"signing intent has an unsupported type",
+			)
+		}
+		wireSigningIntent = &buildTaggedTBTCSignerSigningIntent{
+			Type:       "heartbeat",
+			MessageHex: hex.EncodeToString(heartbeatMessage[:]),
+		}
+	}
+
 	return buildTaggedTBTCSignerMarshalRequest(
 		"InteractiveSessionOpen",
 		buildTaggedTBTCSignerInteractiveSessionOpenRequest{
@@ -2052,6 +2101,7 @@ func buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
 			KeyGroup:             keyGroup,
 			Threshold:            threshold,
 			TaprootMerkleRootHex: taprootMerkleRootHex,
+			SigningIntent:        wireSigningIntent,
 			AttemptContext: buildTaggedTBTCSignerInteractiveAttemptContext{
 				AttemptNumber:                   wireAttemptNumber,
 				CoordinatorIdentifier:           attemptContext.CoordinatorIdentifier,

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -67,7 +67,12 @@ func TestRegisterBuildTaggedTBTCSignerEngine(t *testing.T) {
 	_, err = engine.BuildTaprootTx(
 		"session-1",
 		[]NativeTBTCSignerTxInput{
-			{TxIDHex: "11", Vout: 0, ValueSats: 1},
+			{
+				TxIDHex:         "11",
+				Vout:            0,
+				ValueSats:       1,
+				ScriptPubKeyHex: "5120" + strings.Repeat("22", 32),
+			},
 		},
 		[]NativeTBTCSignerTxOutput{
 			{ScriptPubKeyHex: "0014", ValueSats: 1},
@@ -285,9 +290,10 @@ func TestBuildTaggedTBTCSignerBuildTaprootTxRequestPayload(t *testing.T) {
 		"session-buildtx-1",
 		[]NativeTBTCSignerTxInput{
 			{
-				TxIDHex:   strings.Repeat("11", 32),
-				Vout:      3,
-				ValueSats: 1000,
+				TxIDHex:         strings.Repeat("11", 32),
+				Vout:            3,
+				ValueSats:       1000,
+				ScriptPubKeyHex: "5120" + strings.Repeat("22", 32),
 			},
 		},
 		[]NativeTBTCSignerTxOutput{
@@ -330,6 +336,13 @@ func TestBuildTaggedTBTCSignerBuildTaprootTxRequestPayload(t *testing.T) {
 			request.Inputs[0].TxIDHex,
 		)
 	}
+	if request.Inputs[0].ScriptPubKeyHex != "5120"+strings.Repeat("22", 32) {
+		t.Fatalf(
+			"unexpected input script pubkey\nexpected: [%v]\nactual:   [%v]",
+			"5120"+strings.Repeat("22", 32),
+			request.Inputs[0].ScriptPubKeyHex,
+		)
+	}
 
 	if len(request.Outputs) != 1 {
 		t.Fatalf(
@@ -368,7 +381,7 @@ func TestBuildTaggedTBTCSignerBuildTaprootTxRequestPayload_RejectsInvalidInput(
 			name:      "empty session id",
 			sessionID: "",
 			inputs: []NativeTBTCSignerTxInput{
-				{TxIDHex: strings.Repeat("11", 32), Vout: 0, ValueSats: 1},
+				{TxIDHex: strings.Repeat("11", 32), Vout: 0, ValueSats: 1, ScriptPubKeyHex: "5120" + strings.Repeat("22", 32)},
 			},
 			outputs: []NativeTBTCSignerTxOutput{
 				{ScriptPubKeyHex: "0014aa", ValueSats: 1},
@@ -386,7 +399,7 @@ func TestBuildTaggedTBTCSignerBuildTaprootTxRequestPayload_RejectsInvalidInput(
 			name:      "empty outputs",
 			sessionID: "session-1",
 			inputs: []NativeTBTCSignerTxInput{
-				{TxIDHex: strings.Repeat("11", 32), Vout: 0, ValueSats: 1},
+				{TxIDHex: strings.Repeat("11", 32), Vout: 0, ValueSats: 1, ScriptPubKeyHex: "5120" + strings.Repeat("22", 32)},
 			},
 			outputs: nil,
 		},
@@ -394,7 +407,17 @@ func TestBuildTaggedTBTCSignerBuildTaprootTxRequestPayload_RejectsInvalidInput(
 			name:      "input txid empty",
 			sessionID: "session-1",
 			inputs: []NativeTBTCSignerTxInput{
-				{TxIDHex: "", Vout: 0, ValueSats: 1},
+				{TxIDHex: "", Vout: 0, ValueSats: 1, ScriptPubKeyHex: "5120" + strings.Repeat("22", 32)},
+			},
+			outputs: []NativeTBTCSignerTxOutput{
+				{ScriptPubKeyHex: "0014aa", ValueSats: 1},
+			},
+		},
+		{
+			name:      "input script empty",
+			sessionID: "session-1",
+			inputs: []NativeTBTCSignerTxInput{
+				{TxIDHex: strings.Repeat("11", 32), Vout: 0, ValueSats: 1},
 			},
 			outputs: []NativeTBTCSignerTxOutput{
 				{ScriptPubKeyHex: "0014aa", ValueSats: 1},
@@ -404,7 +427,7 @@ func TestBuildTaggedTBTCSignerBuildTaprootTxRequestPayload_RejectsInvalidInput(
 			name:      "output script empty",
 			sessionID: "session-1",
 			inputs: []NativeTBTCSignerTxInput{
-				{TxIDHex: strings.Repeat("11", 32), Vout: 0, ValueSats: 1},
+				{TxIDHex: strings.Repeat("11", 32), Vout: 0, ValueSats: 1, ScriptPubKeyHex: "5120" + strings.Repeat("22", 32)},
 			},
 			outputs: []NativeTBTCSignerTxOutput{
 				{ScriptPubKeyHex: "", ValueSats: 1},
@@ -414,7 +437,7 @@ func TestBuildTaggedTBTCSignerBuildTaprootTxRequestPayload_RejectsInvalidInput(
 			name:      "script tree empty string",
 			sessionID: "session-1",
 			inputs: []NativeTBTCSignerTxInput{
-				{TxIDHex: strings.Repeat("11", 32), Vout: 0, ValueSats: 1},
+				{TxIDHex: strings.Repeat("11", 32), Vout: 0, ValueSats: 1, ScriptPubKeyHex: "5120" + strings.Repeat("22", 32)},
 			},
 			outputs: []NativeTBTCSignerTxOutput{
 				{ScriptPubKeyHex: "0014aa", ValueSats: 1},
@@ -455,7 +478,7 @@ func TestBuildTaggedTBTCSignerBuildTaprootTxRequestPayload_RejectsInvalidInput(
 
 func TestDecodeBuildTaggedTBTCSignerBuildTaprootTxResponse(t *testing.T) {
 	result, err := decodeBuildTaggedTBTCSignerBuildTaprootTxResponse(
-		[]byte(`{"session_id":"session-buildtx-1","tx_hex":"deadbeef"}`),
+		[]byte(`{"session_id":"session-buildtx-1","tx_hex":"deadbeef","taproot_key_spend_sighashes_hex":["1111111111111111111111111111111111111111111111111111111111111111"]}`),
 	)
 	if err != nil {
 		t.Fatalf("unexpected decode error: [%v]", err)
@@ -475,6 +498,32 @@ func TestDecodeBuildTaggedTBTCSignerBuildTaprootTxResponse(t *testing.T) {
 			"deadbeef",
 			result.TxHex,
 		)
+	}
+	if len(result.TaprootKeySpendSighashesHex) != 1 ||
+		result.TaprootKeySpendSighashesHex[0] != strings.Repeat("11", 32) {
+		t.Fatalf(
+			"unexpected taproot key-spend sighashes: [%v]",
+			result.TaprootKeySpendSighashesHex,
+		)
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerBuildTaprootTxResponseRejectsMissingOrInvalidSighash(
+	t *testing.T,
+) {
+	for name, payload := range map[string]string{
+		"missing": `{"session_id":"session-buildtx-1","tx_hex":"deadbeef"}`,
+		"short":   `{"session_id":"session-buildtx-1","tx_hex":"deadbeef","taproot_key_spend_sighashes_hex":["11"]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := decodeBuildTaggedTBTCSignerBuildTaprootTxResponse([]byte(payload))
+			if err == nil {
+				t.Fatal("missing or malformed BIP-341 sighash must be rejected")
+			}
+			if !errors.Is(err, ErrNativeBridgeOperationFailed) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }
 
@@ -709,6 +758,7 @@ func TestBuildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(t *testing.T)
 		"key-group-1",
 		2,
 		nil,
+		nil,
 		testInteractiveAttemptContext(),
 	)
 	if err != nil {
@@ -738,6 +788,9 @@ func TestBuildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(t *testing.T)
 	if request.TaprootMerkleRootHex != nil {
 		t.Fatalf("expected omitted taproot root, got: [%v]", *request.TaprootMerkleRootHex)
 	}
+	if request.SigningIntent != nil {
+		t.Fatalf("generic signing must omit signing_intent, got: [%+v]", request.SigningIntent)
+	}
 	// Wire attempt_number is 1-based: the RFC-21 0-based 3 serializes as 4.
 	if request.AttemptContext.AttemptNumber != 4 ||
 		request.AttemptContext.CoordinatorIdentifier != 2 ||
@@ -760,7 +813,7 @@ func TestBuildTaggedTBTCSignerInteractiveSessionOpenRequestPayload_FirstAttemptI
 	ctx.AttemptNumber = 0 // RFC-21 first attempt
 
 	payload, err := buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
-		"session-1", 2, []byte{0xab}, "key-group-1", 2, nil, ctx,
+		"session-1", 2, []byte{0xab}, "key-group-1", 2, nil, nil, ctx,
 	)
 	if err != nil {
 		t.Fatalf("unexpected payload build error: [%v]", err)
@@ -784,7 +837,7 @@ func TestBuildTaggedTBTCSignerInteractiveSessionOpenRequestPayload_TaprootMerkle
 	root[31] = 0xcd
 
 	payload, err := buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
-		"session-1", 2, []byte{0xab}, "key-group-1", 2, &root, testInteractiveAttemptContext(),
+		"session-1", 2, []byte{0xab}, "key-group-1", 2, &root, nil, testInteractiveAttemptContext(),
 	)
 	if err != nil {
 		t.Fatalf("unexpected payload build error: [%v]", err)
@@ -799,6 +852,45 @@ func TestBuildTaggedTBTCSignerInteractiveSessionOpenRequestPayload_TaprootMerkle
 	}
 	if *request.TaprootMerkleRootHex != hex.EncodeToString(root[:]) {
 		t.Fatalf("unexpected taproot root hex: [%s]", *request.TaprootMerkleRootHex)
+	}
+}
+
+func TestBuildTaggedTBTCSignerInteractiveSessionOpenRequestPayload_HeartbeatIntent(t *testing.T) {
+	heartbeatMessage := [16]byte{
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+	}
+	payload, err := buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
+		"session-1",
+		2,
+		[]byte{0xab},
+		"key-group-1",
+		2,
+		nil,
+		NewHeartbeatSigningIntent(heartbeatMessage),
+		testInteractiveAttemptContext(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected payload build error: [%v]", err)
+	}
+
+	var request buildTaggedTBTCSignerInteractiveSessionOpenRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode request payload: [%v]", err)
+	}
+	if request.SigningIntent == nil {
+		t.Fatal("heartbeat signing must include signing_intent")
+	}
+	if request.SigningIntent.Type != "heartbeat" {
+		t.Fatalf("unexpected signing intent type: [%s]", request.SigningIntent.Type)
+	}
+	wantMessageHex := "ffffffffffffffff0001020304050607"
+	if request.SigningIntent.MessageHex != wantMessageHex {
+		t.Fatalf(
+			"unexpected heartbeat intent message: got [%s], want [%s]",
+			request.SigningIntent.MessageHex,
+			wantMessageHex,
+		)
 	}
 }
 
@@ -828,7 +920,7 @@ func TestBuildTaggedTBTCSignerInteractiveSessionOpenRequestPayload_RejectsInvali
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			_, err := buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
-				test.sessionID, test.member, test.message, test.keyGroup, test.threshold, nil, test.ctx,
+				test.sessionID, test.member, test.message, test.keyGroup, test.threshold, nil, nil, test.ctx,
 			)
 			if err == nil {
 				t.Fatal("expected invalid input to be rejected")
@@ -837,6 +929,13 @@ func TestBuildTaggedTBTCSignerInteractiveSessionOpenRequestPayload_RejectsInvali
 				t.Fatalf("expected ErrNativeBridgeOperationFailed, got: [%v]", err)
 			}
 		})
+	}
+
+	_, err := buildTaggedTBTCSignerInteractiveSessionOpenRequestPayload(
+		"s", 2, []byte{0xab}, "kg", 2, nil, &SigningIntent{}, ctx,
+	)
+	if err == nil {
+		t.Fatal("an unsupported signing intent must fail closed")
 	}
 }
 

--- a/pkg/frost/signing/native_tbtc_signer_abi_version.go
+++ b/pkg/frost/signing/native_tbtc_signer_abi_version.go
@@ -14,19 +14,19 @@ import (
 // fine and its extras are ignored). Bump these in lockstep with the Rust constants, in
 // the SAME PR that bumps ci/frost-signer-pin.env to the lib commit that provides them.
 const (
-	// Major 2: the coarse-FROST signing path and its FFI symbols
-	// (frost_tbtc_run_dkg, frost_tbtc_sign_share, frost_tbtc_aggregate,
-	// frost_tbtc_generate_nonces_and_commitments, frost_tbtc_start_sign_round,
-	// frost_tbtc_finalize_sign_round) were removed. Dropping exported symbols is a
-	// breaking ABI change, so the lib's abi_major moves 1 -> 2 in lockstep and this
-	// bridge requires exactly 2: a lib still reporting major 1 exposes the retired
-	// coarse contract and must not be linked.
-	requiredTBTCSignerABIMajor uint32 = 2
-	// Minor 0: frost_tbtc_persist_distributed_dkg_key_package - which the
-	// distributed-DKG path calls - is baseline in major 2 (it was added in 1.1 and
-	// carried forward), so the minimum minor for major 2 is 0. Additive minor bumps
-	// on major 2 remain backward compatible and their extras are ignored.
-	requiredTBTCSignerABIMinMinor uint32 = 0
+	// Major 3: BuildTaprootTx now requires every input's spent-output
+	// scriptPubKey and returns the ordered BIP-341 SIGHASH_DEFAULT key-spend
+	// messages. The required request field and changed response semantics are an
+	// incompatible JSON/crypto-contract change, so an ABI-2 library must not be
+	// linked by this bridge.
+	requiredTBTCSignerABIMajor uint32 = 3
+	// Minor 1 adds the typed heartbeat signing intent required to authorize
+	// non-transaction messages while the signing-policy firewall is on. Minor 2
+	// adds the heartbeat rate-limit configuration and dedicated rejection metric.
+	// Minor 3 adds the canary-evidence configuration, including its independent
+	// policy-sample minimum, and pins this bridge to the complete
+	// durability/rollout-assurance signer stack.
+	requiredTBTCSignerABIMinMinor uint32 = 3
 )
 
 // ErrTBTCSignerABIIncompatible marks a linked libfrost_tbtc whose FFI contract version
@@ -39,11 +39,11 @@ var ErrTBTCSignerABIIncompatible = errors.New(
 // parseTBTCSignerABIVersion decodes the frozen {abi_major, abi_minor} root compatibility
 // surface from the lib's frost_tbtc_abi_version response and rejects anything malformed
 // as incompatible. BOTH fields are required: pointer fields distinguish "absent" from a
-// legitimate zero, because Go's json.Unmarshal silently zero-fills a missing field - and
-// a missing abi_minor would otherwise default to 0 and pass the (>= 0) rule, letting a
-// partial/broken lib bypass the fail-closed guard. Extra/unknown fields are tolerated by
-// design (an additive minor bump may add fields old bridges ignore). Pure (no cgo), so
-// it is unit-tested in the default build.
+// legitimate zero, because Go's json.Unmarshal silently zero-fills a missing field.
+// Both fields remain mandatory even when that zero would fail today's minimum: accepting
+// a partial version response would weaken the frozen compatibility contract. Extra/unknown
+// fields are tolerated by design (an additive minor bump may add fields old bridges ignore).
+// Pure (no cgo), so it is unit-tested in the default build.
 func parseTBTCSignerABIVersion(payload []byte) (major, minor uint32, err error) {
 	var decoded struct {
 		AbiMajor *uint32 `json:"abi_major"`

--- a/pkg/frost/signing/native_tbtc_signer_abi_version_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_abi_version_test.go
@@ -7,8 +7,7 @@ import (
 
 func TestCheckABIContractCompatibility(t *testing.T) {
 	// req = major 1, min minor 2, to exercise every branch (the too-old-minor branch is
-	// unreachable against the real requiredTBTCSignerABIMinMinor of 0, since no minor is
-	// below zero).
+	// kept parameterized so every compatibility branch remains explicit.
 	const reqMajor, reqMinMinor = uint32(1), uint32(2)
 	tests := []struct {
 		name           string
@@ -51,8 +50,8 @@ func TestParseTBTCSignerABIVersion(t *testing.T) {
 		}
 	})
 
-	// Both fields are REQUIRED: a missing field must be rejected, not zero-filled - else
-	// a partial lib omitting abi_minor would default to 0 and pass the (>= 0) rule.
+	// Both fields are REQUIRED: a missing field must be rejected, not silently
+	// zero-filled into a partial compatibility response.
 	rejected := map[string]string{
 		"missing abi_minor": `{"abi_major":1}`,
 		"missing abi_major": `{"abi_minor":0}`,
@@ -90,15 +89,27 @@ func TestParseTBTCSignerABIVersion(t *testing.T) {
 }
 
 func TestCheckTBTCSignerABICompatibility_CurrentContract(t *testing.T) {
-	// Pins the bridge's current required contract (major 2, min minor 0 - major bumped
-	// to 2 when the coarse-FROST FFI symbols were removed): the matching lib version is
-	// compatible; a different major is not. A regression here means the required
-	// constants drifted from what the bridge actually speaks.
+	// Pins the bridge's current required contract: major 3 adds the BIP-341
+	// transaction artifact, minor 1 adds heartbeat intent authorization, and
+	// minor 2 adds heartbeat rate limiting/metrics; minor 3 adds canary-evidence
+	// configuration. The matching library version is compatible; a different
+	// major is not. A regression here means the required constants drifted from
+	// what the bridge actually speaks.
+	if requiredTBTCSignerABIMajor != 3 || requiredTBTCSignerABIMinMinor != 3 {
+		t.Fatalf(
+			"unexpected required tbtc-signer ABI: [%d.%d]",
+			requiredTBTCSignerABIMajor,
+			requiredTBTCSignerABIMinMinor,
+		)
+	}
 	if err := checkTBTCSignerABICompatibility(requiredTBTCSignerABIMajor, requiredTBTCSignerABIMinMinor); err != nil {
 		t.Fatalf("the required contract version must be self-compatible: %v", err)
 	}
 	if err := checkTBTCSignerABICompatibility(requiredTBTCSignerABIMajor+1, requiredTBTCSignerABIMinMinor); err == nil {
 		t.Fatal("a higher major must be incompatible")
+	}
+	if err := checkTBTCSignerABICompatibility(2, 0); err == nil {
+		t.Fatal("an ABI-2 signer without the BIP-341 transaction artifact must be incompatible")
 	}
 	// Any minor >= the required minimum is accepted (additive).
 	if err := checkTBTCSignerABICompatibility(requiredTBTCSignerABIMajor, requiredTBTCSignerABIMinMinor+3); err != nil {

--- a/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
+++ b/pkg/frost/signing/native_tbtc_signer_engine_frost_native.go
@@ -16,9 +16,10 @@ type NativeTBTCSignerDKGResult struct {
 // NativeTBTCSignerTxInput describes an unsigned transaction input consumed by
 // BuildTaprootTx.
 type NativeTBTCSignerTxInput struct {
-	TxIDHex   string `json:"txIDHex"`
-	Vout      uint32 `json:"vout"`
-	ValueSats uint64 `json:"valueSats"`
+	TxIDHex         string `json:"txIDHex"`
+	Vout            uint32 `json:"vout"`
+	ValueSats       uint64 `json:"valueSats"`
+	ScriptPubKeyHex string `json:"scriptPubKeyHex"`
 }
 
 // NativeTBTCSignerTxOutput describes an unsigned transaction output consumed
@@ -31,8 +32,9 @@ type NativeTBTCSignerTxOutput struct {
 // NativeTBTCSignerTxResult captures unsigned transaction metadata returned by
 // BuildTaprootTx.
 type NativeTBTCSignerTxResult struct {
-	SessionID string `json:"sessionID"`
-	TxHex     string `json:"txHex"`
+	SessionID                   string   `json:"sessionID"`
+	TxHex                       string   `json:"txHex"`
+	TaprootKeySpendSighashesHex []string `json:"taprootKeySpendSighashesHex"`
 }
 
 // NativeShareVerificationVerdict is the typed result of a single-share FROST

--- a/pkg/frost/signing/request.go
+++ b/pkg/frost/signing/request.go
@@ -13,6 +13,11 @@ import (
 type Request struct {
 	Message   *big.Int
 	SessionID string
+	// SigningIntent carries a narrowly typed authorization artifact for messages
+	// that are not transaction sighashes. It is nil for generic and transaction
+	// signing. Today the only supported value is a heartbeat intent created with
+	// NewHeartbeatSigningIntent.
+	SigningIntent *SigningIntent
 	// RoastSessionID is the STABLE per-signing ROAST session id (derived from
 	// message+root+startBlock, WITHOUT the attempt number), used for ROAST
 	// orchestration, AttemptContext.SessionID, the transition-record registry,
@@ -38,6 +43,45 @@ type Request struct {
 	Channel             net.BroadcastChannel
 	MembershipValidator *group.MembershipValidator
 	Attempt             *Attempt
+}
+
+// SigningIntent is a closed, immutable signing-intent value. Its fields stay
+// private so callers cannot manufacture an unvalidated intent shape; exported
+// constructors are the only way to create one.
+type SigningIntent struct {
+	heartbeatMessage *[16]byte
+}
+
+// NewHeartbeatSigningIntent authorizes the canonical heartbeat signing message
+// derived from the exact 16-byte proposal payload. The payload is copied so it
+// cannot be changed while a concurrent signing attempt is in flight.
+func NewHeartbeatSigningIntent(message [16]byte) *SigningIntent {
+	messageCopy := message
+	return &SigningIntent{heartbeatMessage: &messageCopy}
+}
+
+// HeartbeatMessage returns the raw heartbeat proposal payload carried by this
+// intent. The returned array is a copy.
+func (si *SigningIntent) HeartbeatMessage() ([16]byte, bool) {
+	if si == nil || si.heartbeatMessage == nil {
+		return [16]byte{}, false
+	}
+
+	return *si.heartbeatMessage, true
+}
+
+func cloneSigningIntent(intent *SigningIntent) *SigningIntent {
+	if intent == nil {
+		return nil
+	}
+
+	cloned := *intent
+	if intent.heartbeatMessage != nil {
+		messageCopy := *intent.heartbeatMessage
+		cloned.heartbeatMessage = &messageCopy
+	}
+
+	return &cloned
 }
 
 // LegacyPrivateKeyShare resolves the tECDSA private key share required by the

--- a/pkg/frost/signing/roast_interactive_signing_drive_frost_native.go
+++ b/pkg/frost/signing/roast_interactive_signing_drive_frost_native.go
@@ -135,6 +135,7 @@ func driveInteractiveRoastSigningIfEnabled(
 		active,
 		request.MemberIndex,
 		threshold,
+		request.SigningIntent,
 		engine,
 		collector,
 		deps.Coordinator,

--- a/pkg/frost/signing/roast_real_cgo_interactive_e2e_frost_native_test.go
+++ b/pkg/frost/signing/roast_real_cgo_interactive_e2e_frost_native_test.go
@@ -15,6 +15,9 @@ import (
 	"testing"
 	"time"
 
+	btcec2 "github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
@@ -22,6 +25,21 @@ import (
 // repeats (go test -count=N) over the shared, process-stable signer state path add
 // a fresh DKG session instead of conflicting on a fixed one.
 var realCgoSessionSeq atomic.Uint64
+
+type realCgoSingleTransactionChain struct {
+	bitcoin.Chain
+	transaction *bitcoin.Transaction
+}
+
+func (rcstc *realCgoSingleTransactionChain) GetTransaction(
+	transactionHash bitcoin.Hash,
+) (*bitcoin.Transaction, error) {
+	if rcstc.transaction == nil || rcstc.transaction.Hash() != transactionHash {
+		return nil, fmt.Errorf("transaction [%s] not found", transactionHash)
+	}
+
+	return rcstc.transaction, nil
+}
 
 // This file is the REAL-cgo interactive signing test: a full FROST DKG that
 // PERSISTS a key group, followed by one signer's interactive ROAST contribution
@@ -120,6 +138,7 @@ func TestRealCgoInteractiveSigning_MemberContribution(t *testing.T) {
 		keyGroup,
 		threshold,
 		nil, // key-path spend
+		nil, // generic signing has no typed intent
 		derived.AttemptContext,
 	)
 	skipFrostUnavailable(t, "interactive session open", err)
@@ -137,16 +156,18 @@ func TestRealCgoInteractiveSigning_MemberContribution(t *testing.T) {
 	}
 }
 
-// TestRealCgoInteractiveSigning_MultiSeatAggregate drives TWO local seats through the
-// FULL interactive signing flow in ONE process against the real cgo engine, producing a
-// real 2-of-3 BIP-340 signature. This is the payoff of the multi-seat engine fix
+// TestRealCgoInteractiveSigning_MultiSeatHeartbeatAggregate drives TWO local seats
+// through the FULL typed-heartbeat signing flow in ONE process against the real cgo
+// engine, producing a real 2-of-3 BIP-340 signature while the policy firewall is on.
+// This is also the payoff of the multi-seat engine fix
 // (member-keyed interactive_signing): before it, the second seat's InteractiveSessionOpen
 // failed with SessionConflict, so a single process could only drive one seat's
 // contribution (see _MemberContribution). Now both seats Open, Round1, and Round2
 // independently and their shares aggregate. Skip-guarded; runs only against a linked,
 // CURRENT libfrost_tbtc that includes the multi-seat fix.
-func TestRealCgoInteractiveSigning_MultiSeatAggregate(t *testing.T) {
+func TestRealCgoInteractiveSigning_MultiSeatHeartbeatAggregate(t *testing.T) {
 	setupRealCgoSignerState(t)
+	t.Setenv("TBTC_SIGNER_ENFORCE_SIGNING_POLICY_FIREWALL", "true")
 
 	engine := &buildTaggedTBTCSignerEngine{}
 
@@ -155,7 +176,13 @@ func TestRealCgoInteractiveSigning_MultiSeatAggregate(t *testing.T) {
 	participantIDs := []byte{1, 2, 3}
 	// Both seats are LOCAL members in this one process (the multi-seat case).
 	signingMembers := []byte{1, 2}
-	message := bytesOf(0x42, 32)
+	heartbeatMessage := [16]byte{
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	}
+	heartbeatDigest := bitcoin.ComputeHash(heartbeatMessage[:])
+	message := heartbeatDigest[:]
+	signingIntent := NewHeartbeatSigningIntent(heartbeatMessage)
 
 	keyGroup := runRealCgoDKGKeyGroup(t, engine, sessionID, participantIDs, threshold)
 
@@ -184,7 +211,8 @@ func TestRealCgoInteractiveSigning_MultiSeatAggregate(t *testing.T) {
 			message,
 			keyGroup,
 			threshold,
-			nil, // key-path spend
+			nil, // a heartbeat must not carry a Taproot merkle root
+			signingIntent,
 			derived.AttemptContext,
 		)
 		if isPreMultiSeatConflict(err) {
@@ -247,6 +275,191 @@ func TestRealCgoInteractiveSigning_MultiSeatAggregate(t *testing.T) {
 	skipFrostUnavailable(t, "interactive aggregate", err)
 	if len(signature) != 64 {
 		t.Fatalf("unexpected multi-seat interactive signature length: %d", len(signature))
+	}
+}
+
+func TestRealCgoBuildTaprootTxMatchesGoBIP341Sighash(t *testing.T) {
+	setupRealCgoSignerState(t)
+	t.Setenv("TBTC_SIGNER_ENFORCE_SIGNING_POLICY_FIREWALL", "true")
+	t.Setenv("TBTC_SIGNER_POLICY_ALLOWED_SCRIPT_CLASSES", "p2wpkh")
+	t.Setenv("TBTC_SIGNER_POLICY_MAX_OUTPUT_COUNT", "64")
+	t.Setenv("TBTC_SIGNER_POLICY_MAX_OUTPUT_VALUE_SATS", "100000000")
+	t.Setenv("TBTC_SIGNER_POLICY_MAX_TOTAL_OUTPUT_VALUE_SATS", "100000000")
+
+	engine := &buildTaggedTBTCSignerEngine{}
+	signingSessionID := fmt.Sprintf(
+		"real-cgo-bip341-signing-%d",
+		realCgoSessionSeq.Add(1),
+	)
+
+	privateKeyBytes := bytesOf(0x01, 32)
+	_, publicKey := btcec2.PrivKeyFromBytes(privateKeyBytes)
+	var taprootOutputKey [32]byte
+	copy(taprootOutputKey[:], schnorr.SerializePubKey(publicKey))
+	prevoutScript, err := bitcoin.PayToTaproot(taprootOutputKey)
+	if err != nil {
+		t.Fatalf("build P2TR prevout script: %v", err)
+	}
+	var outputPublicKeyHash [20]byte
+	copy(outputPublicKeyHash[:], bytesOf(0x02, 20))
+	outputScript, err := bitcoin.PayToWitnessPublicKeyHash(outputPublicKeyHash)
+	if err != nil {
+		t.Fatalf("build P2WPKH output script: %v", err)
+	}
+
+	previousTransaction := &bitcoin.Transaction{
+		Version: 1,
+		Inputs: []*bitcoin.TransactionInput{
+			{
+				Outpoint: &bitcoin.TransactionOutpoint{
+					TransactionHash: bitcoin.Hash{
+						0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+						0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+						0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
+						0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
+					},
+					OutputIndex: 0,
+				},
+				SignatureScript: []byte{0x51},
+				Sequence:        0xffffffff,
+			},
+		},
+		Outputs: []*bitcoin.TransactionOutput{
+			{Value: 100_000, PublicKeyScript: prevoutScript},
+		},
+		Locktime: 0,
+	}
+	txIDHex := previousTransaction.Hash().Hex(bitcoin.ReversedByteOrder)
+	const inputValue = int64(100_000)
+	const outputValue = int64(90_000)
+
+	result, err := engine.BuildTaprootTx(
+		signingSessionID,
+		[]NativeTBTCSignerTxInput{
+			{
+				TxIDHex:         txIDHex,
+				Vout:            0,
+				ValueSats:       uint64(inputValue),
+				ScriptPubKeyHex: hex.EncodeToString(prevoutScript),
+			},
+		},
+		[]NativeTBTCSignerTxOutput{
+			{
+				ScriptPubKeyHex: hex.EncodeToString(outputScript),
+				ValueSats:       uint64(outputValue),
+			},
+		},
+		nil,
+	)
+	skipFrostUnavailable(t, "BIP-341 BuildTaprootTx", err)
+
+	if len(result.TaprootKeySpendSighashesHex) != 1 {
+		t.Fatalf(
+			"BuildTaprootTx returned %d sighashes, want 1",
+			len(result.TaprootKeySpendSighashesHex),
+		)
+	}
+
+	referenceBuilder := bitcoin.NewTransactionBuilder(
+		&realCgoSingleTransactionChain{transaction: previousTransaction},
+	)
+	if err := referenceBuilder.AddTaprootKeyPathInput(
+		&bitcoin.UnspentTransactionOutput{
+			Outpoint: &bitcoin.TransactionOutpoint{
+				TransactionHash: previousTransaction.Hash(),
+				OutputIndex:     0,
+			},
+			Value: inputValue,
+		},
+	); err != nil {
+		t.Fatalf("add reference P2TR input: %v", err)
+	}
+	referenceBuilder.AddOutput(
+		&bitcoin.TransactionOutput{
+			Value:           outputValue,
+			PublicKeyScript: outputScript,
+		},
+	)
+	expectedUnsignedTransaction := referenceBuilder.UnsignedTransaction()
+	expectedTxHex := hex.EncodeToString(expectedUnsignedTransaction.Serialize())
+	if result.TxHex != expectedTxHex {
+		t.Fatalf(
+			"BuildTaprootTx returned a different unsigned transaction: Rust=%s Go=%s txid=%s",
+			result.TxHex,
+			expectedTxHex,
+			txIDHex,
+		)
+	}
+
+	expectedSighashes, err := referenceBuilder.ComputeSignatureHashes()
+	if err != nil {
+		t.Fatalf("calculate Go BIP-341 sighash: %v", err)
+	}
+	if len(expectedSighashes) != 1 {
+		t.Fatalf("Go builder returned %d sighashes, want 1", len(expectedSighashes))
+	}
+	expectedSighashHex := fmt.Sprintf("%064x", expectedSighashes[0])
+	if result.TaprootKeySpendSighashesHex[0] != expectedSighashHex {
+		t.Fatalf(
+			"cross-language BIP-341 sighash mismatch: Rust=%s Go=%s txid=%s tx=%s",
+			result.TaprootKeySpendSighashesHex[0],
+			expectedSighashHex,
+			txIDHex,
+			result.TxHex,
+		)
+	}
+
+	// Complete the production ownership path: DKG material remains on the
+	// long-lived wallet session, while BuildTaprootTx and the interactive flow
+	// share a distinct per-signing ROAST session. With the firewall enabled,
+	// Open can succeed only if it reads the BIP-341 artifact from that signing
+	// session and resolves only wallet lifecycle/key material through keyGroup.
+	walletSessionID := fmt.Sprintf(
+		"real-cgo-bip341-wallet-%d",
+		realCgoSessionSeq.Add(1),
+	)
+	const threshold = 2
+	const localMember = uint16(1)
+	includedMembers := []byte{1, 2}
+	keyGroup := runRealCgoDKGKeyGroup(
+		t,
+		engine,
+		walletSessionID,
+		[]byte{1, 2, 3},
+		threshold,
+	)
+	message, err := hex.DecodeString(result.TaprootKeySpendSighashesHex[0])
+	if err != nil {
+		t.Fatalf("decode Rust BIP-341 message: %v", err)
+	}
+	derived, err := engine.DeriveInteractiveAttemptContext(
+		signingSessionID,
+		message,
+		keyGroup,
+		threshold,
+		0,
+		uint16sOf(includedMembers),
+	)
+	skipFrostUnavailable(t, "derive policy-bound interactive attempt", err)
+	opened, err := engine.InteractiveSessionOpen(
+		signingSessionID,
+		localMember,
+		message,
+		keyGroup,
+		threshold,
+		nil,
+		nil,
+		derived.AttemptContext,
+	)
+	skipFrostUnavailable(t, "open policy-bound interactive session", err)
+	commitment, err := engine.InteractiveRound1(
+		signingSessionID,
+		opened.AttemptID,
+		localMember,
+	)
+	skipFrostUnavailable(t, "policy-bound interactive round 1", err)
+	if len(commitment) == 0 {
+		t.Fatal("policy-bound interactive round 1 returned an empty commitment")
 	}
 }
 

--- a/pkg/frost/signing/roast_runner_bus_net_e2e_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_bus_net_e2e_frost_native_test.go
@@ -114,7 +114,7 @@ func buildInteractiveSigningNetHarness(
 		engine.coordinatorIdentifier = uint16(ara.ElectedCoordinator())
 		collector := roast.NewRound2Collector(verifier)
 		runner, err := newInteractiveSigningRunner(
-			ara, member, threshold, engine, collector, coord, signer, bus,
+			ara, member, threshold, nil, engine, collector, coord, signer, bus,
 		)
 		if err != nil {
 			t.Fatalf("runner (seat %d): %v", member, err)

--- a/pkg/frost/signing/roast_runner_engine_frost_native.go
+++ b/pkg/frost/signing/roast_runner_engine_frost_native.go
@@ -39,6 +39,7 @@ type interactiveSigningEngine interface {
 		keyGroup string,
 		threshold uint16,
 		taprootMerkleRoot *[32]byte,
+		signingIntent *SigningIntent,
 		attemptContext NativeInteractiveAttemptContext,
 	) (*NativeInteractiveSessionOpenResult, error)
 

--- a/pkg/frost/signing/roast_runner_engine_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_engine_frost_native_test.go
@@ -41,6 +41,7 @@ type fakeInteractiveSigningEngine struct {
 	aggregateCalls            int
 	abortCalls                int
 	deriveCalls               int
+	lastOpenSigningIntent     *SigningIntent
 	lastAggregateShares       []nativeFROSTSignatureShare
 	lastNewPackageCommitments []nativeFROSTCommitment
 }
@@ -100,6 +101,12 @@ func (f *fakeInteractiveSigningEngine) round2CallCount() int {
 	return f.round2Calls
 }
 
+func (f *fakeInteractiveSigningEngine) openSigningIntent() *SigningIntent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return cloneSigningIntent(f.lastOpenSigningIntent)
+}
+
 // newPackageCommitments returns a copy of the commitments the engine last built a
 // signing package over - the chosen t-subset for the coordinator.
 func (f *fakeInteractiveSigningEngine) newPackageCommitments() []nativeFROSTCommitment {
@@ -139,10 +146,12 @@ func (f *fakeInteractiveSigningEngine) InteractiveSessionOpen(
 	keyGroup string,
 	threshold uint16,
 	taprootMerkleRoot *[32]byte,
+	signingIntent *SigningIntent,
 	attemptContext NativeInteractiveAttemptContext,
 ) (*NativeInteractiveSessionOpenResult, error) {
 	f.mu.Lock()
 	f.openCalls++
+	f.lastOpenSigningIntent = cloneSigningIntent(signingIntent)
 	f.mu.Unlock()
 	return &NativeInteractiveSessionOpenResult{
 		SessionID:  sessionID,
@@ -205,7 +214,7 @@ func (f *fakeInteractiveSigningEngine) InteractiveAggregate(
 func TestFakeInteractiveSigningEngine_Programmable(t *testing.T) {
 	engine := newFakeInteractiveSigningEngine()
 
-	open, err := engine.InteractiveSessionOpen("s", 1, []byte("m"), "kg", 2, nil, NativeInteractiveAttemptContext{})
+	open, err := engine.InteractiveSessionOpen("s", 1, []byte("m"), "kg", 2, nil, nil, NativeInteractiveAttemptContext{})
 	if err != nil || open.AttemptID != "attempt-1" {
 		t.Fatalf("unexpected open result: %+v err=%v", open, err)
 	}

--- a/pkg/frost/signing/roast_runner_frost_native.go
+++ b/pkg/frost/signing/roast_runner_frost_native.go
@@ -50,6 +50,7 @@ type interactiveSigningRunner struct {
 	// message inconsistent with the attempt it is bound to.
 	messageDigest []byte
 	threshold     uint16
+	signingIntent *SigningIntent
 	// includedMembers is the attempt's included set as a lookup, cached at
 	// construction. It gates which shares the collector retains as evidence (any
 	// included member's, even a non-signer observer's divergent share), distinct
@@ -77,6 +78,7 @@ func newInteractiveSigningRunner(
 	attempt *ActiveRoastAttempt,
 	member group.MemberIndex,
 	threshold uint16,
+	signingIntent *SigningIntent,
 	engine interactiveSigningEngine,
 	collector *roast.Round2Collector,
 	coordinator roast.Coordinator,
@@ -125,6 +127,7 @@ func newInteractiveSigningRunner(
 		member:          member,
 		messageDigest:   append([]byte(nil), attemptCtx.MessageDigest[:]...),
 		threshold:       threshold,
+		signingIntent:   cloneSigningIntent(signingIntent),
 		includedMembers: setOf(attemptCtx.IncludedSet),
 		engine:          engine,
 		collector:       collector,
@@ -190,6 +193,7 @@ func (r *interactiveSigningRunner) Run(ctx context.Context) ([]byte, error) {
 		attemptCtx.KeyGroupID,
 		r.threshold,
 		binding.TaprootMerkleRoot(),
+		r.signingIntent,
 		derived.AttemptContext,
 	)
 	if err != nil {

--- a/pkg/frost/signing/roast_runner_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_frost_native_test.go
@@ -45,8 +45,20 @@ type harness struct {
 // buildInteractiveSigningHarness wires n nodes - each with its own coordinator,
 // collector, and fake engine - to one shared in-process bus. Every node
 // subscribes in its constructor, so all are wired before any Run broadcasts.
-func buildInteractiveSigningHarness(t *testing.T, n int, threshold uint16) harness {
+func buildInteractiveSigningHarness(
+	t *testing.T,
+	n int,
+	threshold uint16,
+	signingIntents ...*SigningIntent,
+) harness {
 	t.Helper()
+	if len(signingIntents) > 1 {
+		t.Fatal("at most one signing intent may be supplied")
+	}
+	var signingIntent *SigningIntent
+	if len(signingIntents) == 1 {
+		signingIntent = signingIntents[0]
+	}
 	included := make([]group.MemberIndex, 0, n)
 	for i := 1; i <= n; i++ {
 		included = append(included, group.MemberIndex(i))
@@ -83,7 +95,7 @@ func buildInteractiveSigningHarness(t *testing.T, n int, threshold uint16) harne
 		// coordinator the binding did).
 		engine.coordinatorIdentifier = uint16(ara.ElectedCoordinator())
 		runner, err := newInteractiveSigningRunner(
-			ara, member, threshold,
+			ara, member, threshold, signingIntent,
 			engine,
 			collector,
 			coord, signer, bus,
@@ -104,6 +116,44 @@ func buildInteractiveSigningHarness(t *testing.T, n int, threshold uint16) harne
 		h.runners = append(h.runners, runner)
 	}
 	return h
+}
+
+func TestInteractiveSigningRunner_PassesHeartbeatIntentToOpen(t *testing.T) {
+	heartbeatMessage := [16]byte{
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+	}
+	h := buildInteractiveSigningHarness(
+		t,
+		2,
+		2,
+		NewHeartbeatSigningIntent(heartbeatMessage),
+	)
+	h.runAndAssertAllSucceed(t)
+
+	for i, engine := range h.engines {
+		intentMessage, ok := engine.openSigningIntent().HeartbeatMessage()
+		if !ok || intentMessage != heartbeatMessage {
+			t.Fatalf(
+				"engine %d Open received heartbeat [%x], present [%v], want [%x]",
+				i+1,
+				intentMessage,
+				ok,
+				heartbeatMessage,
+			)
+		}
+	}
+}
+
+func TestInteractiveSigningRunner_GenericOpenHasNoSigningIntent(t *testing.T) {
+	h := buildInteractiveSigningHarness(t, 2, 2)
+	h.runAndAssertAllSucceed(t)
+
+	for i, engine := range h.engines {
+		if intent := engine.openSigningIntent(); intent != nil {
+			t.Fatalf("engine %d generic Open received signing intent [%+v]", i+1, intent)
+		}
+	}
 }
 
 // runAll runs every node concurrently and asserts each reaches a successful
@@ -417,7 +467,7 @@ func TestInteractiveSigningRunner_AbortsNativeAttemptOnEarlyExit(t *testing.T) {
 	engine := newFakeInteractiveSigningEngine()
 	engine.coordinatorIdentifier = uint16(ara.ElectedCoordinator())
 	runner, err := newInteractiveSigningRunner(
-		ara, 1, 2, engine, roast.NewRound2Collector(verifier), coord, signer, bus,
+		ara, 1, 2, nil, engine, roast.NewRound2Collector(verifier), coord, signer, bus,
 	)
 	if err != nil {
 		t.Fatalf("runner: %v", err)
@@ -469,7 +519,7 @@ func TestInteractiveSigningRunner_RejectsEngineCoordinatorMismatch(t *testing.T)
 	// Engine derives a coordinator the binding did NOT elect.
 	engine.coordinatorIdentifier = uint16(ara.ElectedCoordinator()) + 100
 	runner, err := newInteractiveSigningRunner(
-		ara, 1, 2, engine, roast.NewRound2Collector(verifier), coord, signer, bus,
+		ara, 1, 2, nil, engine, roast.NewRound2Collector(verifier), coord, signer, bus,
 	)
 	if err != nil {
 		t.Fatalf("runner: %v", err)
@@ -653,7 +703,7 @@ func buildEquivocationRunner(t *testing.T, included []group.MemberIndex) (
 	}
 	collector := roast.NewRound2Collector(verifier)
 	runner, err := newInteractiveSigningRunner(
-		ara, included[0], 2, newFakeInteractiveSigningEngine(), collector, coord, signer, bus,
+		ara, included[0], 2, nil, newFakeInteractiveSigningEngine(), collector, coord, signer, bus,
 	)
 	if err != nil {
 		t.Fatalf("runner: %v", err)
@@ -979,38 +1029,38 @@ func TestNewInteractiveSigningRunner_RejectsInvalidConstruction(t *testing.T) {
 	collector := roast.NewRound2Collector(verifier)
 
 	// Sanity: the baseline constructs.
-	if _, err := newInteractiveSigningRunner(ara, 1, 2, engine, collector, coord, signer, bus); err != nil {
+	if _, err := newInteractiveSigningRunner(ara, 1, 2, nil, engine, collector, coord, signer, bus); err != nil {
 		t.Fatalf("baseline construction failed: %v", err)
 	}
 
 	tests := map[string]func() (*interactiveSigningRunner, error){
 		"nil attempt": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(nil, 1, 2, engine, collector, coord, signer, bus)
+			return newInteractiveSigningRunner(nil, 1, 2, nil, engine, collector, coord, signer, bus)
 		},
 		"nil engine": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 1, 2, nil, collector, coord, signer, bus)
+			return newInteractiveSigningRunner(ara, 1, 2, nil, nil, collector, coord, signer, bus)
 		},
 		"nil collector": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 1, 2, engine, nil, coord, signer, bus)
+			return newInteractiveSigningRunner(ara, 1, 2, nil, engine, nil, coord, signer, bus)
 		},
 		"nil coordinator": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 1, 2, engine, collector, nil, signer, bus)
+			return newInteractiveSigningRunner(ara, 1, 2, nil, engine, collector, nil, signer, bus)
 		},
 		"nil signer": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 1, 2, engine, collector, coord, nil, bus)
+			return newInteractiveSigningRunner(ara, 1, 2, nil, engine, collector, coord, nil, bus)
 		},
 		"nil bus": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 1, 2, engine, collector, coord, signer, nil)
+			return newInteractiveSigningRunner(ara, 1, 2, nil, engine, collector, coord, signer, nil)
 		},
 		"zero threshold": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 1, 0, engine, collector, coord, signer, bus)
+			return newInteractiveSigningRunner(ara, 1, 0, nil, engine, collector, coord, signer, bus)
 		},
 		"member not included": func() (*interactiveSigningRunner, error) {
-			return newInteractiveSigningRunner(ara, 99, 2, engine, collector, coord, signer, bus)
+			return newInteractiveSigningRunner(ara, 99, 2, nil, engine, collector, coord, signer, bus)
 		},
 		"threshold exceeds included set": func() (*interactiveSigningRunner, error) {
 			// included set has 3 members; a threshold of 4 can never form a subset.
-			return newInteractiveSigningRunner(ara, 1, 4, engine, collector, coord, signer, bus)
+			return newInteractiveSigningRunner(ara, 1, 4, nil, engine, collector, coord, signer, bus)
 		},
 	}
 	for name, build := range tests {
@@ -1086,7 +1136,7 @@ func TestInteractiveSigningRunner_ObserverAggregatesAndAbortsWithoutSigning(t *t
 	engine := newFakeInteractiveSigningEngine()
 	engine.coordinatorIdentifier = uint16(ara.ElectedCoordinator())
 	runner, err := newInteractiveSigningRunner(
-		ara, observer, 2, engine, roast.NewRound2Collector(verifier), coord, signer, bus,
+		ara, observer, 2, nil, engine, roast.NewRound2Collector(verifier), coord, signer, bus,
 	)
 	if err != nil {
 		t.Fatalf("runner: %v", err)

--- a/pkg/frost/signing/roast_runner_real_cgo_dropout_retry_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_real_cgo_dropout_retry_frost_native_test.go
@@ -171,7 +171,7 @@ func TestRealCgoInteractiveSigning_DropoutForcesNextAttemptAndReshuffledSubsetFi
 		}
 		collector := roast.NewRound2Collector(verifier)
 		runner, err := newInteractiveSigningRunner(
-			binding, member, threshold, engine, collector, coord, signer, bus,
+			binding, member, threshold, nil, engine, collector, coord, signer, bus,
 		)
 		if err != nil {
 			t.Fatalf("runner (seat %d): %v", member, err)

--- a/pkg/frost/signing/roast_runner_real_cgo_invalid_share_exclusion_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_real_cgo_invalid_share_exclusion_frost_native_test.go
@@ -156,7 +156,7 @@ func TestRealCgoInteractiveSigning_InvalidShareBlameForcesPermanentExclusion(t *
 			t.Fatalf("active attempt (seat %d): %v", member, err)
 		}
 		collector := roast.NewRound2Collector(verifier)
-		runner, err := newInteractiveSigningRunner(binding, member, threshold, eng, collector, coord, signer, bus)
+		runner, err := newInteractiveSigningRunner(binding, member, threshold, nil, eng, collector, coord, signer, bus)
 		if err != nil {
 			t.Fatalf("runner (seat %d): %v", member, err)
 		}

--- a/pkg/frost/signing/roast_runner_real_cgo_multinode_e2e_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_real_cgo_multinode_e2e_frost_native_test.go
@@ -155,7 +155,7 @@ func buildRealCgoNetHarness(
 		// SAME engine instance for every seat - the multi-seat path keys interactive
 		// state by member, so one engine serves all local seats.
 		runner, err := newInteractiveSigningRunner(
-			ara, member, threshold, engine, collector, coord, signer, bus,
+			ara, member, threshold, nil, engine, collector, coord, signer, bus,
 		)
 		if err != nil {
 			t.Fatalf("runner (seat %d): %v", member, err)

--- a/pkg/frost/signing/roast_runner_real_cgo_share_conflict_equivocation_frost_native_test.go
+++ b/pkg/frost/signing/roast_runner_real_cgo_share_conflict_equivocation_frost_native_test.go
@@ -299,7 +299,7 @@ func TestRealCgoInteractiveSigning_DoubleSignedShareIsDetectedAsEquivocation(t *
 			t.Fatalf("active attempt (seat %d): %v", member, err)
 		}
 		collector := roast.NewRound2Collector(verifier)
-		runner, err := newInteractiveSigningRunner(binding, member, threshold, engine, collector, coord, signer, bus)
+		runner, err := newInteractiveSigningRunner(binding, member, threshold, nil, engine, collector, coord, signer, bus)
 		if err != nil {
 			t.Fatalf("runner (seat %d): %v", member, err)
 		}

--- a/pkg/frost/signing/roast_shapeb_libp2p_multiproc_e2e_frost_native_test.go
+++ b/pkg/frost/signing/roast_shapeb_libp2p_multiproc_e2e_frost_native_test.go
@@ -429,7 +429,7 @@ func runShapeBWorker(t *testing.T, idxStr string) {
 	// This worker's OWN engine, loaded from its OWN copied state dir.
 	engine := &buildTaggedTBTCSignerEngine{}
 	runner, err := newInteractiveSigningRunner(
-		ara, member, cfg.Threshold2uint16(), engine, collector, coord, signer, bus,
+		ara, member, cfg.Threshold2uint16(), nil, engine, collector, coord, signer, bus,
 	)
 	if err != nil {
 		if reportFrostSubprocessSkip("interactive signing runner setup", err) {

--- a/pkg/tbtc/heartbeat.go
+++ b/pkg/tbtc/heartbeat.go
@@ -56,9 +56,9 @@ func (hp *HeartbeatProposal) ValidityBlocks() uint64 {
 // heartbeatSigningExecutor is an interface meant to decouple the specific
 // implementation of the signing executor from the heartbeat action.
 type heartbeatSigningExecutor interface {
-	sign(
+	signHeartbeat(
 		ctx context.Context,
-		message *big.Int,
+		message [16]byte,
 		startBlock uint64,
 	) (*frost.Signature, *signingActivityReport, uint64, error)
 }
@@ -153,9 +153,6 @@ func (ha *heartbeatAction) execute() error {
 		return fmt.Errorf("heartbeat proposal is invalid: [%v]", err)
 	}
 
-	messageBytes := bitcoin.ComputeHash(ha.proposal.Message[:])
-	messageToSign := new(big.Int).SetBytes(messageBytes[:])
-
 	// Just in case. This should never happen.
 	if ha.expiryBlock < heartbeatInactivityClaimValidityBlocks {
 		return fmt.Errorf("invalid proposal expiry block")
@@ -168,9 +165,9 @@ func (ha *heartbeatAction) execute() error {
 	)
 	defer cancelHeartbeatSigningCtx()
 
-	signature, activityReport, _, err := ha.signingExecutor.sign(
+	signature, activityReport, _, err := ha.signingExecutor.signHeartbeat(
 		heartbeatSigningCtx,
-		messageToSign,
+		ha.proposal.Message,
 		ha.startBlock,
 	)
 	if err != nil {
@@ -247,7 +244,7 @@ func (ha *heartbeatAction) execute() error {
 		// period of time. This is a desired outcome for unstaking members as well.
 		activityReport.inactiveMembers,
 		true,
-		messageToSign,
+		heartbeatSigningMessage(ha.proposal.Message),
 	)
 	if err != nil {
 		return fmt.Errorf(

--- a/pkg/tbtc/heartbeat_test.go
+++ b/pkg/tbtc/heartbeat_test.go
@@ -40,12 +40,6 @@ func TestHeartbeatAction_HappyPath(t *testing.T) {
 	heartbeatFailureCounter := newHeartbeatFailureCounter()
 	heartbeatFailureCounter.increment(walletPublicKeyStr)
 
-	// sha256(sha256(messageToSign))
-	sha256d, err := hex.DecodeString("38d30dacec5083c902952ce99fc0287659ad0b1ca2086827a8e78b0bef2c8bc1")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	hostChain := Connect()
 	hostChain.setOperatorsEligibleStake(big.NewInt(100000))
 	hostChain.setHeartbeatProposalValidationResult(proposal, true)
@@ -84,12 +78,13 @@ func TestHeartbeatAction_HappyPath(t *testing.T) {
 		0,
 		uint64(heartbeatFailureCounter.get(walletPublicKeyStr)),
 	)
-	testutils.AssertBigIntsEqual(
-		t,
-		"message to sign",
-		new(big.Int).SetBytes(sha256d),
-		mockExecutor.requestedMessage,
-	)
+	if mockExecutor.requestedMessage != proposal.Message {
+		t.Fatalf(
+			"heartbeat signing received message [%x], want raw proposal [%x]",
+			mockExecutor.requestedMessage,
+			proposal.Message,
+		)
+	}
 	testutils.AssertUintsEqual(
 		t,
 		"start block",
@@ -157,12 +152,9 @@ func TestHeartbeatAction_OperatorUnstaking(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutils.AssertBigIntsEqual(
-		t,
-		"message to sign",
-		nil, // sign not called
-		mockExecutor.requestedMessage,
-	)
+	if mockExecutor.signCalled {
+		t.Fatal("heartbeat signing must not be called for an unstaking operator")
+	}
 }
 
 func TestHeartbeatAction_Failure_SigningError(t *testing.T) {
@@ -604,15 +596,17 @@ type mockHeartbeatSigningExecutor struct {
 	shouldFail           bool
 	activeOperatorsCount uint32
 
-	requestedMessage    *big.Int
+	requestedMessage    [16]byte
 	requestedStartBlock uint64
+	signCalled          bool
 }
 
-func (mhse *mockHeartbeatSigningExecutor) sign(
+func (mhse *mockHeartbeatSigningExecutor) signHeartbeat(
 	ctx context.Context,
-	message *big.Int,
+	message [16]byte,
 	startBlock uint64,
 ) (*frost.Signature, *signingActivityReport, uint64, error) {
+	mhse.signCalled = true
 	mhse.requestedMessage = message
 	mhse.requestedStartBlock = startBlock
 

--- a/pkg/tbtc/native_tbtc_signer_build_taproot_tx_default.go
+++ b/pkg/tbtc/native_tbtc_signer_build_taproot_tx_default.go
@@ -2,7 +2,11 @@
 
 package tbtc
 
-import "github.com/keep-network/keep-core/pkg/bitcoin"
+import (
+	"math/big"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+)
 
 // buildTaprootTxViaNativeSigner is a no-op on builds that do not link the
 // native tbtc-signer bridge.
@@ -10,4 +14,15 @@ func buildTaprootTxViaNativeSigner(
 	unsignedTx *bitcoin.TransactionBuilder,
 ) (string, error) {
 	return "", nil
+}
+
+// bindTaprootTxViaNativeSigner is a no-op on builds that do not link the
+// native tbtc-signer bridge.
+func bindTaprootTxViaNativeSigner(
+	sessionID string,
+	unsignedTx *bitcoin.TransactionBuilder,
+	inputIndex int,
+	expectedSighash *big.Int,
+) error {
+	return nil
 }

--- a/pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer.go
+++ b/pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer.go
@@ -4,13 +4,17 @@ package tbtc
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	frostsigning "github.com/keep-network/keep-core/pkg/frost/signing"
 )
+
+var buildTaprootTxForSessionFn = buildTaprootTxForSession
 
 func buildTaprootTxViaNativeSigner(
 	unsignedTx *bitcoin.TransactionBuilder,
@@ -24,14 +28,46 @@ func buildTaprootTxViaNativeSigner(
 		return "", fmt.Errorf("cannot extract unsigned transaction I/O: [%w]", err)
 	}
 
+	result, err := buildTaprootTxForSessionFn(
+		buildTaprootTxSessionID(inputs, outputs),
+		unsignedTx,
+	)
+	if errors.Is(err, frostsigning.ErrNativeCryptographyUnavailable) {
+		// This legacy parity call is observational unless substitution is
+		// explicitly enabled, so preserve its no-native fallback. The mandatory
+		// per-signing policy binding below deliberately does not suppress this
+		// error.
+		return "", nil
+	}
+	if err != nil || result == nil {
+		return "", err
+	}
+
+	return result.TxHex, nil
+}
+
+func buildTaprootTxForSession(
+	sessionID string,
+	unsignedTx *bitcoin.TransactionBuilder,
+) (*frostsigning.NativeTBTCSignerTxResult, error) {
+	if unsignedTx == nil {
+		return nil, fmt.Errorf("unsigned transaction builder is nil")
+	}
+
+	inputs, outputs, err := unsignedTx.UnsignedTransactionIO()
+	if err != nil {
+		return nil, fmt.Errorf("cannot extract unsigned transaction I/O: [%w]", err)
+	}
+
 	nativeInputs := make([]frostsigning.NativeTBTCSignerTxInput, 0, len(inputs))
 	for _, input := range inputs {
 		nativeInputs = append(
 			nativeInputs,
 			frostsigning.NativeTBTCSignerTxInput{
-				TxIDHex:   input.TxIDHex,
-				Vout:      input.Vout,
-				ValueSats: input.ValueSats,
+				TxIDHex:         input.TxIDHex,
+				Vout:            input.Vout,
+				ValueSats:       input.ValueSats,
+				ScriptPubKeyHex: input.ScriptPubKeyHex,
 			},
 		)
 	}
@@ -47,8 +83,6 @@ func buildTaprootTxViaNativeSigner(
 		)
 	}
 
-	sessionID := buildTaprootTxSessionID(inputs, outputs)
-
 	result, err := frostsigning.BuildNativeTBTCSignerTaprootTx(
 		sessionID,
 		nativeInputs,
@@ -56,21 +90,15 @@ func buildTaprootTxViaNativeSigner(
 		nil,
 	)
 	if err != nil {
-		// Keep legacy fallback behavior for the observational BuildTaprootTx
-		// phase when native bridge support is unavailable.
-		if errors.Is(err, frostsigning.ErrNativeCryptographyUnavailable) {
-			return "", nil
-		}
-
-		return "", err
+		return nil, err
 	}
 
 	if result == nil {
-		return "", fmt.Errorf("native tbtc-signer returned nil BuildTaprootTx result")
+		return nil, fmt.Errorf("native tbtc-signer returned nil BuildTaprootTx result")
 	}
 
 	if result.SessionID != sessionID {
-		return "", fmt.Errorf(
+		return nil, fmt.Errorf(
 			"native tbtc-signer BuildTaprootTx returned unexpected session ID: [%v] != [%v]",
 			result.SessionID,
 			sessionID,
@@ -78,10 +106,60 @@ func buildTaprootTxViaNativeSigner(
 	}
 
 	if result.TxHex == "" {
-		return "", fmt.Errorf("native tbtc-signer BuildTaprootTx returned empty tx hex")
+		return nil, fmt.Errorf("native tbtc-signer BuildTaprootTx returned empty tx hex")
 	}
 
-	return result.TxHex, nil
+	return result, nil
+}
+
+// bindTaprootTxViaNativeSigner creates the policy artifact in the SAME stable
+// ROAST session InteractiveSessionOpen will use, then proves the Rust builder
+// authorized the exact transaction and input sighash the Go host is about to
+// sign.
+func bindTaprootTxViaNativeSigner(
+	sessionID string,
+	unsignedTx *bitcoin.TransactionBuilder,
+	inputIndex int,
+	expectedSighash *big.Int,
+) error {
+	if expectedSighash == nil {
+		return fmt.Errorf("expected sighash is nil")
+	}
+
+	result, err := buildTaprootTxForSessionFn(sessionID, unsignedTx)
+	if err != nil {
+		return err
+	}
+
+	expectedTxHex := hex.EncodeToString(unsignedTx.UnsignedTransaction().Serialize())
+	if result.TxHex != expectedTxHex {
+		return fmt.Errorf(
+			"native tbtc-signer BuildTaprootTx returned a different unsigned transaction",
+		)
+	}
+	if inputIndex < 0 || inputIndex >= len(result.TaprootKeySpendSighashesHex) {
+		return fmt.Errorf(
+			"native tbtc-signer BuildTaprootTx returned [%d] sighashes; input index [%d] is unavailable",
+			len(result.TaprootKeySpendSighashesHex),
+			inputIndex,
+		)
+	}
+
+	sighash, err := hex.DecodeString(result.TaprootKeySpendSighashesHex[inputIndex])
+	if err != nil || len(sighash) != 32 {
+		return fmt.Errorf(
+			"native tbtc-signer BuildTaprootTx returned invalid sighash for input [%d]",
+			inputIndex,
+		)
+	}
+	if new(big.Int).SetBytes(sighash).Cmp(expectedSighash) != 0 {
+		return fmt.Errorf(
+			"native tbtc-signer BuildTaprootTx sighash for input [%d] does not match the Go signing message",
+			inputIndex,
+		)
+	}
+
+	return nil
 }
 
 func buildTaprootTxSessionID(

--- a/pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer_test.go
+++ b/pkg/tbtc/native_tbtc_signer_build_taproot_tx_frost_native_tbtc_signer_test.go
@@ -1,0 +1,50 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package tbtc
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	frostsigning "github.com/keep-network/keep-core/pkg/frost/signing"
+)
+
+func TestNativeBuildUnavailableIsOptionalForParityButFatalForSigningBinding(
+	t *testing.T,
+) {
+	original := buildTaprootTxForSessionFn
+	defer func() { buildTaprootTxForSessionFn = original }()
+
+	unavailable := fmt.Errorf(
+		"%w: injected unavailable signer",
+		frostsigning.ErrNativeCryptographyUnavailable,
+	)
+	buildTaprootTxForSessionFn = func(
+		string,
+		*bitcoin.TransactionBuilder,
+	) (*frostsigning.NativeTBTCSignerTxResult, error) {
+		return nil, unavailable
+	}
+
+	unsignedTx := bitcoin.NewTransactionBuilder(nil)
+	parityTxHex, err := buildTaprootTxViaNativeSigner(unsignedTx)
+	if err != nil {
+		t.Fatalf("observational parity build must preserve unavailable fallback: %v", err)
+	}
+	if parityTxHex != "" {
+		t.Fatalf("unavailable parity build returned transaction %q", parityTxHex)
+	}
+
+	err = bindTaprootTxViaNativeSigner(
+		"roast-policy-session",
+		unsignedTx,
+		0,
+		big.NewInt(1),
+	)
+	if !errors.Is(err, frostsigning.ErrNativeCryptographyUnavailable) {
+		t.Fatalf("mandatory policy binding must propagate unavailable signer: %v", err)
+	}
+}

--- a/pkg/tbtc/signing.go
+++ b/pkg/tbtc/signing.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/clientinfo"
 	"github.com/keep-network/keep-core/pkg/frost"
 	"github.com/keep-network/keep-core/pkg/frost/roast"
@@ -42,6 +43,43 @@ const (
 // errSigningExecutorBusy is an error returned when the signing executor
 // cannot execute the requested signature due to an ongoing signing.
 var errSigningExecutorBusy = fmt.Errorf("signing executor is busy")
+
+var bindTaprootTxViaNativeSignerFn = bindTaprootTxViaNativeSigner
+
+func bindTaprootPolicyArtifactForSigning(
+	message *big.Int,
+	taprootMerkleRoot *[32]byte,
+	startBlock uint64,
+	keyGroupID string,
+	unsignedTx *bitcoin.TransactionBuilder,
+	inputIndex int,
+) (string, error) {
+	if unsignedTx == nil {
+		return "", nil
+	}
+	if keyGroupID == "" {
+		return "", fmt.Errorf(
+			"cannot bind transaction policy without a FROST key-group identifier",
+		)
+	}
+
+	roastSID := roastSessionID(
+		message,
+		taprootMerkleRoot,
+		startBlock,
+		keyGroupID,
+	)
+	if err := bindTaprootTxViaNativeSignerFn(
+		roastSID,
+		unsignedTx,
+		inputIndex,
+		message,
+	); err != nil {
+		return "", err
+	}
+
+	return roastSID, nil
+}
 
 func signingSessionID(
 	message *big.Int,
@@ -236,10 +274,58 @@ func (se *signingExecutor) signBatchWithTaprootMerkleRoots(
 	taprootMerkleRoots []*[32]byte,
 	startBlock uint64,
 ) ([]*frost.Signature, error) {
+	return se.signBatchWithTaprootPolicy(
+		ctx,
+		messages,
+		taprootMerkleRoots,
+		startBlock,
+		nil,
+	)
+}
+
+// signBatchWithTaprootTransaction binds each input's policy-checked transaction
+// artifact under the exact stable ROAST session used for that input's signing.
+// Batch items after the first derive their start block dynamically, so this
+// binding must happen inside the sequential loop rather than as a wallet-level
+// preflight.
+func (se *signingExecutor) signBatchWithTaprootTransaction(
+	ctx context.Context,
+	messages []*big.Int,
+	taprootMerkleRoots []*[32]byte,
+	startBlock uint64,
+	unsignedTx *bitcoin.TransactionBuilder,
+) ([]*frost.Signature, error) {
+	if unsignedTx == nil {
+		return nil, fmt.Errorf("unsigned transaction builder is nil")
+	}
+
+	return se.signBatchWithTaprootPolicy(
+		ctx,
+		messages,
+		taprootMerkleRoots,
+		startBlock,
+		unsignedTx,
+	)
+}
+
+func (se *signingExecutor) signBatchWithTaprootPolicy(
+	ctx context.Context,
+	messages []*big.Int,
+	taprootMerkleRoots []*[32]byte,
+	startBlock uint64,
+	unsignedTx *bitcoin.TransactionBuilder,
+) ([]*frost.Signature, error) {
 	if taprootMerkleRoots != nil && len(taprootMerkleRoots) != len(messages) {
 		return nil, fmt.Errorf(
 			"taproot merkle roots count [%v] does not match messages count [%v]",
 			len(taprootMerkleRoots),
+			len(messages),
+		)
+	}
+	if unsignedTx != nil && len(unsignedTx.UnsignedTransaction().Inputs) != len(messages) {
+		return nil, fmt.Errorf(
+			"unsigned transaction input count [%v] does not match messages count [%v]",
+			len(unsignedTx.UnsignedTransaction().Inputs),
 			len(messages),
 		)
 	}
@@ -282,6 +368,7 @@ func (se *signingExecutor) signBatchWithTaprootMerkleRoots(
 	signingStartBlock := startBlock // start block for the first signing
 	signatures := make([]*frost.Signature, len(messages))
 	endBlocks := make([]uint64, len(messages))
+	roastKeyGroupID := roastSelectorKeyGroupID(se.signers[0])
 
 	for i, message := range messages {
 		signingBatchMessageLogger := signingBatchLogger.With(
@@ -300,11 +387,28 @@ func (se *signingExecutor) signBatchWithTaprootMerkleRoots(
 			taprootMerkleRoot = taprootMerkleRoots[i]
 		}
 
-		signature, _, endBlock, err := se.signWithTaprootMerkleRoot(
+		policyBoundRoastSID, err := bindTaprootPolicyArtifactForSigning(
+			message,
+			taprootMerkleRoot,
+			signingStartBlock,
+			roastKeyGroupID,
+			unsignedTx,
+			i,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"cannot bind input [%d] to the native signer policy artifact: [%w]",
+				i,
+				err,
+			)
+		}
+
+		signature, _, endBlock, err := se.signWithTaprootMerkleRootForSession(
 			ctx,
 			message,
 			taprootMerkleRoot,
 			signingStartBlock,
+			policyBoundRoastSID,
 		)
 		if err != nil {
 			// Error metrics are recorded in the sign() method for all error paths.
@@ -339,11 +443,70 @@ func (se *signingExecutor) sign(
 	return se.signWithTaprootMerkleRoot(ctx, message, nil, startBlock)
 }
 
+// signHeartbeat computes the canonical SHA256d heartbeat message exactly as the
+// generic path historically did, while retaining the raw 16-byte proposal as a
+// typed authorization intent for the native signing-policy firewall.
+func (se *signingExecutor) signHeartbeat(
+	ctx context.Context,
+	heartbeatMessage [16]byte,
+	startBlock uint64,
+) (*frost.Signature, *signingActivityReport, uint64, error) {
+	messageToSign := heartbeatSigningMessage(heartbeatMessage)
+
+	return se.signWithTaprootMerkleRootForSessionAndIntent(
+		ctx,
+		messageToSign,
+		nil,
+		startBlock,
+		"",
+		signing.NewHeartbeatSigningIntent(heartbeatMessage),
+	)
+}
+
+func heartbeatSigningMessage(heartbeatMessage [16]byte) *big.Int {
+	messageBytes := bitcoin.ComputeHash(heartbeatMessage[:])
+	return new(big.Int).SetBytes(messageBytes[:])
+}
+
 func (se *signingExecutor) signWithTaprootMerkleRoot(
 	ctx context.Context,
 	message *big.Int,
 	taprootMerkleRoot *[32]byte,
 	startBlock uint64,
+) (*frost.Signature, *signingActivityReport, uint64, error) {
+	return se.signWithTaprootMerkleRootForSession(
+		ctx,
+		message,
+		taprootMerkleRoot,
+		startBlock,
+		"",
+	)
+}
+
+func (se *signingExecutor) signWithTaprootMerkleRootForSession(
+	ctx context.Context,
+	message *big.Int,
+	taprootMerkleRoot *[32]byte,
+	startBlock uint64,
+	policyBoundRoastSessionID string,
+) (*frost.Signature, *signingActivityReport, uint64, error) {
+	return se.signWithTaprootMerkleRootForSessionAndIntent(
+		ctx,
+		message,
+		taprootMerkleRoot,
+		startBlock,
+		policyBoundRoastSessionID,
+		nil,
+	)
+}
+
+func (se *signingExecutor) signWithTaprootMerkleRootForSessionAndIntent(
+	ctx context.Context,
+	message *big.Int,
+	taprootMerkleRoot *[32]byte,
+	startBlock uint64,
+	policyBoundRoastSessionID string,
+	signingIntent *signing.SigningIntent,
 ) (*frost.Signature, *signingActivityReport, uint64, error) {
 	if lockAcquired := se.lock.TryAcquire(1); !lockAcquired {
 		// Record failure metrics for lock acquisition failure
@@ -403,7 +566,10 @@ func (se *signingExecutor) signWithTaprootMerkleRoot(
 	// signer's retry loop and signing request, so the ROAST participant selector
 	// and transition-record registry are keyed consistently across this signing's
 	// attempts. Computed once; constant across signers and attempts.
-	roastSID := roastSessionID(message, taprootMerkleRoot, startBlock, roastKeyGroupID)
+	roastSID := policyBoundRoastSessionID
+	if roastSID == "" {
+		roastSID = roastSessionID(message, taprootMerkleRoot, startBlock, roastKeyGroupID)
+	}
 
 	for _, currentSigner := range se.signers {
 		go func(signer *signer) {
@@ -485,6 +651,7 @@ func (se *signingExecutor) signWithTaprootMerkleRoot(
 				&signing.Request{
 					Message:           message,
 					RoastSessionID:    roastSID,
+					SigningIntent:     signingIntent,
 					MemberIndex:       signer.signingGroupMemberIndex,
 					SignerMaterial:    signer.signingMaterial(),
 					TaprootMerkleRoot: taprootMerkleRoot,
@@ -581,6 +748,7 @@ func (se *signingExecutor) signWithTaprootMerkleRoot(
 							Message:           message,
 							SessionID:         sessionID,
 							RoastSessionID:    roastSID,
+							SigningIntent:     signingIntent,
 							MemberIndex:       signer.signingGroupMemberIndex,
 							SignerMaterial:    signer.signingMaterial(),
 							PrivateKeyShare:   signer.privateKeyShare,

--- a/pkg/tbtc/signing_policy_binding_frost_native_roast_retry_test.go
+++ b/pkg/tbtc/signing_policy_binding_frost_native_roast_retry_test.go
@@ -1,0 +1,125 @@
+//go:build frost_native && frost_roast_retry
+
+package tbtc
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+)
+
+func TestBindTaprootPolicyArtifactForSigningUsesStableRoastSession(t *testing.T) {
+	original := bindTaprootTxViaNativeSignerFn
+	defer func() { bindTaprootTxViaNativeSignerFn = original }()
+
+	message := new(big.Int).SetBytes([]byte{0x11, 0x22, 0x33})
+	merkleRoot := &[32]byte{0x44}
+	startBlock := uint64(12345)
+	keyGroupID := "policy-binding-key-group"
+	unsignedTx := bitcoin.NewTransactionBuilder(nil)
+	inputIndex := 2
+
+	var capturedSessionID string
+	bindTaprootTxViaNativeSignerFn = func(
+		sessionID string,
+		capturedTx *bitcoin.TransactionBuilder,
+		capturedInputIndex int,
+		capturedMessage *big.Int,
+	) error {
+		capturedSessionID = sessionID
+		if capturedTx != unsignedTx {
+			t.Fatal("binding received a different transaction builder")
+		}
+		if capturedInputIndex != inputIndex {
+			t.Fatalf("binding input index = %d, want %d", capturedInputIndex, inputIndex)
+		}
+		if capturedMessage.Cmp(message) != 0 {
+			t.Fatalf("binding message = %x, want %x", capturedMessage, message)
+		}
+		return nil
+	}
+
+	sessionID, err := bindTaprootPolicyArtifactForSigning(
+		message,
+		merkleRoot,
+		startBlock,
+		keyGroupID,
+		unsignedTx,
+		inputIndex,
+	)
+	if err != nil {
+		t.Fatalf("unexpected binding error: %v", err)
+	}
+
+	expectedSessionID := roastSessionID(message, merkleRoot, startBlock, keyGroupID)
+	if sessionID != expectedSessionID || capturedSessionID != expectedSessionID {
+		t.Fatalf(
+			"policy artifact session mismatch: returned=%q captured=%q expected=%q",
+			sessionID,
+			capturedSessionID,
+			expectedSessionID,
+		)
+	}
+}
+
+func TestBindTaprootPolicyArtifactForSigningPropagatesFailure(t *testing.T) {
+	original := bindTaprootTxViaNativeSignerFn
+	defer func() { bindTaprootTxViaNativeSignerFn = original }()
+
+	expectedErr := errors.New("policy artifact rejected")
+	bindTaprootTxViaNativeSignerFn = func(
+		string,
+		*bitcoin.TransactionBuilder,
+		int,
+		*big.Int,
+	) error {
+		return expectedErr
+	}
+
+	sessionID, err := bindTaprootPolicyArtifactForSigning(
+		big.NewInt(1),
+		nil,
+		1,
+		"policy-binding-key-group",
+		bitcoin.NewTransactionBuilder(nil),
+		0,
+	)
+	if sessionID != "" {
+		t.Fatalf("failed binding returned session ID %q", sessionID)
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("binding error = %v, want %v", err, expectedErr)
+	}
+}
+
+func TestBindTaprootPolicyArtifactForSigningRejectsMissingKeyGroup(t *testing.T) {
+	called := false
+	original := bindTaprootTxViaNativeSignerFn
+	bindTaprootTxViaNativeSignerFn = func(
+		string,
+		*bitcoin.TransactionBuilder,
+		int,
+		*big.Int,
+	) error {
+		called = true
+		return nil
+	}
+	defer func() { bindTaprootTxViaNativeSignerFn = original }()
+
+	_, err := bindTaprootPolicyArtifactForSigning(
+		big.NewInt(1),
+		nil,
+		1,
+		"",
+		bitcoin.NewTransactionBuilder(nil),
+		0,
+	)
+	if err == nil {
+		t.Fatal("transaction policy binding without a key group must fail closed")
+	}
+	if called {
+		t.Fatal("native binding must not run with an empty key group")
+	}
+}

--- a/pkg/tbtc/signing_test.go
+++ b/pkg/tbtc/signing_test.go
@@ -197,6 +197,33 @@ func TestSigningExecutor_Sign(t *testing.T) {
 	}
 }
 
+func TestSigningExecutor_SignHeartbeatUsesCanonicalSHA256d(t *testing.T) {
+	executor := setupSigningExecutor(t)
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	heartbeatMessage := [16]byte{
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	}
+	messageHash := bitcoin.ComputeHash(heartbeatMessage[:])
+	messageToSign := new(big.Int).SetBytes(messageHash[:])
+
+	signature, _, _, err := executor.signHeartbeat(ctx, heartbeatMessage, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ecdsa.Verify(
+		executor.wallet().publicKey,
+		messageToSign.Bytes(),
+		new(big.Int).SetBytes(signature.R[:]),
+		new(big.Int).SetBytes(signature.S[:]),
+	) {
+		t.Fatalf("heartbeat signature does not verify over SHA256d [%x]", messageHash)
+	}
+}
+
 func TestSigningExecutor_Sign_Busy(t *testing.T) {
 	executor := setupSigningExecutor(t)
 

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -305,6 +305,16 @@ type taprootTweakedWalletSigningExecutor interface {
 	) ([]*frost.Signature, error)
 }
 
+type taprootPolicyBoundWalletSigningExecutor interface {
+	signBatchWithTaprootTransaction(
+		ctx context.Context,
+		messages []*big.Int,
+		taprootMerkleRoots []*[32]byte,
+		startBlock uint64,
+		unsignedTx *bitcoin.TransactionBuilder,
+	) ([]*frost.Signature, error)
+}
+
 // walletTransactionExecutor is a component allowing to sign and broadcast
 // wallet Bitcoin transactions.
 type walletTransactionExecutor struct {
@@ -344,13 +354,17 @@ func (wte *walletTransactionExecutor) signTransaction(
 	signingStartBlock uint64,
 	signingTimeoutBlock uint64,
 ) (*bitcoin.Transaction, error) {
+	usesSchnorrSignatures := wte.usesSchnorrSignatures()
+
 	// The native tbtc-signer BuildTaprootTx parity/substitution path applies
-	// only to Taproot transactions: the native builder is a Taproot builder, so
-	// running it for a legacy (non-Taproot) ECDSA redemption/sweep/moving-funds
-	// transaction is meaningless, and a hard error from it would otherwise fail
-	// the signing of that legacy transaction. FROST/Schnorr wallets sign
-	// exclusively all-Taproot transactions (enforced below).
-	if unsignedTx.HasOnlyTaprootKeyPathInputs() {
+	// only to Taproot transactions that do not use the mandatory policy-bound
+	// Schnorr path below. That path calls BuildTaprootTx under the exact ROAST
+	// session before every signature; running this preflight first under a
+	// buildtx-* session would consume one extra token from the signer's global
+	// policy rate limiter, and its artifact cannot authorize the ROAST session.
+	// The native builder is meaningless for legacy transactions, so those skip
+	// this path as before.
+	if unsignedTx.HasOnlyTaprootKeyPathInputs() && !usesSchnorrSignatures {
 		if err := wte.maybeSubstituteNativeBuildTaprootTx(
 			signTxLogger,
 			unsignedTx,
@@ -376,7 +390,7 @@ func (wte *walletTransactionExecutor) signTransaction(
 		)
 	}
 
-	if wte.usesSchnorrSignatures() &&
+	if usesSchnorrSignatures &&
 		!unsignedTx.HasOnlyTaprootKeyPathInputs() {
 		return nil, fmt.Errorf(
 			"cannot apply FROST signatures to non-taproot transaction inputs",
@@ -394,7 +408,22 @@ func (wte *walletTransactionExecutor) signTransaction(
 
 	var signatures []*frost.Signature
 	taprootMerkleRoots := unsignedTx.TaprootKeyPathInputMerkleRoots()
-	if hasTaprootMerkleRoots(taprootMerkleRoots) {
+	policyBoundSigningExecutor, policyBindingAvailable :=
+		wte.signingExecutor.(taprootPolicyBoundWalletSigningExecutor)
+	if usesSchnorrSignatures {
+		if !policyBindingAvailable {
+			return nil, fmt.Errorf(
+				"Schnorr signing executor does not support transaction policy binding",
+			)
+		}
+		signatures, err = policyBoundSigningExecutor.signBatchWithTaprootTransaction(
+			signingCtx,
+			sigHashes,
+			taprootMerkleRoots,
+			signingStartBlock,
+			unsignedTx,
+		)
+	} else if hasTaprootMerkleRoots(taprootMerkleRoots) {
 		tweakedSigningExecutor, ok := wte.signingExecutor.(taprootTweakedWalletSigningExecutor)
 		if !ok {
 			return nil, fmt.Errorf(

--- a/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
+++ b/pkg/tbtc/wallet_sign_transaction_build_taproot_tx_test.go
@@ -535,8 +535,10 @@ func TestNativeBuildTaprootTxSigningSubstitutionEnabled(t *testing.T) {
 // The native tbtc-signer BuildTaprootTx parity/substitution path is gated on the
 // transaction being all-Taproot. The substitution LOGIC itself (observational
 // logging, divergence rejection, matching-IO acceptance) is covered directly by
-// the TestEvaluateNativeUnsignedTransactionForSigning_* tests; these two tests
-// cover the signTransaction gate: skip for legacy, invoke for Taproot.
+// the TestEvaluateNativeUnsignedTransactionForSigning_* tests. The tests below
+// cover the signTransaction gate: skip for legacy, run for an eligible
+// non-policy-bound Taproot path, and skip the redundant preflight when
+// policy-bound Schnorr signing performs the mandatory build.
 func TestWalletTransactionExecutor_SignTransaction_SkipsNativeBuildForLegacyTransaction(
 	t *testing.T,
 ) {
@@ -597,16 +599,15 @@ func TestWalletTransactionExecutor_SignTransaction_SkipsNativeBuildForLegacyTran
 	}
 }
 
-func TestWalletTransactionExecutor_SignTransaction_SubstitutesNativeBuildForTaprootTransaction(
+func TestWalletTransactionExecutor_SignTransaction_SubstitutesNativeBuildForNonPolicyBoundTaprootTransaction(
 	t *testing.T,
 ) {
 	unsignedTx, privateKey := buildTaprootKeyPathUnsignedTxForTest(t)
 
 	// The native builder returns a transaction structurally identical to the
-	// Go-built one, so substitution mode accepts it and substitutes -- this
-	// exercises the ReplaceUnsignedTransaction call and the substitution info
-	// log in the real signTransaction caller. Returning a non-empty hex also
-	// proves the gate invoked the native build for an all-Taproot transaction.
+	// Go-built one, so substitution mode accepts it. The executor deliberately
+	// does not advertise Schnorr policy binding, keeping this path eligible for
+	// the observational/substitution preflight.
 	nativeUnsignedTxHex := hex.EncodeToString(
 		unsignedTx.UnsignedTransaction().Serialize(bitcoin.Standard),
 	)
@@ -618,11 +619,11 @@ func TestWalletTransactionExecutor_SignTransaction_SubstitutesNativeBuildForTapr
 		nativeBuildTaprootTxSigningSubstitutionEnabledFn = originalSigningSubstitutionEnabledFn
 	})
 
-	nativeBuildCalled := false
+	preflightBuildCalls := 0
 	buildTaprootTxViaNativeSignerFn = func(
 		unsignedTx *bitcoin.TransactionBuilder,
 	) (string, error) {
-		nativeBuildCalled = true
+		preflightBuildCalls++
 		return nativeUnsignedTxHex, nil
 	}
 	nativeBuildTaprootTxSigningSubstitutionEnabledFn = func() bool {
@@ -631,8 +632,10 @@ func TestWalletTransactionExecutor_SignTransaction_SubstitutesNativeBuildForTapr
 
 	wte := &walletTransactionExecutor{
 		executingWallet: generateWallet(big.NewInt(111)),
-		signingExecutor: &deterministicSchnorrSigningExecutorForTaproot{
-			privateKey: privateKey,
+		signingExecutor: &nonPolicyBoundTaprootSigningExecutor{
+			delegate: &deterministicSchnorrSigningExecutorForTaproot{
+				privateKey: privateKey,
+			},
 		},
 		waitForBlockFn: func(ctx context.Context, block uint64) error {
 			return nil
@@ -645,10 +648,8 @@ func TestWalletTransactionExecutor_SignTransaction_SubstitutesNativeBuildForTapr
 		t.Fatalf("unexpected signTransaction error: [%v]", err)
 	}
 
-	if !nativeBuildCalled {
-		t.Fatal(
-			"native BuildTaprootTx must be invoked for an all-Taproot transaction",
-		)
+	if preflightBuildCalls != 1 {
+		t.Fatalf("unexpected observational BuildTaprootTx calls: [%d]", preflightBuildCalls)
 	}
 	if !containsLoggedMessage(
 		logger.infoMessages,
@@ -658,6 +659,94 @@ func TestWalletTransactionExecutor_SignTransaction_SubstitutesNativeBuildForTapr
 	}
 	if len(tx.Inputs) != 1 || len(tx.Inputs[0].Witness) == 0 {
 		t.Fatal("expected the substituted transaction to be signed with a taproot witness")
+	}
+}
+
+func TestWalletTransactionExecutor_SignTransaction_PolicyBoundSchnorrChargesOnlyMandatoryNativeBuild(
+	t *testing.T,
+) {
+	unsignedTx, privateKey := buildTaprootKeyPathUnsignedTxForTest(t)
+
+	// Model the signer's global BuildTaprootTx rate limiter at its supported
+	// minimum. The policy-bound signing call must consume the one token; the
+	// observational parity/substitution preflight must not run first and consume
+	// it under a different session.
+	availableBuildTokens := 1
+	consumeBuildToken := func() error {
+		if availableBuildTokens == 0 {
+			return errors.New("signer policy rate limit exceeded")
+		}
+
+		availableBuildTokens--
+		return nil
+	}
+
+	nativeUnsignedTxHex := hex.EncodeToString(
+		unsignedTx.UnsignedTransaction().Serialize(bitcoin.Standard),
+	)
+
+	originalBuildTaprootTxViaNativeSignerFn := buildTaprootTxViaNativeSignerFn
+	originalSigningSubstitutionEnabledFn := nativeBuildTaprootTxSigningSubstitutionEnabledFn
+	t.Cleanup(func() {
+		buildTaprootTxViaNativeSignerFn = originalBuildTaprootTxViaNativeSignerFn
+		nativeBuildTaprootTxSigningSubstitutionEnabledFn = originalSigningSubstitutionEnabledFn
+	})
+
+	preflightBuildCalls := 0
+	buildTaprootTxViaNativeSignerFn = func(
+		unsignedTx *bitcoin.TransactionBuilder,
+	) (string, error) {
+		preflightBuildCalls++
+		if err := consumeBuildToken(); err != nil {
+			return "", err
+		}
+
+		return nativeUnsignedTxHex, nil
+	}
+	// Even an explicitly enabled substitution flag must not reintroduce the
+	// redundant preflight on the mandatory policy-bound path.
+	nativeBuildTaprootTxSigningSubstitutionEnabledFn = func() bool {
+		return true
+	}
+	mandatoryBuildCalls := 0
+
+	wte := &walletTransactionExecutor{
+		executingWallet: generateWallet(big.NewInt(111)),
+		signingExecutor: &deterministicSchnorrSigningExecutorForTaproot{
+			privateKey: privateKey,
+			beforePolicyBinding: func() error {
+				mandatoryBuildCalls++
+				return consumeBuildToken()
+			},
+		},
+		waitForBlockFn: func(ctx context.Context, block uint64) error {
+			return nil
+		},
+	}
+
+	logger := &warningCaptureLogger{}
+	tx, err := wte.signTransaction(logger, unsignedTx, 0, 0)
+	if err != nil {
+		t.Fatalf("unexpected signTransaction error: [%v]", err)
+	}
+
+	if preflightBuildCalls != 0 {
+		t.Fatalf("unexpected observational BuildTaprootTx calls: [%d]", preflightBuildCalls)
+	}
+	if mandatoryBuildCalls != 1 {
+		t.Fatalf("unexpected mandatory BuildTaprootTx calls: [%d]", mandatoryBuildCalls)
+	}
+	if availableBuildTokens != 0 {
+		t.Fatalf("unexpected remaining BuildTaprootTx tokens: [%d]", availableBuildTokens)
+	}
+	if containsLoggedMessage(
+		logger.infoMessages,
+		"substituted Go unsigned transaction with native tbtc-signer BuildTaprootTx output",
+	) {
+		t.Fatalf("policy-bound Schnorr signing must not run substitution: [%v]", logger.infoMessages)
+	}
+	if len(tx.Inputs) != 1 || len(tx.Inputs[0].Witness) == 0 {
+		t.Fatal("expected the transaction to be signed with a taproot witness")
 	}
 }
 
@@ -1434,7 +1523,24 @@ func (desefbts *deterministicECDSASigningExecutorForBuildTaprootTxSubstitution) 
 }
 
 type deterministicSchnorrSigningExecutorForTaproot struct {
-	privateKey *btcec2.PrivateKey
+	privateKey          *btcec2.PrivateKey
+	beforePolicyBinding func() error
+}
+
+// nonPolicyBoundTaprootSigningExecutor returns valid Schnorr signature bytes
+// without implementing schnorrWalletSigningExecutor or the mandatory policy-
+// binding interface. This preserves coverage for the legacy all-Taproot
+// observational/substitution caller path.
+type nonPolicyBoundTaprootSigningExecutor struct {
+	delegate *deterministicSchnorrSigningExecutorForTaproot
+}
+
+func (npbtse *nonPolicyBoundTaprootSigningExecutor) signBatch(
+	ctx context.Context,
+	messages []*big.Int,
+	startBlock uint64,
+) ([]*frost.Signature, error) {
+	return npbtse.delegate.signBatch(ctx, messages, startBlock)
 }
 
 func (dsseft *deterministicSchnorrSigningExecutorForTaproot) signBatch(
@@ -1466,6 +1572,22 @@ func (dsseft *deterministicSchnorrSigningExecutorForTaproot) signBatch(
 
 func (dsseft *deterministicSchnorrSigningExecutorForTaproot) usesSchnorrSignatures() bool {
 	return true
+}
+
+func (dsseft *deterministicSchnorrSigningExecutorForTaproot) signBatchWithTaprootTransaction(
+	ctx context.Context,
+	messages []*big.Int,
+	taprootMerkleRoots []*[32]byte,
+	startBlock uint64,
+	unsignedTx *bitcoin.TransactionBuilder,
+) ([]*frost.Signature, error) {
+	if dsseft.beforePolicyBinding != nil {
+		if err := dsseft.beforePolicyBinding(); err != nil {
+			return nil, err
+		}
+	}
+
+	return dsseft.signBatch(ctx, messages, startBlock)
 }
 
 type taprootMerkleRootRecordingSchnorrSigningExecutor struct {
@@ -1523,6 +1645,21 @@ func (tmrrsse *taprootMerkleRootRecordingSchnorrSigningExecutor) signBatchWithTa
 
 func (tmrrsse *taprootMerkleRootRecordingSchnorrSigningExecutor) usesSchnorrSignatures() bool {
 	return true
+}
+
+func (tmrrsse *taprootMerkleRootRecordingSchnorrSigningExecutor) signBatchWithTaprootTransaction(
+	ctx context.Context,
+	messages []*big.Int,
+	taprootMerkleRoots []*[32]byte,
+	startBlock uint64,
+	unsignedTx *bitcoin.TransactionBuilder,
+) ([]*frost.Signature, error) {
+	return tmrrsse.signBatchWithTaprootMerkleRoots(
+		ctx,
+		messages,
+		taprootMerkleRoots,
+		startBlock,
+	)
 }
 
 type unexpectedSigningExecutorForBuildTaprootTxError struct{}


### PR DESCRIPTION
## Relationship

Companion integration for the full Rust signer stack #4147 → #4148 → #4149. This PR is based on the Go FROST scaffold branch from #3866 and pins final signer commit `6e0fa9741ffb6b0bb5603eabe26fb4cc1b13ecd9` (ABI 3.3).

## What changed

- send every input prevout script to `BuildTaprootTx` and decode the ordered BIP-341 key-spend messages
- bind the complete transaction under the exact stable ROAST session ID used by Interactive Open
- compare Rust transaction bytes and the selected input sighash with the Go builder immediately before signing
- carry the transaction builder through sequential batch signing after each input start block is finalized
- require policy binding for Schnorr wallets and fail closed on missing key groups or unavailable native signing
- skip the optional `buildtx-*` parity preflight on the mandatory Schnorr path, so the global policy rate limiter charges only the per-input build under the actual ROAST session; retain the preflight for eligible non-policy-bound Taproot callers
- retain native-unavailable fallback only for the optional observational parity call
- carry a closed, immutable heartbeat intent from the raw 16-byte proposal through the FFI runner to Rust Open
- require ABI 3.3 and pin the complete policy/durability/rollout stack, including ABI-compatible public latency metrics
- compute the cross-language expected BIP-341 sighash dynamically through the production Go builder rather than treating a literal as a btcd-derived oracle

## Design boundaries verified

- Schnorr/FROST transaction signing supports all-P2TR input sets only. Mixed or legacy inputs are rejected before native binding; hybrid ECDSA/Schnorr assembly remains out of scope.
- A build missing `frost_tbtc_signer && cgo` cannot start a FROST-enabled node: startup checks the actual linked native engine, so the default no-op binder cannot silently serve production.
- Generic signing carries no intent. Heartbeat signing alone supplies `{type:"heartbeat",message_hex:"..."}`; Rust validates the protocol shape and digest at Open and Round2.
- ABI 3.3 includes the per-wallet heartbeat throttle/metric and independently tunable canary policy-evidence minimum while preserving ABI-3 public latency field semantics.

## Verification

- `go test ./pkg/frost/signing ./pkg/tbtc`
- `go test -tags frost_native ./pkg/frost/signing ./pkg/tbtc`
- focused one-token rate-limit and non-policy-bound substitution regressions
- final pinned Rust head: `cargo test --locked` (library: 249 passed, 1 ignored; admission binary: 25 passed; BIP-341 vector: 1 passed)
- final pinned Rust head: `cargo check --locked --all-targets`
- final pinned Rust head: `cargo clippy --locked --all-targets -- -D warnings`
- final pinned Rust head: six exact Phase-5 chaos scenarios passed
- ABI 3.3 compatibility, nil-intent, JSON wire-shape, runner propagation, mixed-input rejection, unavailable-native, one-token rate-limit, substitution-compatibility, and public latency semantic regressions pass
- `git diff --check`
