### PR TITLE
fix(tbtc/signer): reject empty attestation statuses

### DIFF
--- a/pkg/tbtc/signer/src/bin/admission_checker.rs
+++ b/pkg/tbtc/signer/src/bin/admission_checker.rs
@@ -759,7 +759,20 @@ fn evaluate_admission(
 
     let required_attestation_status = trimmed_lowercase(&policy.required_attestation_status);
     let candidate_attestation_status = trimmed_lowercase(&candidate.attestation_status);
-    if candidate_attestation_status != required_attestation_status {
+    if required_attestation_status.is_empty() {
+        reasons.push(AdmissionReason {
+            code: "required_attestation_status_missing".to_string(),
+            detail: "policy required_attestation_status must be non-empty".to_string(),
+        });
+    }
+    if candidate_attestation_status.is_empty() {
+        reasons.push(AdmissionReason {
+            code: "attestation_status_missing".to_string(),
+            detail: "candidate attestation_status must be non-empty".to_string(),
+        });
+    } else if !required_attestation_status.is_empty()
+        && candidate_attestation_status != required_attestation_status
+    {
         reasons.push(AdmissionReason {
             code: "attestation_status_not_approved".to_string(),
             detail: format!(
@@ -1062,6 +1075,74 @@ mod tests {
             .reasons
             .iter()
             .any(|reason| reason.code == "attestation_status_not_approved"));
+    }
+
+    #[test]
+    fn evaluate_admission_rejects_empty_required_and_candidate_attestation_statuses() {
+        let mut policy = baseline_policy();
+        policy.required_attestation_status = "  \t".to_string();
+        let mut candidate = baseline_candidate();
+        candidate.attestation_status = " \n ".to_string();
+
+        let decision = evaluate_admission(&policy, &candidate, &baseline_existing(), 1_700_000_000);
+        assert_eq!(decision.decision, "reject");
+        assert!(decision
+            .reasons
+            .iter()
+            .any(|reason| reason.code == "required_attestation_status_missing"));
+        assert!(decision
+            .reasons
+            .iter()
+            .any(|reason| reason.code == "attestation_status_missing"));
+    }
+
+    #[test]
+    fn evaluate_admission_reports_empty_attestation_fields_before_mismatch() {
+        let mut empty_candidate = baseline_candidate();
+        empty_candidate.attestation_status = "   ".to_string();
+        let candidate_decision = evaluate_admission(
+            &baseline_policy(),
+            &empty_candidate,
+            &baseline_existing(),
+            1_700_000_000,
+        );
+        assert!(candidate_decision
+            .reasons
+            .iter()
+            .any(|reason| reason.code == "attestation_status_missing"));
+        assert!(!candidate_decision
+            .reasons
+            .iter()
+            .any(|reason| reason.code == "attestation_status_not_approved"));
+
+        let mut empty_policy = baseline_policy();
+        empty_policy.required_attestation_status = "\t".to_string();
+        let policy_decision = evaluate_admission(
+            &empty_policy,
+            &baseline_candidate(),
+            &baseline_existing(),
+            1_700_000_000,
+        );
+        assert!(policy_decision
+            .reasons
+            .iter()
+            .any(|reason| reason.code == "required_attestation_status_missing"));
+        assert!(!policy_decision
+            .reasons
+            .iter()
+            .any(|reason| reason.code == "attestation_status_not_approved"));
+    }
+
+    #[test]
+    fn evaluate_admission_normalizes_non_empty_attestation_statuses() {
+        let mut policy = baseline_policy();
+        policy.required_attestation_status = " Approved ".to_string();
+        let mut candidate = baseline_candidate();
+        candidate.attestation_status = "APPROVED".to_string();
+
+        let decision = evaluate_admission(&policy, &candidate, &baseline_existing(), 1_700_000_000);
+        assert_eq!(decision.decision, "allow");
+        assert!(decision.reasons.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Stack

Rust signer review-fix stack 2 of 2.

- Depends on: [#4155](https://github.com/threshold-network/keep-core/pull/4155)
- Ultimate base: `extraction/frost-signer-mirror-2026-05-26` ([#4005](https://github.com/threshold-network/keep-core/pull/4005))

## What changed

- Reject an empty or whitespace-only policy `required_attestation_status` with `required_attestation_status_missing`.
- Reject an empty or whitespace-only candidate `attestation_status` with `attestation_status_missing`.
- Compare statuses only after both normalized values are non-empty, avoiding a misleading mismatch reason for missing data.
- Preserve case-insensitive, whitespace-normalized matching for legitimate non-empty values.

## Review finding addressed

- P2: reject empty attestation statuses before comparing them — an empty policy and empty candidate can no longer normalize to equality and pass admission.

## Verification

- `cargo fmt --manifest-path pkg/tbtc/signer/Cargo.toml -- --check`
- `cargo check --locked --manifest-path pkg/tbtc/signer/Cargo.toml --all-targets`
- `cargo clippy --locked --manifest-path pkg/tbtc/signer/Cargo.toml --all-targets -- -D warnings`
- `cargo test --locked --manifest-path pkg/tbtc/signer/Cargo.toml`
- `cargo test --locked --manifest-path pkg/tbtc/signer/Cargo.toml --bin admission_checker attestation`
- `git diff --check`
