### PR TITLE
docs(tbtc/signer): retire stale rollout benchmark gate

### DIFF
--- a/pkg/tbtc/signer/docs/roast-phase-5-rollout-runbook.md
+++ b/pkg/tbtc/signer/docs/roast-phase-5-rollout-runbook.md
@@ -22,8 +22,9 @@ This runbook is paired with:
 Before Stage 1 canary:
 
 1. Security/correctness gate checks are green.
-2. Benchmark suite is current:
-   - `cd pkg/tbtc/signer && cargo bench --features bench-restart-hook --bench phase5_roast`
+2. Fresh interactive latency-window evidence is available for the stage being
+   promoted, including the required sample counts and p95 values. The retired
+   coarse-path `phase5_roast` benchmark is not a rollout gate.
 3. Chaos/failure suite is green:
    - `cd pkg/tbtc/signer && ./scripts/run_phase5_chaos_suite.sh`
 4. Pre-ROAST baseline window captured for:


### PR DESCRIPTION
## Follow-up

Follow-up to #4149. The README and security rollout gates correctly retired the deleted coarse signing benchmark, but the paired Phase 5 operator runbook still required that nonexistent command.

## What changed

- remove the stale phase5_roast benchmark prerequisite from the operator runbook
- require fresh interactive latency-window sample counts and p95 evidence for the stage being promoted
- retain the exact-filter Phase 5 chaos-suite prerequisite

## Verification

- the pre-fix benchmark command fails with no bench target named phase5_roast
- repository-wide search finds no remaining cargo bench invocation for phase5_roast
- git diff --check

