### PR TITLE
fix(tbtc/signer): preserve canary recovery bookkeeping

### DIFF
--- a/pkg/tbtc/signer/src/engine/lifecycle.rs
+++ b/pkg/tbtc/signer/src/engine/lifecycle.rs
@@ -340,6 +340,18 @@ pub fn canary_rollout_status() -> Result<CanaryRolloutStatusResult, EngineError>
     })
 }
 
+fn record_recovered_canary_transition(pending_operation: &PersistencePendingOperation) {
+    record_hardening_telemetry(|telemetry| match pending_operation {
+        PersistencePendingOperation::CanaryPromotion { .. } => {
+            telemetry.canary_promotions_total = telemetry.canary_promotions_total.saturating_add(1);
+        }
+        PersistencePendingOperation::CanaryRollback { .. } => {
+            telemetry.canary_rollbacks_total = telemetry.canary_rollbacks_total.saturating_add(1);
+        }
+        _ => {}
+    });
+}
+
 pub fn promote_canary(request: PromoteCanaryRequest) -> Result<PromoteCanaryResult, EngineError> {
     enforce_provenance_gate()?;
     if !matches!(request.target_percent, 10 | 50 | 100) {
@@ -366,8 +378,12 @@ pub fn promote_canary(request: PromoteCanaryRequest) -> Result<PromoteCanaryResu
         };
         persist_engine_state_to_storage(&guard)
             .map_err(PersistEngineStateError::into_engine_error)?;
+        // The post-replacement error path already activated the new stage and
+        // reset prior-stage evidence. This retry confirms durability only, so
+        // preserve evidence accumulated since that transition and count the
+        // recovered operation exactly once before clearing its pending marker.
+        record_recovered_canary_transition(&pending_operation);
         clear_persistence_pending_operation(&pending_operation);
-        reset_canary_promotion_evidence();
         if let Some(result) = matching_result {
             return Ok(result);
         }
@@ -465,8 +481,10 @@ pub fn rollback_canary(
         };
         persist_engine_state_to_storage(&guard)
             .map_err(PersistEngineStateError::into_engine_error)?;
+        // See promote_canary: repairing directory durability does not start a
+        // second rollout stage and must not discard current-stage evidence.
+        record_recovered_canary_transition(&pending_operation);
         clear_persistence_pending_operation(&pending_operation);
-        reset_canary_promotion_evidence();
         if let Some(result) = matching_result {
             return Ok(result);
         }

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -2672,6 +2672,105 @@ fn canary_rollback_persist_failure_rolls_back_and_retry_is_durable() {
 }
 
 #[test]
+fn canary_post_rename_recovery_preserves_evidence_and_records_transitions() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("canary_post_rename_recovery_bookkeeping");
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+
+    let baseline_metrics = hardening_metrics();
+    seed_canary_promotion_evidence_for_tests(1, 1, 1, 0);
+    let promotion_request = PromoteCanaryRequest { target_percent: 50 };
+    set_persist_fault_injection_for_tests(
+        PersistFaultInjectionPoint::AfterRenameBeforeDirectorySync,
+    );
+    promote_canary(promotion_request.clone())
+        .expect_err("post-rename fault must leave the promotion pending");
+    clear_persist_fault_injection_for_tests();
+
+    assert!(pending_canary_promotion_result(50).is_some());
+    assert_eq!(
+        hardening_metrics().canary_promotions_total,
+        baseline_metrics.canary_promotions_total,
+        "an unconfirmed transition must not be counted yet"
+    );
+    seed_canary_promotion_evidence_for_tests(1, 1, 1, 0);
+    assert!(
+        canary_rollout_status()
+            .expect("active 50% stage status before recovery")
+            .promotion_gate_passed,
+        "operations after the rename must count toward the active 50% stage"
+    );
+
+    let promotion =
+        promote_canary(promotion_request).expect("matching retry repairs promotion durability");
+    assert_eq!(promotion.from_percent, 10);
+    assert_eq!(promotion.to_percent, 50);
+    assert!(pending_canary_promotion_result(50).is_none());
+    assert!(
+        canary_rollout_status()
+            .expect("active 50% stage status after recovery")
+            .promotion_gate_passed,
+        "confirming durability must preserve current-stage evidence"
+    );
+    assert_eq!(
+        hardening_metrics().canary_promotions_total,
+        baseline_metrics.canary_promotions_total.saturating_add(1),
+        "recovery must record the completed promotion exactly once"
+    );
+
+    let rollback_request = RollbackCanaryRequest {
+        reason: "post-rename recovery bookkeeping".to_string(),
+    };
+    set_persist_fault_injection_for_tests(
+        PersistFaultInjectionPoint::AfterRenameBeforeDirectorySync,
+    );
+    rollback_canary(rollback_request.clone())
+        .expect_err("post-rename fault must leave the rollback pending");
+    clear_persist_fault_injection_for_tests();
+
+    assert!(pending_canary_rollback_result("post-rename recovery bookkeeping").is_some());
+    assert_eq!(
+        hardening_metrics().canary_rollbacks_total,
+        baseline_metrics.canary_rollbacks_total,
+        "an unconfirmed rollback must not be counted yet"
+    );
+    seed_canary_promotion_evidence_for_tests(1, 1, 1, 0);
+    assert!(
+        canary_rollout_status()
+            .expect("active rolled-back stage status before recovery")
+            .promotion_gate_passed,
+        "operations after the rename must count toward the rolled-back stage"
+    );
+
+    let rollback =
+        rollback_canary(rollback_request).expect("matching retry repairs rollback durability");
+    assert_eq!(rollback.from_percent, 50);
+    assert_eq!(rollback.to_percent, 10);
+    assert!(pending_canary_rollback_result("post-rename recovery bookkeeping").is_none());
+    assert!(
+        canary_rollout_status()
+            .expect("active rolled-back stage status after recovery")
+            .promotion_gate_passed,
+        "confirming rollback durability must preserve current-stage evidence"
+    );
+    let recovered_metrics = hardening_metrics();
+    assert_eq!(
+        recovered_metrics.canary_promotions_total,
+        baseline_metrics.canary_promotions_total.saturating_add(1)
+    );
+    assert_eq!(
+        recovered_metrics.canary_rollbacks_total,
+        baseline_metrics.canary_rollbacks_total.saturating_add(1),
+        "recovery must record the completed rollback exactly once"
+    );
+
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
 fn lifecycle_post_rename_persist_failures_remain_fail_closed_and_retry_durably() {
     let _guard = lock_test_state();
     let state_path = configure_test_state_path("lifecycle_post_rename_retry");


### PR DESCRIPTION
## Follow-up

Follow-up to #4148 and #4149. This fixes canary bookkeeping when a state-file rename succeeds but directory synchronization fails and the operator later repairs durability.

## What changed

- preserve evidence accumulated for the already-active stage while a promotion or rollback is persistence-pending
- record the recovered transition counter exactly once after durability repair succeeds
- classify the counter by the pending transition itself, so either lifecycle API can safely repair the opposite pending operation
- add a regression covering both promotion and rollback recovery

The initial post-rename error path still resets prior-stage evidence when the new stage becomes active. A recovery retry changes durability only, so it no longer advances the evidence epoch a second time.

## Verification

- pre-fix regression failed at the current-stage evidence preservation assertion
- focused regression passes after the fix
- all 17 canary tests pass
- existing lifecycle post-rename recovery test passes
- cargo test --locked: 250 library tests passed, 1 ignored; 25 admission tests passed; BIP-341 vector passed
- cargo fmt --all -- --check
- cargo check --locked --all-targets
- cargo clippy --locked --all-targets -- -D warnings
- six exact Phase 5 chaos scenarios passed
- git diff --check

