### PR TITLE
fix(tbtc/signer): bound interactive session persistence

### DIFF
--- a/pkg/tbtc/signer/Cargo.toml
+++ b/pkg/tbtc/signer/Cargo.toml
@@ -27,7 +27,7 @@ frost-core = { version = "=3.0.0", default-features = false }
 chacha20poly1305 = "0.10"
 rand_chacha = "0.3"
 libc = "0.2"
-zeroize = { version = "1.8", default-features = false, features = ["serde"] }
+zeroize = { version = "1.8", default-features = false, features = ["alloc", "serde"] }
 bitcoin = "0.32"
 
 [dev-dependencies]

--- a/pkg/tbtc/signer/docs/rust-rewrite-bootstrap.md
+++ b/pkg/tbtc/signer/docs/rust-rewrite-bootstrap.md
@@ -204,17 +204,17 @@ rewrite architecture.
   - reject over-limit runtime insertions and over-limit persisted payloads
     instead of evicting entries (no silent replay-protection weakening).
 - Added fail-closed global session-registry bounds:
-  - bounded active session count via `TBTC_SIGNER_MAX_SESSIONS` (default
-    `1024`),
-  - idle per-message interactive sessions move into a separately bounded
-    persisted retirement tier of the same size, retaining delayed-retry routing,
-    policy artifacts, and replay/aggregate authorization tombstones without
-    exhausting active admission; the oldest retired entry is evicted when that
-    tier reaches its bound,
-  - reject over-limit active persisted state, compact an over-limit retired tier
-    to its bound during load, reject over-limit state during encode, and reject
-    new runtime session creation at active capacity while preserving idempotent
-    retries for existing `session_id` values.
+  - bounded the total persisted session count via
+    `TBTC_SIGNER_MAX_SESSIONS` (default `1024`) so schema-1 state remains
+    readable after an emergency rollback,
+  - idle per-message interactive sessions use the portion of that shared budget
+    not occupied by active sessions, retaining delayed-retry routing, policy
+    artifacts, and replay/aggregate authorization tombstones until active
+    admission needs the slot; the oldest eligible retired entry is then evicted,
+  - compact over-limit retired entries during load, reject over-limit state
+    during encode, and reject new runtime session creation only when the shared
+    budget has no eligible retired entry, while preserving idempotent retries for
+    existing `session_id` values.
 - Bootstrap dealer-model constraint: the current engine holds all generated key
   packages for a session in one process. This is temporary bootstrap behavior
   and does not provide production threshold key isolation.

--- a/pkg/tbtc/signer/docs/rust-rewrite-bootstrap.md
+++ b/pkg/tbtc/signer/docs/rust-rewrite-bootstrap.md
@@ -204,11 +204,17 @@ rewrite architecture.
   - reject over-limit runtime insertions and over-limit persisted payloads
     instead of evicting entries (no silent replay-protection weakening).
 - Added fail-closed global session-registry bounds:
-  - bounded total persisted session count via `TBTC_SIGNER_MAX_SESSIONS`
-    (default `1024`),
-  - reject over-limit persisted state payloads during decode/encode, and reject
-    new runtime session creation at capacity while preserving idempotent retries
-    for existing `session_id` values.
+  - bounded active session count via `TBTC_SIGNER_MAX_SESSIONS` (default
+    `1024`),
+  - idle per-message interactive sessions move into a separately bounded
+    persisted retirement tier of the same size, retaining delayed-retry routing,
+    policy artifacts, and replay/aggregate authorization tombstones without
+    exhausting active admission; the oldest retired entry is evicted when that
+    tier reaches its bound,
+  - reject over-limit active persisted state, compact an over-limit retired tier
+    to its bound during load, reject over-limit state during encode, and reject
+    new runtime session creation at active capacity while preserving idempotent
+    retries for existing `session_id` values.
 - Bootstrap dealer-model constraint: the current engine holds all generated key
   packages for a session in one process. This is temporary bootstrap behavior
   and does not provide production threshold key isolation.

--- a/pkg/tbtc/signer/scripts/formal/run_tla_models.sh
+++ b/pkg/tbtc/signer/scripts/formal/run_tla_models.sh
@@ -16,7 +16,7 @@ TLA_TOOLS_URL="${TLA_TOOLS_URL:-https://github.com/tlaplus/tlaplus/releases/down
 # release v1.8.0). Re-pin this when the upstream release asset is rebuilt and the
 # download-verification gate below reports a mismatch, after confirming the new
 # jar comes from the official release URL.
-TLA_TOOLS_SHA256="${TLA_TOOLS_SHA256:-33de7da9ce1b7fffb9d1c184021178dbb051747be48504e65c584c423721a32e}"
+TLA_TOOLS_SHA256="${TLA_TOOLS_SHA256:-150b0294c3d407c15f0c971351ccd4ae8c6d885397546dff87871a14be2b4ee4}"
 
 if ! command -v java >/dev/null 2>&1; then
   echo "java is required to run TLC model checks" >&2

--- a/pkg/tbtc/signer/src/api.rs
+++ b/pkg/tbtc/signer/src/api.rs
@@ -1,4 +1,46 @@
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+
+/// A hex-encoded secret whose owned Rust allocation is wiped on drop and whose
+/// `Debug` representation never exposes its contents. Serde remains transparent
+/// so the C-ABI JSON contract continues to carry an ordinary string.
+#[derive(Clone, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct SecretHex(Zeroizing<String>);
+
+impl SecretHex {
+    pub fn new(value: String) -> Self {
+        Self(Zeroizing::new(value))
+    }
+
+    /// Borrows the secret for the narrow decode/serialization boundary without
+    /// creating another unmanaged `String` allocation.
+    pub fn expose_secret(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl From<String> for SecretHex {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl fmt::Debug for SecretHex {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("<redacted>")
+    }
+}
+
+impl Zeroize for SecretHex {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for SecretHex {}
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct DkgResult {
@@ -20,7 +62,7 @@ pub struct DkgRound2Package {
     pub identifier: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sender_identifier: Option<String>,
-    pub package_hex: String,
+    pub package_hex: SecretHex,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
@@ -32,26 +74,26 @@ pub struct DkgPart1Request {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct DkgPart1Result {
-    pub secret_package_hex: String,
+    pub secret_package_hex: SecretHex,
     pub package: DkgRound1Package,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct DkgPart2Request {
-    pub secret_package_hex: String,
+    pub secret_package_hex: SecretHex,
     pub round1_packages: Vec<DkgRound1Package>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct DkgPart2Result {
-    pub secret_package_hex: String,
+    pub secret_package_hex: SecretHex,
     pub packages: Vec<DkgRound2Package>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct NativeFrostKeyPackage {
     pub identifier: String,
-    pub data_hex: String,
+    pub data_hex: SecretHex,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
@@ -62,7 +104,7 @@ pub struct NativeFrostPublicKeyPackage {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct DkgPart3Request {
-    pub secret_package_hex: String,
+    pub secret_package_hex: SecretHex,
     pub round1_packages: Vec<DkgRound1Package>,
     pub round2_packages: Vec<DkgRound2Package>,
 }
@@ -847,4 +889,173 @@ pub struct InitSignerConfigResult {
     pub idempotent: bool,
     pub config_fingerprint: String,
     pub configured_key_count: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET_SENTINEL: &str =
+        "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+    fn secret_hex() -> SecretHex {
+        SecretHex::new(SECRET_SENTINEL.to_string())
+    }
+
+    fn round1_package() -> DkgRound1Package {
+        DkgRound1Package {
+            identifier: "round1-identifier".to_string(),
+            package_hex: "public-round1-package".to_string(),
+        }
+    }
+
+    fn round2_package() -> DkgRound2Package {
+        DkgRound2Package {
+            identifier: "round2-recipient".to_string(),
+            sender_identifier: Some("round2-sender".to_string()),
+            package_hex: secret_hex(),
+        }
+    }
+
+    fn public_key_package() -> NativeFrostPublicKeyPackage {
+        NativeFrostPublicKeyPackage {
+            verifying_shares: std::collections::BTreeMap::new(),
+            verifying_key: "public-verifying-key".to_string(),
+        }
+    }
+
+    fn key_package() -> NativeFrostKeyPackage {
+        NativeFrostKeyPackage {
+            identifier: "key-package-identifier".to_string(),
+            data_hex: secret_hex(),
+        }
+    }
+
+    #[test]
+    fn dkg_secret_hex_zeroizes_and_is_zeroize_on_drop() {
+        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+
+        assert_zeroize_on_drop::<SecretHex>();
+
+        let mut secret = secret_hex();
+        secret.zeroize();
+        assert!(secret.expose_secret().is_empty());
+    }
+
+    #[test]
+    fn dkg_secret_fields_preserve_json_string_wire_shape() {
+        let encoded_holder =
+            serde_json::to_string(&secret_hex()).expect("secret holder serializes");
+        assert_eq!(encoded_holder, format!("\"{SECRET_SENTINEL}\""));
+        let decoded_holder: SecretHex =
+            serde_json::from_str(&encoded_holder).expect("secret holder deserializes");
+        assert_eq!(decoded_holder.expose_secret(), SECRET_SENTINEL);
+
+        let serialized_fields = [
+            serde_json::to_value(DkgRound2Package {
+                identifier: "recipient".to_string(),
+                sender_identifier: Some("sender".to_string()),
+                package_hex: secret_hex(),
+            })
+            .expect("round2 package serializes")["package_hex"]
+                .clone(),
+            serde_json::to_value(DkgPart1Result {
+                secret_package_hex: secret_hex(),
+                package: round1_package(),
+            })
+            .expect("part1 result serializes")["secret_package_hex"]
+                .clone(),
+            serde_json::to_value(DkgPart2Request {
+                secret_package_hex: secret_hex(),
+                round1_packages: vec![round1_package()],
+            })
+            .expect("part2 request serializes")["secret_package_hex"]
+                .clone(),
+            serde_json::to_value(DkgPart2Result {
+                secret_package_hex: secret_hex(),
+                packages: vec![round2_package()],
+            })
+            .expect("part2 result serializes")["secret_package_hex"]
+                .clone(),
+            serde_json::to_value(DkgPart3Request {
+                secret_package_hex: secret_hex(),
+                round1_packages: vec![round1_package()],
+                round2_packages: vec![round2_package()],
+            })
+            .expect("part3 request serializes")["secret_package_hex"]
+                .clone(),
+            serde_json::to_value(key_package()).expect("key package serializes")["data_hex"]
+                .clone(),
+        ];
+
+        for serialized_field in serialized_fields {
+            assert_eq!(serialized_field, serde_json::json!(SECRET_SENTINEL));
+        }
+    }
+
+    #[test]
+    fn dkg_secret_fields_redact_direct_and_nested_debug_output() {
+        let rendered = [
+            format!("{:?}", round2_package()),
+            format!(
+                "{:?}",
+                DkgPart1Result {
+                    secret_package_hex: secret_hex(),
+                    package: round1_package(),
+                }
+            ),
+            format!(
+                "{:?}",
+                DkgPart2Request {
+                    secret_package_hex: secret_hex(),
+                    round1_packages: vec![round1_package()],
+                }
+            ),
+            format!(
+                "{:?}",
+                DkgPart2Result {
+                    secret_package_hex: secret_hex(),
+                    packages: vec![round2_package()],
+                }
+            ),
+            format!("{:?}", key_package()),
+            format!(
+                "{:?}",
+                DkgPart3Request {
+                    secret_package_hex: secret_hex(),
+                    round1_packages: vec![round1_package()],
+                    round2_packages: vec![round2_package()],
+                }
+            ),
+            format!(
+                "{:?}",
+                DkgPart3Result {
+                    key_package: key_package(),
+                    public_key_package: public_key_package(),
+                }
+            ),
+            format!(
+                "{:?}",
+                PersistDistributedDkgKeyPackageRequest {
+                    session_id: "debug-redaction-session".to_string(),
+                    participant_identifier: 1,
+                    threshold: 2,
+                    participant_count: 3,
+                    key_package: key_package(),
+                    public_key_package: public_key_package(),
+                }
+            ),
+        ];
+
+        for rendered_value in rendered {
+            assert!(
+                !rendered_value.contains(SECRET_SENTINEL),
+                "Debug output leaked DKG secret material: {rendered_value}"
+            );
+            assert!(
+                rendered_value.contains("<redacted>"),
+                "Debug output did not mark DKG secret material as redacted: {rendered_value}"
+            );
+        }
+    }
 }

--- a/pkg/tbtc/signer/src/engine/codec.rs
+++ b/pkg/tbtc/signer/src/engine/codec.rs
@@ -229,7 +229,7 @@ pub(crate) fn decode_round2_package_map(
         let mut package_bytes = decode_hex_field(
             operation,
             &format!("round2_packages[{index}].package_hex"),
-            &package.package_hex,
+            package.package_hex.expose_secret(),
         )?;
         let round2_package_result = frost::keys::dkg::round2::Package::deserialize(&package_bytes);
         package_bytes.zeroize();

--- a/pkg/tbtc/signer/src/engine/dkg.rs
+++ b/pkg/tbtc/signer/src/engine/dkg.rs
@@ -174,7 +174,7 @@ pub fn persist_distributed_dkg_key_package(
     let mut guard = state()?
         .lock()
         .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
-    ensure_session_insert_capacity(&mut guard.sessions, &request.session_id)?;
+    ensure_session_insert_capacity(&guard.sessions, &request.session_id)?;
 
     // A group verifying key identifies one wallet. Keeping the same key_group in
     // two sessions would make wallet lookup depend on randomized HashMap order and

--- a/pkg/tbtc/signer/src/engine/dkg.rs
+++ b/pkg/tbtc/signer/src/engine/dkg.rs
@@ -16,10 +16,10 @@ pub fn persist_distributed_dkg_key_package(
     mut request: PersistDistributedDkgKeyPackageRequest,
 ) -> Result<DkgResult, EngineError> {
     const OP: &str = "persist_distributed_dkg_key_package";
-    // data_hex is the serialized SECRET signing share. Move it into a zeroizing holder
-    // BEFORE any fallible check (validation, admission, quarantine can all return first),
-    // so serde's owned String is wiped on EVERY return path rather than dropped un-wiped.
-    let data_hex = Zeroizing::new(std::mem::take(&mut request.key_package.data_hex));
+    // data_hex is the serialized SECRET signing share. Move its redacting,
+    // zeroizing holder out BEFORE any fallible check so it is wiped on every
+    // return path and the rest of the request no longer retains it.
+    let data_hex = std::mem::take(&mut request.key_package.data_hex);
     validate_session_id(&request.session_id)?;
     // Gate BEFORE decoding or persisting any key material: this op writes signing
     // material to durable state that interactive signing trusts after restart, so
@@ -102,7 +102,11 @@ pub fn persist_distributed_dkg_key_package(
         auto_quarantine_config.as_ref(),
     )?;
 
-    let key_package = decode_key_package(OP, &request.key_package.identifier, &data_hex)?;
+    let key_package = decode_key_package(
+        OP,
+        &request.key_package.identifier,
+        data_hex.expose_secret(),
+    )?;
 
     // The key package must belong to this participant AND be consistent with the
     // group public key package: matching identifier, embedded threshold, group

--- a/pkg/tbtc/signer/src/engine/dkg.rs
+++ b/pkg/tbtc/signer/src/engine/dkg.rs
@@ -174,7 +174,6 @@ pub fn persist_distributed_dkg_key_package(
     let mut guard = state()?
         .lock()
         .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
-    ensure_session_insert_capacity(&guard.sessions, &request.session_id)?;
 
     // A group verifying key identifies one wallet. Keeping the same key_group in
     // two sessions would make wallet lookup depend on randomized HashMap order and
@@ -208,6 +207,11 @@ pub fn persist_distributed_dkg_key_package(
         });
     }
 
+    // Reserve a total-registry slot only after every rejection that can apply
+    // to a fresh DKG session. If the ensuing durable write fails before file
+    // replacement, restore any retired tombstone evicted for this slot.
+    let compacted_retired_sessions =
+        ensure_session_insert_capacity(&mut guard, &request.session_id)?;
     let dkg_session_id = request.session_id.clone();
     let session_existed = guard.sessions.contains_key(&dkg_session_id);
     let session = guard
@@ -296,6 +300,7 @@ pub fn persist_distributed_dkg_key_package(
             } else {
                 guard.sessions.remove(&dkg_session_id);
             }
+            restore_compacted_retired_sessions(&mut guard, compacted_retired_sessions);
         }
         return Err(persist_error);
     }

--- a/pkg/tbtc/signer/src/engine/dkg.rs
+++ b/pkg/tbtc/signer/src/engine/dkg.rs
@@ -174,7 +174,7 @@ pub fn persist_distributed_dkg_key_package(
     let mut guard = state()?
         .lock()
         .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
-    ensure_session_insert_capacity(&guard.sessions, &request.session_id)?;
+    ensure_session_insert_capacity(&mut guard.sessions, &request.session_id)?;
 
     // A group verifying key identifies one wallet. Keeping the same key_group in
     // two sessions would make wallet lookup depend on randomized HashMap order and

--- a/pkg/tbtc/signer/src/engine/frost_ops.rs
+++ b/pkg/tbtc/signer/src/engine/frost_ops.rs
@@ -46,7 +46,7 @@ pub fn dkg_part1(request: DkgPart1Request) -> Result<DkgPart1Result, EngineError
         .map_err(|e| EngineError::Internal(format!("failed to serialize DKG part1 secret: {e}")))?;
 
     let result = DkgPart1Result {
-        secret_package_hex: hex::encode(&secret_package_bytes),
+        secret_package_hex: SecretHex::new(hex::encode(&secret_package_bytes)),
         package: DkgRound1Package {
             identifier: frost_identifier_to_go_string(identifier),
             package_hex: hex::encode(package_bytes),
@@ -63,7 +63,7 @@ pub fn dkg_part2(request: DkgPart2Request) -> Result<DkgPart2Result, EngineError
     let mut secret_package_bytes = decode_hex_field(
         "DKGPart2",
         "secret_package_hex",
-        &request.secret_package_hex,
+        request.secret_package_hex.expose_secret(),
     )?;
     let secret_package_result =
         frost::keys::dkg::round1::SecretPackage::deserialize(&secret_package_bytes);
@@ -96,7 +96,7 @@ pub fn dkg_part2(request: DkgPart2Request) -> Result<DkgPart2Result, EngineError
         packages.push(DkgRound2Package {
             identifier: frost_identifier_to_go_string(identifier),
             sender_identifier: None,
-            package_hex: hex::encode(&package_bytes),
+            package_hex: SecretHex::new(hex::encode(&package_bytes)),
         });
         package_bytes.zeroize();
     }
@@ -107,7 +107,7 @@ pub fn dkg_part2(request: DkgPart2Request) -> Result<DkgPart2Result, EngineError
         .map_err(|e| EngineError::Internal(format!("failed to serialize DKG part2 secret: {e}")))?;
 
     let result = DkgPart2Result {
-        secret_package_hex: hex::encode(&round2_secret_package_bytes),
+        secret_package_hex: SecretHex::new(hex::encode(&round2_secret_package_bytes)),
         packages,
     };
     round2_secret_package_bytes.zeroize();
@@ -121,7 +121,7 @@ pub fn dkg_part3(request: DkgPart3Request) -> Result<DkgPart3Result, EngineError
     let mut secret_package_bytes = decode_hex_field(
         "DKGPart3",
         "secret_package_hex",
-        &request.secret_package_hex,
+        request.secret_package_hex.expose_secret(),
     )?;
     let secret_package_result =
         frost::keys::dkg::round2::SecretPackage::deserialize(&secret_package_bytes);
@@ -163,7 +163,7 @@ pub fn dkg_part3(request: DkgPart3Request) -> Result<DkgPart3Result, EngineError
     let result = DkgPart3Result {
         key_package: NativeFrostKeyPackage {
             identifier: frost_identifier_to_go_string(*key_package.identifier()),
-            data_hex: hex::encode(&key_package_bytes),
+            data_hex: SecretHex::new(hex::encode(&key_package_bytes)),
         },
         public_key_package: native_public_key_package,
     };

--- a/pkg/tbtc/signer/src/engine/interactive.rs
+++ b/pkg/tbtc/signer/src/engine/interactive.rs
@@ -18,6 +18,45 @@
 
 use super::*;
 
+#[cfg(test)]
+static INTERACTIVE_AGGREGATE_HOLD_AFTER_UNLOCK: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+#[cfg(test)]
+static INTERACTIVE_AGGREGATE_UNLOCK_HELD: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+#[cfg(test)]
+static INTERACTIVE_AGGREGATE_RELEASE_AFTER_UNLOCK: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(true);
+
+#[cfg(test)]
+pub(crate) fn arm_interactive_aggregate_unlock_hold_for_tests() {
+    use std::sync::atomic::Ordering;
+    INTERACTIVE_AGGREGATE_UNLOCK_HELD.store(false, Ordering::SeqCst);
+    INTERACTIVE_AGGREGATE_RELEASE_AFTER_UNLOCK.store(false, Ordering::SeqCst);
+    INTERACTIVE_AGGREGATE_HOLD_AFTER_UNLOCK.store(true, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+pub(crate) fn interactive_aggregate_unlock_held_for_tests() -> bool {
+    INTERACTIVE_AGGREGATE_UNLOCK_HELD.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+#[cfg(test)]
+pub(crate) fn release_interactive_aggregate_unlock_for_tests() {
+    INTERACTIVE_AGGREGATE_RELEASE_AFTER_UNLOCK.store(true, std::sync::atomic::Ordering::SeqCst);
+}
+
+#[cfg(test)]
+fn maybe_hold_interactive_aggregate_after_unlock_for_tests() {
+    use std::sync::atomic::Ordering;
+    if INTERACTIVE_AGGREGATE_HOLD_AFTER_UNLOCK.swap(false, Ordering::SeqCst) {
+        INTERACTIVE_AGGREGATE_UNLOCK_HELD.store(true, Ordering::SeqCst);
+        while !INTERACTIVE_AGGREGATE_RELEASE_AFTER_UNLOCK.load(Ordering::SeqCst) {
+            std::thread::yield_now();
+        }
+    }
+}
+
 // Multi-seat: a session's interactive consumed-nonce markers are keyed per
 // (attempt_id, member_identifier), so independent local seats can each consume
 // their own nonces for the same attempt without colliding. The marker is written
@@ -26,7 +65,10 @@ use super::*;
 // possibly reloaded from durable state) are honored FAIL-CLOSED on read: a bare
 // marker means the attempt is consumed for every member.
 pub(crate) fn interactive_consumed_marker(attempt_id: &str, member_identifier: u16) -> String {
-    format!("m{member_identifier}@{attempt_id}@v2")
+    // Keep the schema-1 wire representation understood by the immediately
+    // previous signer. A binary rollback must continue to see the attempt as
+    // consumed and fail closed rather than releasing a second share.
+    format!("m{member_identifier}@{attempt_id}")
 }
 
 pub(crate) fn interactive_attempt_consumed(
@@ -35,9 +77,9 @@ pub(crate) fn interactive_attempt_consumed(
     member_identifier: u16,
 ) -> bool {
     markers.contains(&interactive_consumed_marker(attempt_id, member_identifier))
-        // Pre-v2 multi-seat marker. It remains a replay blocker after upgrade,
-        // but does not authorize Aggregate because it has no package binding.
-        || markers.contains(&format!("m{member_identifier}@{attempt_id}"))
+        // Transitional marker written by an unreleased intermediate build.
+        // Continue honoring it fail-closed when upgrading that state.
+        || markers.contains(&format!("m{member_identifier}@{attempt_id}@v2"))
         || markers.contains(attempt_id)
 }
 
@@ -70,11 +112,41 @@ pub(crate) fn interactive_aggregate_authorization_marker(
     Ok(hex::encode(hasher.finalize()))
 }
 
-// A live authorization is exact only when this engine still holds a Round1
-// commitment included in the package. Open context alone cannot bind a FROST
-// package to attempt_number because the package carries no attempt id. Durable
-// authorization therefore comes from Round2; this live path supports a local
-// participating coordinator before its own Round2 call.
+// Session-scoped identity for a successfully aggregated canonical package.
+// It deliberately excludes attempt_id: the inner FROST package does not carry
+// one, so a non-signing coordinator can validate only the live coordinator
+// context plus package shape. Persisting this identity prevents the same valid
+// package/share set from being replayed under fresh canonical attempts to fill
+// the bounded completion registry.
+pub(crate) fn interactive_aggregate_package_completion_marker(
+    signing_package: &frost::SigningPackage,
+    taproot_merkle_root: Option<&[u8; 32]>,
+) -> Result<String, EngineError> {
+    let signing_package_bytes = signing_package.serialize().map_err(|error| {
+        EngineError::Internal(format!(
+            "failed to serialize signing package for Aggregate completion: {error}"
+        ))
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(b"tbtc-signer/interactive-aggregate-package-completion/v1");
+    match taproot_merkle_root {
+        Some(root) => {
+            hasher.update([1]);
+            hasher.update(root);
+        }
+        None => hasher.update([0]),
+    }
+    hasher.update((signing_package_bytes.len() as u64).to_be_bytes());
+    hasher.update(&signing_package_bytes);
+    Ok(hex::encode(hasher.finalize()))
+}
+
+// A signer proves live authorization with the exact Round1 commitment included
+// in the package. The elected coordinator is also allowed to aggregate a strict
+// first-t package that omits it: its validated live attempt authorizes the
+// common message/threshold/included-subset shape, while the package-completion
+// marker above prevents cross-attempt reuse of that otherwise attempt-less
+// FROST package. An omitted non-coordinator never receives this fallback.
 fn interactive_aggregate_has_live_authorization(
     session: &SessionState,
     attempt_id: &str,
@@ -89,7 +161,22 @@ fn interactive_aggregate_has_live_authorization(
         match verify_round2_signing_package(interactive, signing_package) {
             Ok(()) => return Ok(true),
             Err(error @ EngineError::Internal(_)) => return Err(error),
-            Err(_) => {}
+            Err(_) => {
+                let own_identifier =
+                    participant_identifier_to_frost_identifier(interactive.member_identifier)?;
+                let is_omitted_coordinator = interactive.member_identifier
+                    == interactive.attempt_context.coordinator_identifier
+                    && !signing_package
+                        .signing_commitments()
+                        .contains_key(&own_identifier);
+                if is_omitted_coordinator {
+                    match verify_interactive_signing_package_context(interactive, signing_package) {
+                        Ok(()) => return Ok(true),
+                        Err(error @ EngineError::Internal(_)) => return Err(error),
+                        Err(_) => {}
+                    }
+                }
+            }
         }
     }
     Ok(false)
@@ -1021,6 +1108,10 @@ pub fn interactive_aggregate(
         &signing_package,
         taproot_merkle_root.as_ref(),
     )?;
+    let aggregate_package_completion_marker = interactive_aggregate_package_completion_marker(
+        &signing_package,
+        taproot_merkle_root.as_ref(),
+    )?;
 
     let mut guard = state()?
         .lock()
@@ -1043,10 +1134,10 @@ pub fn interactive_aggregate(
     // the request - consistent with the no-secret-on-the-FFI discipline
     // and so a caller cannot substitute verifying material. The session
     // must exist with completed DKG.
-    let public_key_package = {
+    let (public_key_package, aggregate_eviction_pin) = {
         // The completion marker is per-signing-session state; read it - and the wallet
         // key_group this session serves - from request.session_id.
-        let key_group = {
+        let (key_group, aggregate_eviction_pin) = {
             let session = guard.sessions.get(&request.session_id).ok_or_else(|| {
                 EngineError::SessionNotFound {
                     session_id: request.session_id.clone(),
@@ -1081,16 +1172,26 @@ pub fn interactive_aggregate(
                     request.session_id
                 )));
             }
+            if session
+                .authorized_interactive_aggregate_markers
+                .contains(&aggregate_package_completion_marker)
+            {
+                return Err(EngineError::Validation(format!(
+                    "InteractiveAggregate: signing package was already aggregated in session [{}]",
+                    request.session_id
+                )));
+            }
             // The wallet key this signing session serves: its own DKG (co-located) or
             // the key_group bound at Open (distinct per-signing RoastSessionID).
-            session
+            let key_group = session
                 .dkg_result
                 .as_ref()
                 .map(|dkg| dkg.key_group.clone())
                 .or_else(|| session.bound_key_group.clone())
                 .ok_or_else(|| EngineError::DkgNotReady {
                     session_id: request.session_id.clone(),
-                })?
+                })?;
+            (key_group, Arc::clone(&session.aggregate_eviction_pin))
         };
         // The group's public key package (the verifying shares used to check each
         // contribution) is a WALLET-level asset resolved by key_group, so a per-signing
@@ -1107,15 +1208,18 @@ pub fn interactive_aggregate(
                 .ok_or_else(|| EngineError::SessionNotFound {
                     session_id: wallet_session_id.clone(),
                 })?;
-        session
+        let public_key_package = session
             .dkg_public_key_package
             .as_ref()
             .ok_or_else(|| {
                 EngineError::Internal("missing DKG public key package cache".to_string())
             })?
-            .clone()
+            .clone();
+        (public_key_package, aggregate_eviction_pin)
     };
     drop(guard);
+    #[cfg(test)]
+    maybe_hold_interactive_aggregate_after_unlock_for_tests();
 
     // Aggregation uses only public material (commitments, shares,
     // verifying shares), so no policy gate runs here - the secret-bearing
@@ -1232,12 +1336,36 @@ pub fn interactive_aggregate(
             request.session_id
         )));
     }
+    if session
+        .authorized_interactive_aggregate_markers
+        .contains(&aggregate_package_completion_marker)
+    {
+        return Err(EngineError::Validation(format!(
+            "InteractiveAggregate: signing package was already aggregated in session [{}]",
+            request.session_id
+        )));
+    }
     ensure_consumed_registry_insert_capacity(
         &session.aggregated_interactive_attempt_markers,
         &aggregated_marker,
         "aggregated_interactive_attempt_markers",
         &request.session_id,
     )?;
+    // A Round2 authorization is no longer needed once its exact package has
+    // completed, so replace it in-place with the package replay marker. A
+    // coordinator omitted from the signing subset has no Round2 authorization
+    // to replace and therefore consumes one normal bounded slot.
+    let replaces_aggregate_authorization = session
+        .authorized_interactive_aggregate_markers
+        .contains(&aggregate_authorization_marker);
+    if !replaces_aggregate_authorization {
+        ensure_consumed_registry_insert_capacity(
+            &session.authorized_interactive_aggregate_markers,
+            &aggregate_package_completion_marker,
+            "authorized_interactive_aggregate_markers",
+            &request.session_id,
+        )?;
+    }
     // Resolve the state-encryption key under the held ENGINE_STATE guard, in the
     // same serialized order as the write, and BEFORE inserting the marker.
     // Resolving under the guard makes key selection match the write order, so the
@@ -1250,6 +1378,12 @@ pub fn interactive_aggregate(
     session
         .aggregated_interactive_attempt_markers
         .insert(aggregated_marker.clone());
+    let removed_aggregate_authorization = session
+        .authorized_interactive_aggregate_markers
+        .remove(&aggregate_authorization_marker);
+    session
+        .authorized_interactive_aggregate_markers
+        .insert(aggregate_package_completion_marker.clone());
     if let Err(persist_error) =
         persist_engine_state_to_storage_with_key(&guard, &resolved_state_key)
     {
@@ -1274,6 +1408,14 @@ pub fn interactive_aggregate(
             session
                 .aggregated_interactive_attempt_markers
                 .remove(&aggregated_marker);
+            session
+                .authorized_interactive_aggregate_markers
+                .remove(&aggregate_package_completion_marker);
+            if removed_aggregate_authorization {
+                session
+                    .authorized_interactive_aggregate_markers
+                    .insert(aggregate_authorization_marker.clone());
+            }
         }
         if state_file_replaced {
             retire_idle_per_message_sessions(&mut guard, Some(&request.session_id));
@@ -1299,6 +1441,9 @@ pub fn interactive_aggregate(
     );
     retire_idle_per_message_sessions(&mut guard, Some(&request.session_id));
     drop(guard);
+    // Keep the target unevictable through both lock sections and the durable
+    // completion write. Error returns and unwinding release the clone by RAII.
+    drop(aggregate_eviction_pin);
 
     latency_guard.mark_success();
     record_hardening_telemetry(|telemetry| {
@@ -1416,9 +1561,9 @@ fn interactive_state_for_attempt_mut<'session>(
     Ok(interactive)
 }
 
-// The frozen spec's Round2 checks (a)-(f). Returns Ok only when every
-// check passes; the caller consumes the nonces strictly afterwards.
-fn verify_round2_signing_package(
+// Checks shared by a signer releasing a share and an elected coordinator
+// aggregating a strict first-t package that does not include itself.
+fn verify_interactive_signing_package_context(
     interactive: &InteractiveSigningState,
     signing_package: &frost::SigningPackage,
 ) -> Result<(), EngineError> {
@@ -1458,6 +1603,18 @@ fn verify_round2_signing_package(
             ));
         }
     }
+
+    Ok(())
+}
+
+// The frozen spec's Round2 checks (a)-(f). Returns Ok only when every
+// check passes; the caller consumes the nonces strictly afterwards.
+fn verify_round2_signing_package(
+    interactive: &InteractiveSigningState,
+    signing_package: &frost::SigningPackage,
+) -> Result<(), EngineError> {
+    verify_interactive_signing_package_context(interactive, signing_package)?;
+    let package_commitments = signing_package.signing_commitments();
 
     // (a) this member must be in the chosen subset.
     let own_identifier = participant_identifier_to_frost_identifier(interactive.member_identifier)?;

--- a/pkg/tbtc/signer/src/engine/interactive.rs
+++ b/pkg/tbtc/signer/src/engine/interactive.rs
@@ -38,6 +38,44 @@ pub(crate) fn interactive_attempt_consumed(
         || markers.contains(attempt_id)
 }
 
+// Aggregate is a public operation, so both signers (whose Round2 consumption
+// marker is durable) and observers (whose live Open state remains until
+// aggregation) may run it. Require one of those existing bindings before an
+// aggregate attempt can create durable completion state. Without this check a
+// caller could replay one valid package/share set under arbitrary attempt ids,
+// filling the bounded marker registry without ever opening those attempts.
+pub(crate) fn interactive_aggregate_attempt_is_bound(
+    session: &SessionState,
+    attempt_id: &str,
+) -> bool {
+    if session
+        .interactive_signing
+        .values()
+        .any(|interactive| interactive.attempt_context.attempt_id == attempt_id)
+    {
+        return true;
+    }
+
+    session
+        .consumed_interactive_attempt_markers
+        .iter()
+        .any(|marker| {
+            if marker == attempt_id {
+                // Legacy single-seat marker.
+                return true;
+            }
+
+            let Some((member, marker_attempt_id)) = marker.split_once('@') else {
+                return false;
+            };
+            member
+                .strip_prefix('m')
+                .and_then(|member| member.parse::<u16>().ok())
+                .is_some()
+                && marker_attempt_id == attempt_id
+        })
+}
+
 // The aggregate completion marker binds attempt_id to the AGGREGATED message digest,
 // so the durable "this attempt is final" record cannot be set for one attempt id via
 // a valid aggregate over a DIFFERENT message - which would otherwise let a replayed
@@ -426,7 +464,7 @@ pub fn interactive_session_open(
     // Bound by the SAME total-session cap as every other session-creating path (a fresh
     // RoastSessionID per message would otherwise let the registry grow unbounded and
     // then be rejected on reload); a reopen of an existing session is exempt.
-    ensure_session_insert_capacity(&guard.sessions, &request.session_id)?;
+    ensure_session_insert_capacity(&mut guard.sessions, &request.session_id)?;
 
     // A typed heartbeat never passes through BuildTaprootTx, so charge its own
     // per-wallet policy budget at the last fallible boundary before installing
@@ -903,16 +941,7 @@ pub fn interactive_aggregate(
         HardeningOperationLatencyGuard::success_only(HardeningOperation::InteractiveAggregate);
     enforce_provenance_gate()?;
     validate_session_id(&request.session_id)?;
-    let attempt_id = canonical_attempt_id(&request.attempt_id);
-    // The completion marker persists attempt_id, and the reload path rejects an
-    // empty key; reject an empty attempt_id here too so a malformed (or
-    // malicious) request cannot write durable state that fails to reload after
-    // a restart.
-    if attempt_id.is_empty() {
-        return Err(EngineError::Validation(
-            "InteractiveAggregate: attempt_id must not be empty".to_string(),
-        ));
-    }
+    let attempt_id = canonical_aggregate_attempt_id(&request.attempt_id)?;
 
     let mut signing_package_bytes = decode_hex_field(
         "InteractiveAggregate",
@@ -988,6 +1017,12 @@ pub fn interactive_aggregate(
                     session_id: request.session_id.clone(),
                     attempt_id,
                 });
+            }
+            if !interactive_aggregate_attempt_is_bound(session, &attempt_id) {
+                return Err(EngineError::Validation(format!(
+                    "InteractiveAggregate: attempt_id [{attempt_id}] is not bound to an open or consumed attempt for session [{}]",
+                    request.session_id
+                )));
             }
             // The wallet key this signing session serves: its own DKG (co-located) or
             // the key_group bound at Open (distinct per-signing RoastSessionID).
@@ -1252,6 +1287,9 @@ pub fn interactive_session_abort(
         }
         None => false,
     };
+    // An Open-only per-message shell carries no durable replay or policy state;
+    // once its last member is aborted it can be recreated safely on a retry.
+    reclaim_per_message_sessions(&mut guard.sessions, false);
 
     // Only count a success when live interactive state was actually
     // aborted. A no-op call (no session, or an attempt_id filter that
@@ -1446,6 +1484,17 @@ fn canonical_attempt_id(attempt_id: &str) -> String {
     attempt_id.to_ascii_lowercase()
 }
 
+fn canonical_aggregate_attempt_id(attempt_id: &str) -> Result<String, EngineError> {
+    if attempt_id.len() != 64 || !attempt_id.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(EngineError::Validation(
+            "InteractiveAggregate: attempt_id must be exactly 64 hexadecimal characters"
+                .to_string(),
+        ));
+    }
+
+    Ok(canonical_attempt_id(attempt_id))
+}
+
 // The chosen signing subset as Go u16 identifiers: the included
 // participants whose commitment appears in the signing package. The
 // caller MUST have run verify_round2_signing_package first (which
@@ -1569,6 +1618,10 @@ pub(crate) fn sweep_expired_interactive_state(engine_state: &mut EngineState) {
             }
         }
     }
+    // Expiry has abort semantics. Reclaim only empty Open-created shells here;
+    // consumed-but-unaggregated sessions and BuildTaprootTx policy artifacts
+    // must survive for restart/outer-loop retry.
+    reclaim_per_message_sessions(&mut engine_state.sessions, false);
 }
 
 pub(crate) fn max_live_interactive_sessions_limit() -> usize {

--- a/pkg/tbtc/signer/src/engine/interactive.rs
+++ b/pkg/tbtc/signer/src/engine/interactive.rs
@@ -1476,16 +1476,26 @@ pub fn interactive_aggregate(
             .get_mut(&request.session_id)
             .expect("session existed under the held engine lock");
         if state_file_replaced {
-            mark_persistence_pending(PersistencePendingOperation::InteractiveAggregate {
-                session_id: request.session_id.clone(),
-                aggregated_marker: aggregated_marker.clone(),
-            });
             remove_finalized_interactive_members(
                 session,
                 &attempt_id,
                 &aggregated_message_digest,
                 taproot_merkle_root.as_ref(),
             );
+            // Stage retirement BEFORE registering the pending operation. Generic
+            // retirement deliberately skips pending sessions to protect uncertain
+            // markers from eviction; registering first would therefore strand this
+            // now-idle shell as active. With retirement staged first, the pending
+            // operation protects the tombstone and any later successful full-state
+            // snapshot (the exact retry or an unrelated writer) durably covers both
+            // the completion marker and retirement before clearing pending.
+            if session.interactive_signing.is_empty() && per_message_interactive_session(session) {
+                session.retired_interactive_at_unix = Some(now_unix().max(1));
+            }
+            mark_persistence_pending(PersistencePendingOperation::InteractiveAggregate {
+                session_id: request.session_id.clone(),
+                aggregated_marker: aggregated_marker.clone(),
+            });
         } else {
             session
                 .aggregated_interactive_attempt_markers

--- a/pkg/tbtc/signer/src/engine/interactive.rs
+++ b/pkg/tbtc/signer/src/engine/interactive.rs
@@ -26,7 +26,7 @@ use super::*;
 // possibly reloaded from durable state) are honored FAIL-CLOSED on read: a bare
 // marker means the attempt is consumed for every member.
 pub(crate) fn interactive_consumed_marker(attempt_id: &str, member_identifier: u16) -> String {
-    format!("m{member_identifier}@{attempt_id}")
+    format!("m{member_identifier}@{attempt_id}@v2")
 }
 
 pub(crate) fn interactive_attempt_consumed(
@@ -35,45 +35,64 @@ pub(crate) fn interactive_attempt_consumed(
     member_identifier: u16,
 ) -> bool {
     markers.contains(&interactive_consumed_marker(attempt_id, member_identifier))
+        // Pre-v2 multi-seat marker. It remains a replay blocker after upgrade,
+        // but does not authorize Aggregate because it has no package binding.
+        || markers.contains(&format!("m{member_identifier}@{attempt_id}"))
         || markers.contains(attempt_id)
 }
 
-// Aggregate is a public operation, so both signers (whose Round2 consumption
-// marker is durable) and observers (whose live Open state remains until
-// aggregation) may run it. Require one of those existing bindings before an
-// aggregate attempt can create durable completion state. Without this check a
-// caller could replay one valid package/share set under arbitrary attempt ids,
-// filling the bounded marker registry without ever opening those attempts.
-pub(crate) fn interactive_aggregate_attempt_is_bound(
+// Fixed-size, exact authorization written atomically with the Round2 consumed
+// marker. Hash canonical package bytes rather than caller-provided hex so
+// alternate encodings cannot create distinct persistent records.
+pub(crate) fn interactive_aggregate_authorization_marker(
+    attempt_id: &str,
+    signing_package: &frost::SigningPackage,
+    taproot_merkle_root: Option<&[u8; 32]>,
+) -> Result<String, EngineError> {
+    let signing_package_bytes = signing_package.serialize().map_err(|error| {
+        EngineError::Internal(format!(
+            "failed to serialize signing package for Aggregate authorization: {error}"
+        ))
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(b"tbtc-signer/interactive-aggregate-authorization/v1");
+    hasher.update((attempt_id.len() as u64).to_be_bytes());
+    hasher.update(attempt_id.as_bytes());
+    match taproot_merkle_root {
+        Some(root) => {
+            hasher.update([1]);
+            hasher.update(root);
+        }
+        None => hasher.update([0]),
+    }
+    hasher.update((signing_package_bytes.len() as u64).to_be_bytes());
+    hasher.update(&signing_package_bytes);
+    Ok(hex::encode(hasher.finalize()))
+}
+
+// A live authorization is exact only when this engine still holds a Round1
+// commitment included in the package. Open context alone cannot bind a FROST
+// package to attempt_number because the package carries no attempt id. Durable
+// authorization therefore comes from Round2; this live path supports a local
+// participating coordinator before its own Round2 call.
+fn interactive_aggregate_has_live_authorization(
     session: &SessionState,
     attempt_id: &str,
-) -> bool {
-    if session
-        .interactive_signing
-        .values()
-        .any(|interactive| interactive.attempt_context.attempt_id == attempt_id)
-    {
-        return true;
+    signing_package: &frost::SigningPackage,
+    taproot_merkle_root: Option<&[u8; 32]>,
+) -> Result<bool, EngineError> {
+    for interactive in session.interactive_signing.values().filter(|interactive| {
+        interactive.attempt_context.attempt_id == attempt_id
+            && interactive.taproot_merkle_root.as_ref() == taproot_merkle_root
+            && interactive.round1.is_some()
+    }) {
+        match verify_round2_signing_package(interactive, signing_package) {
+            Ok(()) => return Ok(true),
+            Err(error @ EngineError::Internal(_)) => return Err(error),
+            Err(_) => {}
+        }
     }
-
-    session
-        .consumed_interactive_attempt_markers
-        .iter()
-        .any(|marker| {
-            if marker == attempt_id {
-                // Legacy single-seat marker.
-                return true;
-            }
-
-            let Some((member, marker_attempt_id)) = marker.split_once('@') else {
-                return false;
-            };
-            member
-                .strip_prefix('m')
-                .and_then(|member| member.parse::<u16>().ok())
-                .is_some()
-                && marker_attempt_id == attempt_id
-        })
+    Ok(false)
 }
 
 // The aggregate completion marker binds attempt_id to the AGGREGATED message digest,
@@ -458,13 +477,10 @@ pub fn interactive_session_open(
         }
     }
 
-    // Create the per-signing session on first Open if it is distinct from the wallet
-    // DKG session (the production case). Its DKG material is NOT copied here - it stays
-    // the single wallet copy, resolved by key_group; only per-signing state lives here.
-    // Bound by the SAME total-session cap as every other session-creating path (a fresh
-    // RoastSessionID per message would otherwise let the registry grow unbounded and
-    // then be rejected on reload); a reopen of an existing session is exempt.
-    ensure_session_insert_capacity(&mut guard.sessions, &request.session_id)?;
+    // Admission/reactivation is fallible at a full active tier. Preflight it
+    // before charging the wallet's heartbeat budget; the engine lock prevents
+    // the count from changing before the actual install below.
+    ensure_interactive_session_admission_capacity(&guard, &request.session_id)?;
 
     // A typed heartbeat never passes through BuildTaprootTx, so charge its own
     // per-wallet policy budget at the last fallible boundary before installing
@@ -485,6 +501,12 @@ pub fn interactive_session_open(
             &mut wallet_session.heartbeat_rate_limiter,
         )?;
     }
+
+    // Create (or reactivate) the per-signing session only after every other
+    // fallible gate. A rejected heartbeat must not pull an idle tombstone back
+    // into the active budget. DKG material remains solely in the wallet session.
+    reactivate_retired_per_message_session(&mut guard, &request.session_id)?;
+    ensure_session_insert_capacity(&guard.sessions, &request.session_id)?;
 
     let session = guard
         .sessions
@@ -644,10 +666,6 @@ pub fn interactive_round2(
     if interactive_round2_persistence_pending(&request.session_id, &consumed_marker) {
         persist_engine_state_to_storage(&guard)
             .map_err(PersistEngineStateError::into_engine_error)?;
-        clear_persistence_pending_operation(&PersistencePendingOperation::InteractiveRound2 {
-            session_id: request.session_id.clone(),
-            consumed_marker: consumed_marker.clone(),
-        });
     }
 
     // Quarantine inputs must be read before the session is borrowed
@@ -822,6 +840,17 @@ pub fn interactive_round2(
         &quarantined_operator_identifiers,
         auto_quarantine_config.as_ref(),
     )?;
+    let aggregate_authorization_marker = interactive_aggregate_authorization_marker(
+        &attempt_id,
+        &signing_package,
+        interactive.taproot_merkle_root.as_ref(),
+    )?;
+    ensure_consumed_registry_insert_capacity(
+        &session.authorized_interactive_aggregate_markers,
+        &aggregate_authorization_marker,
+        "authorized_interactive_aggregate_markers",
+        &request.session_id,
+    )?;
 
     // Consumption-before-release: the durable marker is persisted BEFORE the
     // share is computed and returned. A failure before state-file replacement
@@ -842,6 +871,17 @@ pub fn interactive_round2(
     session
         .consumed_interactive_attempt_markers
         .insert(consumed_marker.clone());
+    session
+        .authorized_interactive_aggregate_markers
+        .insert(aggregate_authorization_marker.clone());
+    let retires_session =
+        session.interactive_signing.len() == 1 && per_message_interactive_session(session);
+    let compacted_retired_sessions = if retires_session {
+        session.retired_interactive_at_unix = Some(now_unix().max(1));
+        compact_retired_per_message_sessions(&mut guard, Some(&request.session_id))
+    } else {
+        Vec::new()
+    };
     if let Err(persist_error) =
         persist_engine_state_to_storage_with_key(&guard, &resolved_state_key)
     {
@@ -866,6 +906,13 @@ pub fn interactive_round2(
             session
                 .consumed_interactive_attempt_markers
                 .remove(&consumed_marker);
+            session
+                .authorized_interactive_aggregate_markers
+                .remove(&aggregate_authorization_marker);
+            if retires_session {
+                session.retired_interactive_at_unix = None;
+            }
+            restore_compacted_retired_sessions(&mut guard, compacted_retired_sessions);
         }
         return Err(persist_error);
     }
@@ -969,6 +1016,11 @@ pub fn interactive_aggregate(
         &aggregated_message_digest,
         taproot_merkle_root.as_ref(),
     );
+    let aggregate_authorization_marker = interactive_aggregate_authorization_marker(
+        &attempt_id,
+        &signing_package,
+        taproot_merkle_root.as_ref(),
+    )?;
 
     let mut guard = state()?
         .lock()
@@ -979,10 +1031,6 @@ pub fn interactive_aggregate(
     if interactive_aggregate_persistence_pending(&request.session_id, &aggregated_marker) {
         persist_engine_state_to_storage(&guard)
             .map_err(PersistEngineStateError::into_engine_error)?;
-        clear_persistence_pending_operation(&PersistencePendingOperation::InteractiveAggregate {
-            session_id: request.session_id.clone(),
-            aggregated_marker: aggregated_marker.clone(),
-        });
     }
     // Aggregate takes the engine lock like every other interactive entry
     // point, so it sweeps expired interactive state too: the TTL
@@ -1018,9 +1066,18 @@ pub fn interactive_aggregate(
                     attempt_id,
                 });
             }
-            if !interactive_aggregate_attempt_is_bound(session, &attempt_id) {
+            let authorized = session
+                .authorized_interactive_aggregate_markers
+                .contains(&aggregate_authorization_marker)
+                || interactive_aggregate_has_live_authorization(
+                    session,
+                    &attempt_id,
+                    &signing_package,
+                    taproot_merkle_root.as_ref(),
+                )?;
+            if !authorized {
                 return Err(EngineError::Validation(format!(
-                    "InteractiveAggregate: attempt_id [{attempt_id}] is not bound to an open or consumed attempt for session [{}]",
+                    "InteractiveAggregate: package is not authorized for attempt_id [{attempt_id}] in session [{}]",
                     request.session_id
                 )));
             }
@@ -1160,6 +1217,21 @@ pub fn interactive_aggregate(
             attempt_id,
         });
     }
+    let authorized = session
+        .authorized_interactive_aggregate_markers
+        .contains(&aggregate_authorization_marker)
+        || interactive_aggregate_has_live_authorization(
+            session,
+            &attempt_id,
+            &signing_package,
+            taproot_merkle_root.as_ref(),
+        )?;
+    if !authorized {
+        return Err(EngineError::Validation(format!(
+            "InteractiveAggregate: package authorization changed before completion for attempt_id [{attempt_id}] in session [{}]",
+            request.session_id
+        )));
+    }
     ensure_consumed_registry_insert_capacity(
         &session.aggregated_interactive_attempt_markers,
         &aggregated_marker,
@@ -1203,6 +1275,9 @@ pub fn interactive_aggregate(
                 .aggregated_interactive_attempt_markers
                 .remove(&aggregated_marker);
         }
+        if state_file_replaced {
+            retire_idle_per_message_sessions(&mut guard, Some(&request.session_id));
+        }
         return Err(persist_error);
     }
 
@@ -1222,6 +1297,7 @@ pub fn interactive_aggregate(
         &aggregated_message_digest,
         taproot_merkle_root.as_ref(),
     );
+    retire_idle_per_message_sessions(&mut guard, Some(&request.session_id));
     drop(guard);
 
     latency_guard.mark_success();
@@ -1287,9 +1363,11 @@ pub fn interactive_session_abort(
         }
         None => false,
     };
-    // An Open-only per-message shell carries no durable replay or policy state;
-    // once its last member is aborted it can be recreated safely on a retry.
-    reclaim_per_message_sessions(&mut guard.sessions, false);
+    // Once the last live member is aborted, move a production per-message
+    // entry into the separately bounded retirement tier. Its BuildTaprootTx
+    // artifact and replay markers remain available for a delayed outer retry,
+    // without consuming the active-session budget indefinitely.
+    retire_idle_per_message_sessions(&mut guard, None);
 
     // Only count a success when live interactive state was actually
     // aborted. A no-op call (no session, or an attempt_id filter that
@@ -1618,10 +1696,9 @@ pub(crate) fn sweep_expired_interactive_state(engine_state: &mut EngineState) {
             }
         }
     }
-    // Expiry has abort semantics. Reclaim only empty Open-created shells here;
-    // consumed-but-unaggregated sessions and BuildTaprootTx policy artifacts
-    // must survive for restart/outer-loop retry.
-    reclaim_per_message_sessions(&mut engine_state.sessions, false);
+    // Expiry has abort semantics. Retire idle per-message entries while
+    // retaining their bounded policy/replay tombstones for delayed retries.
+    retire_idle_per_message_sessions(engine_state, None);
 }
 
 pub(crate) fn max_live_interactive_sessions_limit() -> usize {

--- a/pkg/tbtc/signer/src/engine/interactive.rs
+++ b/pkg/tbtc/signer/src/engine/interactive.rs
@@ -284,7 +284,7 @@ pub fn interactive_session_open(
     let mut guard = state()?
         .lock()
         .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
-    sweep_expired_interactive_state(&mut guard);
+    sweep_expired_interactive_state_durably(&mut guard)?;
 
     let auto_quarantine_config = load_auto_quarantine_config()?;
 
@@ -564,45 +564,130 @@ pub fn interactive_session_open(
         }
     }
 
-    // Admission/reactivation is fallible at a full active tier. Preflight it
-    // before charging the wallet's heartbeat budget; the engine lock prevents
-    // the count from changing before the actual install below.
+    // Admission/reactivation is fallible at active capacity, or when every
+    // retired slot at the shared total bound is protected. Preflight it before
+    // charging the wallet's heartbeat budget; the engine lock prevents the
+    // registry from changing before the actual install below.
     ensure_interactive_session_admission_capacity(&guard, &request.session_id)?;
 
+    // A BuildTaprootTx-backed signing shell is persisted before its first Open.
+    // Make the first wallet binding durable before reporting Open success, or a
+    // crash would reload that old unbound shell as an active non-retirable entry.
+    // A co-located DKG session already has a durable wallet role and needs no
+    // additional write here; a previously bound per-message session likewise
+    // reuses its durable identity.
+    let persists_new_per_message_binding = match guard.sessions.get(&request.session_id) {
+        Some(session) => session.dkg_result.is_none() && session.bound_key_group.is_none(),
+        None => true,
+    };
+    let resolved_binding_state_key = if persists_new_per_message_binding {
+        Some(state_encryption_key_material()?)
+    } else {
+        None
+    };
+
     // A typed heartbeat never passes through BuildTaprootTx, so charge its own
-    // per-wallet policy budget at the last fallible boundary before installing
-    // live signing state. All validation and the exact-retry return above have
-    // already run: malformed/conflicting Opens cannot burn a token, an
-    // idempotent retry is free, and Round2 only rechecks the stored intent.
-    if matches!(
+    // per-wallet policy budget only after all validation and the exact-retry
+    // return above. If the new binding cannot be persisted before replacement,
+    // the limiter snapshot is restored along with the session registry, so a
+    // durability failure cannot burn the caller's only legitimate token.
+    let is_heartbeat = matches!(
         request.signing_intent.as_ref(),
         Some(InteractiveSigningIntent::Heartbeat { .. })
-    ) {
+    );
+    let previous_heartbeat_rate_limiter = if is_heartbeat {
         let wallet_session = guard.sessions.get_mut(&wallet_session_id).ok_or_else(|| {
             EngineError::SessionNotFound {
                 session_id: wallet_session_id.clone(),
             }
         })?;
+        let previous = wallet_session.heartbeat_rate_limiter.clone();
         enforce_heartbeat_rate_limit(
             &request.session_id,
             &mut wallet_session.heartbeat_rate_limiter,
         )?;
-    }
+        Some(previous)
+    } else {
+        None
+    };
 
     // Create (or reactivate) the per-signing session only after every other
     // fallible gate. A rejected heartbeat must not pull an idle tombstone back
     // into the active budget. DKG material remains solely in the wallet session.
+    let session_existed = guard.sessions.contains_key(&request.session_id);
+    let (previous_bound_key_group, previous_retired_at) = guard
+        .sessions
+        .get(&request.session_id)
+        .map(|session| {
+            (
+                session.bound_key_group.clone(),
+                session.retired_interactive_at_unix,
+            )
+        })
+        .unwrap_or((None, None));
     reactivate_retired_per_message_session(&mut guard, &request.session_id)?;
-    ensure_session_insert_capacity(&guard.sessions, &request.session_id)?;
+    let compacted_retired_sessions =
+        ensure_session_insert_capacity(&mut guard, &request.session_id)?;
+
+    {
+        let session = guard
+            .sessions
+            .entry(request.session_id.clone())
+            .or_insert_with(SessionState::default);
+        // Bind this signing session to the wallet key it signs for, so Round2 and
+        // Aggregate resolve the same wallet material by key_group.
+        session.bound_key_group = Some(request.key_group.clone());
+    }
+
+    if let Some(resolved_state_key) = resolved_binding_state_key.as_ref() {
+        if let Err(persist_error) =
+            persist_engine_state_to_storage_with_key(&guard, resolved_state_key)
+        {
+            let state_file_replaced = persist_error.state_file_replaced();
+            let persist_error = persist_error.into_engine_error();
+
+            if let Some(previous) = previous_heartbeat_rate_limiter {
+                guard
+                    .sessions
+                    .get_mut(&wallet_session_id)
+                    .expect("wallet session existed while rolling back Open")
+                    .heartbeat_rate_limiter = previous;
+            }
+
+            if state_file_replaced {
+                let session = guard
+                    .sessions
+                    .get_mut(&request.session_id)
+                    .expect("Open session existed after state-file replacement");
+                if session.interactive_signing.is_empty()
+                    && per_message_interactive_session(session)
+                {
+                    session.retired_interactive_at_unix = Some(now_unix().max(1));
+                }
+                mark_persistence_pending(PersistencePendingOperation::InteractiveState {
+                    session_id: request.session_id.clone(),
+                });
+            } else {
+                if session_existed {
+                    let session = guard
+                        .sessions
+                        .get_mut(&request.session_id)
+                        .expect("Open session existed while rolling back binding");
+                    session.bound_key_group = previous_bound_key_group;
+                    session.retired_interactive_at_unix = previous_retired_at;
+                } else {
+                    guard.sessions.remove(&request.session_id);
+                }
+                restore_compacted_retired_sessions(&mut guard, compacted_retired_sessions);
+            }
+            return Err(persist_error);
+        }
+    }
 
     let session = guard
         .sessions
-        .entry(request.session_id.clone())
-        .or_insert_with(SessionState::default);
-    // Bind this signing session to the wallet key it signs for, so Round2 and Aggregate
-    // resolve the same wallet material by key_group.
-    session.bound_key_group = Some(request.key_group.clone());
-
+        .get_mut(&request.session_id)
+        .expect("Open session existed after binding persistence");
     // Replace only THIS member's prior entry (zeroizing its old nonces); sibling
     // seats' entries are untouched.
     if let Some(mut replaced) = session.interactive_signing.remove(&member_identifier) {
@@ -658,7 +743,7 @@ pub fn interactive_round1(
     let mut guard = state()?
         .lock()
         .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
-    sweep_expired_interactive_state(&mut guard);
+    sweep_expired_interactive_state_durably(&mut guard)?;
 
     let session = guard.sessions.get_mut(&request.session_id).ok_or_else(|| {
         EngineError::SessionNotFound {
@@ -745,7 +830,7 @@ pub fn interactive_round2(
     let mut guard = state()?
         .lock()
         .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
-    sweep_expired_interactive_state(&mut guard);
+    sweep_expired_interactive_state_durably(&mut guard)?;
 
     // An earlier marker write may have replaced the state file but failed its
     // directory sync. Flush that fail-closed marker before consulting the replay
@@ -1116,6 +1201,9 @@ pub fn interactive_aggregate(
     let mut guard = state()?
         .lock()
         .map_err(|_| EngineError::Internal("engine lock poisoned".to_string()))?;
+    // Sweep first so a failure while repairing any prior completion marker can
+    // never postpone destruction of newly expired nonce handles.
+    sweep_expired_interactive_state_durably(&mut guard)?;
     // A prior completion-marker write may have replaced the state file but failed
     // its directory sync. Re-persist that fail-closed marker before the completed
     // attempt check so a retry repairs durability and is then rejected normally.
@@ -1123,12 +1211,6 @@ pub fn interactive_aggregate(
         persist_engine_state_to_storage(&guard)
             .map_err(PersistEngineStateError::into_engine_error)?;
     }
-    // Aggregate takes the engine lock like every other interactive entry
-    // point, so it sweeps expired interactive state too: the TTL
-    // guarantee (a nonce handle gone within the TTL of inactivity) must
-    // hold even when the only post-expiry traffic is aggregate calls.
-    sweep_expired_interactive_state(&mut guard);
-
     // Resolve the group's public key package (the verifying shares used
     // to check each contribution) from the session's own DKG state, not
     // the request - consistent with the no-secret-on-the-FFI discipline
@@ -1480,16 +1562,19 @@ pub fn interactive_session_abort(
     // Abort takes the lock like every other entry point, so it sweeps
     // expired interactive state too: the TTL guarantee (nonces gone
     // within the TTL of inactivity) must hold even when the only
-    // post-expiry traffic is aborts for other sessions.
-    sweep_expired_interactive_state(&mut guard);
+    // post-expiry traffic is aborts for other sessions. The durable helper also
+    // repairs a prior post-rename Abort snapshot before an idempotent retry can
+    // return `aborted: false` without writing.
+    sweep_expired_interactive_state_durably(&mut guard)?;
 
-    let aborted = match guard.sessions.get_mut(&request.session_id) {
+    let members_to_abort = match guard.sessions.get(&request.session_id) {
         Some(session) => {
             // Abort has no member parameter, so it is session-level over the map:
-            // remove every member entry matching the optional attempt filter,
-            // zeroizing each entry's nonces. Sibling members on a non-matching
-            // attempt survive. Aborted iff at least one entry was removed.
-            let members_to_abort: Vec<u16> = session
+            // select every member entry matching the optional attempt filter.
+            // Keep the nonce-bearing entries live until the durable retirement
+            // snapshot has replaced the state file, so a pre-replacement failure
+            // remains cleanly retryable.
+            session
                 .interactive_signing
                 .iter()
                 .filter(|(_, interactive)| {
@@ -1498,38 +1583,97 @@ pub fn interactive_session_abort(
                             == Some(interactive.attempt_context.attempt_id.as_str())
                 })
                 .map(|(member, _)| *member)
-                .collect();
+                .collect::<Vec<_>>()
+        }
+        None => Vec::new(),
+    };
+
+    if members_to_abort.is_empty() {
+        return Ok(InteractiveSessionAbortResult {
+            session_id: request.session_id,
+            aborted: false,
+        });
+    }
+
+    // Resolve the key before staging retirement. A key-provider outage must not
+    // consume the live nonces or turn a retryable attempt into an inert shell.
+    let resolved_state_key = state_encryption_key_material()?;
+    let (retires_session, previous_retired_at) = {
+        let session = guard
+            .sessions
+            .get_mut(&request.session_id)
+            .expect("selected abort session existed under the held engine lock");
+        let retires_session = members_to_abort.len() == session.interactive_signing.len()
+            && per_message_interactive_session(session);
+        let previous_retired_at = session.retired_interactive_at_unix;
+        if retires_session {
+            session.retired_interactive_at_unix = Some(now_unix().max(1));
+        }
+        (retires_session, previous_retired_at)
+    };
+    let compacted_retired_sessions =
+        compact_retired_per_message_sessions(&mut guard, Some(&request.session_id));
+
+    // Interactive nonce state is intentionally never serialized. Persist while
+    // it is still held in memory: the snapshot durably carries the Open binding,
+    // policy artifact, and (for a last-member Abort) retirement timestamp. Only
+    // after replacement is it safe to destroy the selected nonce handles and
+    // report success.
+    if let Err(persist_error) =
+        persist_engine_state_to_storage_with_key(&guard, &resolved_state_key)
+    {
+        let state_file_replaced = persist_error.state_file_replaced();
+        let persist_error = persist_error.into_engine_error();
+        if state_file_replaced {
+            let session = guard
+                .sessions
+                .get_mut(&request.session_id)
+                .expect("abort session existed after state-file replacement");
             for member in &members_to_abort {
                 if let Some(mut removed) = session.interactive_signing.remove(member) {
                     zeroize_interactive_round1(&mut removed);
                 }
             }
-            !members_to_abort.is_empty()
+            mark_persistence_pending(PersistencePendingOperation::InteractiveState {
+                session_id: request.session_id.clone(),
+            });
+        } else {
+            if retires_session {
+                guard
+                    .sessions
+                    .get_mut(&request.session_id)
+                    .expect("abort session existed while rolling back retirement")
+                    .retired_interactive_at_unix = previous_retired_at;
+            }
+            restore_compacted_retired_sessions(&mut guard, compacted_retired_sessions);
         }
-        None => false,
-    };
-    // Once the last live member is aborted, move a production per-message
-    // entry into the separately bounded retirement tier. Its BuildTaprootTx
-    // artifact and replay markers remain available for a delayed outer retry,
-    // without consuming the active-session budget indefinitely.
-    retire_idle_per_message_sessions(&mut guard, None);
+        return Err(persist_error);
+    }
+
+    let session = guard
+        .sessions
+        .get_mut(&request.session_id)
+        .expect("abort session existed after durable retirement");
+    for member in &members_to_abort {
+        if let Some(mut removed) = session.interactive_signing.remove(member) {
+            zeroize_interactive_round1(&mut removed);
+        }
+    }
 
     // Only count a success when live interactive state was actually
     // aborted. A no-op call (no session, or an attempt_id filter that
     // matched nothing) returns aborted == false and must not inflate the
     // success counter - the calls_total counter at the top already
     // records that the entry point ran.
-    if aborted {
-        record_hardening_telemetry(|telemetry| {
-            telemetry.interactive_session_abort_success_total = telemetry
-                .interactive_session_abort_success_total
-                .saturating_add(1);
-        });
-    }
+    record_hardening_telemetry(|telemetry| {
+        telemetry.interactive_session_abort_success_total = telemetry
+            .interactive_session_abort_success_total
+            .saturating_add(1);
+    });
 
     Ok(InteractiveSessionAbortResult {
         session_id: request.session_id,
-        aborted,
+        aborted: true,
     })
 }
 
@@ -1831,14 +1975,15 @@ pub(crate) fn resolve_wallet_session_id(
         .map(|(id, _)| id.clone())
 }
 
-pub(crate) fn sweep_expired_interactive_state(engine_state: &mut EngineState) {
+pub(crate) fn sweep_expired_interactive_state(engine_state: &mut EngineState) -> Vec<String> {
     let ttl_seconds = interactive_session_ttl_seconds();
     let now = now_unix();
-    // Interactive sessions always ride a DKG-populated session (Open
-    // requires existing DKG state), so expiry only clears the live
-    // attempt's nonces; the session itself - DKG material, consumed
-    // markers - is retained for future signing.
-    for session in engine_state.sessions.values_mut() {
+    let mut changed_session_ids = HashSet::new();
+    // Open requires an existing wallet DKG, but production signing normally
+    // uses a distinct per-message session bound to that wallet. Expiry clears
+    // each live attempt's nonces; retirement below retains its bounded policy
+    // and replay state until active admission needs the shared slot.
+    for (session_id, session) in &mut engine_state.sessions {
         // Per-member expiry: each seat's entry expires independently by its own
         // opened_at_unix; non-expired sibling seats in the same session survive.
         let expired_members: Vec<u16> = session
@@ -1847,6 +1992,9 @@ pub(crate) fn sweep_expired_interactive_state(engine_state: &mut EngineState) {
             .filter(|(_, interactive)| now.saturating_sub(interactive.opened_at_unix) > ttl_seconds)
             .map(|(member, _)| *member)
             .collect();
+        if !expired_members.is_empty() {
+            changed_session_ids.insert(session_id.clone());
+        }
         for member in &expired_members {
             if let Some(mut removed) = session.interactive_signing.remove(member) {
                 zeroize_interactive_round1(&mut removed);
@@ -1855,7 +2003,58 @@ pub(crate) fn sweep_expired_interactive_state(engine_state: &mut EngineState) {
     }
     // Expiry has abort semantics. Retire idle per-message entries while
     // retaining their bounded policy/replay tombstones for delayed retries.
-    retire_idle_per_message_sessions(engine_state, None);
+    changed_session_ids.extend(retire_idle_per_message_session_ids(engine_state, None));
+    changed_session_ids.retain(|session_id| engine_state.sessions.contains_key(session_id));
+    changed_session_ids.into_iter().collect()
+}
+
+pub(crate) fn sweep_expired_interactive_state_durably(
+    engine_state: &mut EngineState,
+) -> Result<(), EngineError> {
+    // Persist every session whose live member set changed, not only sessions
+    // whose last member expired. Open binds a Build-backed per-message shell
+    // in memory, while live interactive state is intentionally omitted from
+    // snapshots. If one sibling expired and another remained live, skipping
+    // this write would let a crash reload the old unbound shell; persisting the
+    // binding lets load classify it as retired once the nonces disappear.
+    let changed_session_ids = sweep_expired_interactive_state(engine_state);
+    let repairs_pending_interactive_state = interactive_state_persistence_pending();
+    // An existing Abort/expiry repair must be retried even when this sweep found
+    // no additional expiry. Avoid key-provider/filesystem work on the ordinary
+    // no-op fast path.
+    if changed_session_ids.is_empty() && !repairs_pending_interactive_state {
+        return Ok(());
+    }
+
+    if let Err(persist_error) = persist_engine_state_to_storage(engine_state) {
+        for session_id in changed_session_ids {
+            mark_persistence_pending(PersistencePendingOperation::InteractiveState { session_id });
+        }
+        return Err(persist_error.into_engine_error());
+    }
+
+    // Pending sessions are deliberately excluded from retirement until a
+    // successful snapshot covers their uncertain post-rename state. If this
+    // sweep expired the last surviving sibling of such an Abort, the write above
+    // cleared its protection; classify and persist that now-idle session before
+    // returning from the same entry point.
+    if repairs_pending_interactive_state {
+        let retired_after_repair = sweep_expired_interactive_state(engine_state);
+        if let Err(persist_error) = if retired_after_repair.is_empty() {
+            Ok(())
+        } else {
+            persist_engine_state_to_storage(engine_state)
+        } {
+            for session_id in retired_after_repair {
+                mark_persistence_pending(PersistencePendingOperation::InteractiveState {
+                    session_id,
+                });
+            }
+            return Err(persist_error.into_engine_error());
+        }
+    }
+
+    Ok(())
 }
 
 pub(crate) fn max_live_interactive_sessions_limit() -> usize {

--- a/pkg/tbtc/signer/src/engine/mod.rs
+++ b/pkg/tbtc/signer/src/engine/mod.rs
@@ -76,7 +76,7 @@ use crate::api::{
     PersistDistributedDkgKeyPackageRequest, PromoteCanaryRequest, PromoteCanaryResult,
     QuarantineStatusRequest, QuarantineStatusResult, RefreshCadenceStatusRequest,
     RefreshCadenceStatusResult, RefreshSharesRequest, RefreshSharesResult,
-    RoastLivenessPolicyResult, RollbackCanaryRequest, RollbackCanaryResult, RoundState,
+    RoastLivenessPolicyResult, RollbackCanaryRequest, RollbackCanaryResult, RoundState, SecretHex,
     SignatureResult, SignerHardeningMetricsResult, TransactionResult, TranscriptAuditRecord,
     TranscriptAuditRequest, TranscriptAuditResult, TriggerEmergencyRekeyRequest,
     TriggerEmergencyRekeyResult, VerifyBlameProofRequest,

--- a/pkg/tbtc/signer/src/engine/mod.rs
+++ b/pkg/tbtc/signer/src/engine/mod.rs
@@ -48,7 +48,7 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Output, Stdio};
 use std::str::FromStr;
-use std::sync::{mpsc, Mutex, OnceLock};
+use std::sync::{mpsc, Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use frost_secp256k1_tr::{

--- a/pkg/tbtc/signer/src/engine/persistence.rs
+++ b/pkg/tbtc/signer/src/engine/persistence.rs
@@ -76,7 +76,8 @@ pub(crate) struct PersistedSessionState {
     pub(crate) bound_key_group: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) retired_interactive_at_unix: Option<u64>,
-    // Fixed-size exact Aggregate authorizations written with Round2.
+    // Fixed-size exact Aggregate authorizations and successful-package replay
+    // identities (see SessionState).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) authorized_interactive_aggregate_markers: Vec<String>,
 }
@@ -1967,6 +1968,7 @@ impl TryFrom<PersistedSessionState> for SessionState {
             // by key_group. Public data; survives with the consumed/aggregate markers.
             bound_key_group: persisted.bound_key_group,
             retired_interactive_at_unix: persisted.retired_interactive_at_unix,
+            aggregate_eviction_pin: Arc::new(()),
             consumed_interactive_attempt_markers,
             authorized_interactive_aggregate_markers,
             aggregated_interactive_attempt_markers,

--- a/pkg/tbtc/signer/src/engine/persistence.rs
+++ b/pkg/tbtc/signer/src/engine/persistence.rs
@@ -281,6 +281,9 @@ pub(crate) enum PersistencePendingOperation {
         session_id: String,
         aggregated_marker: String,
     },
+    InteractiveState {
+        session_id: String,
+    },
 }
 
 static PERSISTENCE_PENDING_OPERATIONS: OnceLock<Mutex<Vec<PersistencePendingOperation>>> =
@@ -337,6 +340,14 @@ fn persistence_pending_same_slot(
                 aggregated_marker: replacement_marker,
             },
         ) => existing_session == replacement_session && existing_marker == replacement_marker,
+        (
+            PersistencePendingOperation::InteractiveState {
+                session_id: existing_session,
+            },
+            PersistencePendingOperation::InteractiveState {
+                session_id: replacement_session,
+            },
+        ) => existing_session == replacement_session,
         _ => false,
     }
 }
@@ -372,7 +383,8 @@ pub(crate) fn persistence_pending_session_ids() -> HashSet<String> {
         .filter_map(|operation| match operation {
             PersistencePendingOperation::BuildTaprootTx { session_id, .. }
             | PersistencePendingOperation::InteractiveRound2 { session_id, .. }
-            | PersistencePendingOperation::InteractiveAggregate { session_id, .. } => {
+            | PersistencePendingOperation::InteractiveAggregate { session_id, .. }
+            | PersistencePendingOperation::InteractiveState { session_id } => {
                 Some(session_id.clone())
             }
             PersistencePendingOperation::EmergencyRekey { result } => {
@@ -384,10 +396,13 @@ pub(crate) fn persistence_pending_session_ids() -> HashSet<String> {
         .collect()
 }
 
-fn clear_snapshot_covered_marker_operations(engine_state: &EngineState) {
+fn clear_snapshot_covered_operations(engine_state: &EngineState) {
     // Round2/Aggregate pending entries cache no result. Clear one only when the
     // successful snapshot actually contains its fail-closed marker; merely
     // writing some other snapshot must never erase a repair obligation.
+    // InteractiveState carries no replay marker, so any snapshot still containing
+    // its protected session covers the binding/retirement state that was uncertain
+    // after an Open, Abort, or expiry write replaced the file.
     // Lifecycle/build/refresh entries additionally preserve the original
     // operation result, so keep those until that caller retries (one bounded
     // slot per session, plus one canary slot).
@@ -417,6 +432,9 @@ fn clear_snapshot_covered_marker_operations(engine_state: &EngineState) {
                         .aggregated_interactive_attempt_markers
                         .contains(aggregated_marker)
                 }),
+            PersistencePendingOperation::InteractiveState { session_id } => {
+                !engine_state.sessions.contains_key(session_id)
+            }
             _ => true,
         });
 }
@@ -540,6 +558,19 @@ pub(crate) fn interactive_aggregate_persistence_pending(
                     session_id: pending_session,
                     aggregated_marker: pending_marker,
                 } if pending_session == session_id && pending_marker == aggregated_marker
+            )
+        })
+}
+
+pub(crate) fn interactive_state_persistence_pending() -> bool {
+    persistence_pending_operations()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .iter()
+        .any(|operation| {
+            matches!(
+                operation,
+                PersistencePendingOperation::InteractiveState { .. }
             )
         })
 }
@@ -1332,6 +1363,12 @@ pub(crate) fn load_engine_state_from_storage() -> Result<EngineState, EngineErro
         }
     };
 
+    // An intermediate schema-1 writer allowed independent active and retired
+    // allowances. Conversion below can safely compact its retired excess, but
+    // the old oversized envelope must also be replaced immediately; otherwise
+    // an emergency rollback before the next ordinary write still fails the
+    // previous reader's total-count validation.
+    let session_registry_requires_rewrite = persisted.sessions.len() > max_sessions_limit();
     let (engine_state, recovered_from_corruption): (EngineState, bool) = match persisted.try_into()
     {
         Ok(engine_state) => (engine_state, false),
@@ -1352,10 +1389,10 @@ pub(crate) fn load_engine_state_from_storage() -> Result<EngineState, EngineErro
     // mutation will create a fresh encrypted state file. This explicit recovery
     // outcome replaces the former `Path::exists` probe without hiding metadata
     // errors or treating dangling symlinks as first initialization.
-    if should_rewrite_state && !recovered_from_corruption {
+    if (should_rewrite_state || session_registry_requires_rewrite) && !recovered_from_corruption {
         persist_engine_state_to_storage(&engine_state).map_err(|e| {
             EngineError::Internal(format!(
-                "loaded legacy signer state file [{}] but failed to migrate to current encrypted envelope: {e}",
+                "loaded signer state file [{}] but failed to rewrite its migrated state: {e}",
                 path.display()
             ))
         })?;
@@ -1532,7 +1569,7 @@ pub(crate) fn persist_engine_state_to_storage_with_key(
     bytes.zeroize();
     match persist_result {
         Ok(()) => {
-            clear_snapshot_covered_marker_operations(engine_state);
+            clear_snapshot_covered_operations(engine_state);
             Ok(())
         }
         Err(error) if state_file_replaced => {

--- a/pkg/tbtc/signer/src/engine/persistence.rs
+++ b/pkg/tbtc/signer/src/engine/persistence.rs
@@ -74,6 +74,11 @@ pub(crate) struct PersistedSessionState {
     // (a key group id), not secret. serde(default) keeps pre-existing state loadable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) bound_key_group: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) retired_interactive_at_unix: Option<u64>,
+    // Fixed-size exact Aggregate authorizations written with Round2.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) authorized_interactive_aggregate_markers: Vec<String>,
 }
 
 // Hand-written Debug: `sign_message_hex` is `SecretString`
@@ -138,6 +143,14 @@ impl std::fmt::Debug for PersistedSessionState {
                 &self.aggregated_interactive_attempt_markers,
             )
             .field("bound_key_group", &self.bound_key_group)
+            .field(
+                "retired_interactive_at_unix",
+                &self.retired_interactive_at_unix,
+            )
+            .field(
+                "authorized_interactive_aggregate_markers",
+                &self.authorized_interactive_aggregate_markers,
+            )
             .finish()
     }
 }
@@ -350,21 +363,60 @@ pub(crate) fn clear_persistence_pending_operation(operation: &PersistencePending
         .retain(|pending| pending != operation);
 }
 
-fn clear_snapshot_covered_marker_operations() {
-    // Round2/Aggregate pending entries cache no result; once any complete state
-    // snapshot succeeds, their retained markers are durable and the normal
-    // replay gates are sufficient. Lifecycle/build/refresh entries additionally
-    // preserve the original operation result, so keep those until that caller
-    // retries (one bounded slot per session, plus one canary slot).
+pub(crate) fn persistence_pending_session_ids() -> HashSet<String> {
     persistence_pending_operations()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .retain(|pending| {
-            !matches!(
-                pending,
-                PersistencePendingOperation::InteractiveRound2 { .. }
-                    | PersistencePendingOperation::InteractiveAggregate { .. }
-            )
+        .iter()
+        .filter_map(|operation| match operation {
+            PersistencePendingOperation::BuildTaprootTx { session_id, .. }
+            | PersistencePendingOperation::InteractiveRound2 { session_id, .. }
+            | PersistencePendingOperation::InteractiveAggregate { session_id, .. } => {
+                Some(session_id.clone())
+            }
+            PersistencePendingOperation::EmergencyRekey { result } => {
+                Some(result.session_id.clone())
+            }
+            PersistencePendingOperation::CanaryPromotion { .. }
+            | PersistencePendingOperation::CanaryRollback { .. } => None,
+        })
+        .collect()
+}
+
+fn clear_snapshot_covered_marker_operations(engine_state: &EngineState) {
+    // Round2/Aggregate pending entries cache no result. Clear one only when the
+    // successful snapshot actually contains its fail-closed marker; merely
+    // writing some other snapshot must never erase a repair obligation.
+    // Lifecycle/build/refresh entries additionally preserve the original
+    // operation result, so keep those until that caller retries (one bounded
+    // slot per session, plus one canary slot).
+    persistence_pending_operations()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .retain(|pending| match pending {
+            PersistencePendingOperation::InteractiveRound2 {
+                session_id,
+                consumed_marker,
+            } => !engine_state
+                .sessions
+                .get(session_id)
+                .is_some_and(|session| {
+                    session
+                        .consumed_interactive_attempt_markers
+                        .contains(consumed_marker)
+                }),
+            PersistencePendingOperation::InteractiveAggregate {
+                session_id,
+                aggregated_marker,
+            } => !engine_state
+                .sessions
+                .get(session_id)
+                .is_some_and(|session| {
+                    session
+                        .aggregated_interactive_attempt_markers
+                        .contains(aggregated_marker)
+                }),
+            _ => true,
         });
 }
 
@@ -1479,7 +1531,7 @@ pub(crate) fn persist_engine_state_to_storage_with_key(
     bytes.zeroize();
     match persist_result {
         Ok(()) => {
-            clear_snapshot_covered_marker_operations();
+            clear_snapshot_covered_marker_operations(engine_state);
             Ok(())
         }
         Err(error) if state_file_replaced => {
@@ -1518,7 +1570,19 @@ impl TryFrom<PersistedEngineState> for EngineState {
             }
             sessions.insert(session_id, session_state);
         }
-        ensure_session_registry_persisted_bound(sessions.len())?;
+        // State written before the retirement tier existed restores no live
+        // interactive nonces by construction. Classify its idle, bound
+        // per-message entries into the retired tier during load so a full
+        // legacy registry cannot remain permanently wedged after upgrade.
+        let migration_retired_at = now_unix().max(1);
+        for session in sessions.values_mut() {
+            if session.retired_interactive_at_unix.is_none()
+                && session.interactive_signing.is_empty()
+                && per_message_interactive_session(session)
+            {
+                session.retired_interactive_at_unix = Some(migration_retired_at);
+            }
+        }
         let mut quarantined_operator_identifiers = HashSet::new();
         for operator_identifier in persisted.quarantined_operator_identifiers {
             if operator_identifier == 0 {
@@ -1559,13 +1623,19 @@ impl TryFrom<PersistedEngineState> for EngineState {
             ));
         }
 
-        Ok(EngineState {
+        let mut engine_state = EngineState {
             sessions,
             refresh_epoch_counter: persisted.refresh_epoch_counter,
             operator_fault_scores: persisted.operator_fault_scores,
             quarantined_operator_identifiers,
             canary_rollout,
-        })
+        };
+        drop(compact_retired_per_message_sessions(
+            &mut engine_state,
+            None,
+        ));
+        ensure_session_registry_persisted_bound(&engine_state.sessions)?;
+        Ok(engine_state)
     }
 }
 
@@ -1573,7 +1643,7 @@ impl TryFrom<&EngineState> for PersistedEngineState {
     type Error = EngineError;
 
     fn try_from(engine_state: &EngineState) -> Result<Self, Self::Error> {
-        ensure_session_registry_persisted_bound(engine_state.sessions.len())?;
+        ensure_session_registry_persisted_bound(&engine_state.sessions)?;
         let mut sessions = HashMap::new();
         for (session_id, session_state) in &engine_state.sessions {
             sessions.insert(session_id.clone(), session_state.try_into()?);
@@ -1777,6 +1847,29 @@ impl TryFrom<PersistedSessionState> for SessionState {
             "consumed_interactive_attempt_markers",
         )?;
 
+        let mut authorized_interactive_aggregate_markers = HashSet::new();
+        for authorization_marker in persisted.authorized_interactive_aggregate_markers {
+            let canonical_sha256 = authorization_marker.len() == 64
+                && authorization_marker
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
+            if !canonical_sha256 {
+                return Err(EngineError::Internal(
+                    "persisted interactive Aggregate authorization marker must be canonical 64-character lowercase hex"
+                        .to_string(),
+                ));
+            }
+            if !authorized_interactive_aggregate_markers.insert(authorization_marker.clone()) {
+                return Err(EngineError::Internal(format!(
+                    "duplicate persisted interactive Aggregate authorization marker [{authorization_marker}]"
+                )));
+            }
+        }
+        ensure_consumed_registry_persisted_bound(
+            authorized_interactive_aggregate_markers.len(),
+            "authorized_interactive_aggregate_markers",
+        )?;
+
         let mut aggregated_interactive_attempt_markers = HashSet::new();
         for attempt_marker in persisted.aggregated_interactive_attempt_markers {
             if attempt_marker.is_empty() {
@@ -1828,7 +1921,13 @@ impl TryFrom<PersistedSessionState> for SessionState {
             }
         }
 
-        Ok(SessionState {
+        if persisted.retired_interactive_at_unix == Some(0) {
+            return Err(EngineError::Internal(
+                "persisted retired_interactive_at_unix must be positive".to_string(),
+            ));
+        }
+
+        let session = SessionState {
             dkg_request_fingerprint: persisted.dkg_request_fingerprint,
             dkg_key_packages,
             dkg_public_key_package,
@@ -1867,9 +1966,19 @@ impl TryFrom<PersistedSessionState> for SessionState {
             // runs after a restart (past a member's Round2) can still resolve the wallet
             // by key_group. Public data; survives with the consumed/aggregate markers.
             bound_key_group: persisted.bound_key_group,
+            retired_interactive_at_unix: persisted.retired_interactive_at_unix,
             consumed_interactive_attempt_markers,
+            authorized_interactive_aggregate_markers,
             aggregated_interactive_attempt_markers,
-        })
+        };
+        if session.retired_interactive_at_unix.is_some()
+            && !per_message_interactive_session(&session)
+        {
+            return Err(EngineError::Internal(
+                "persisted retired interactive session must have the per-message role".to_string(),
+            ));
+        }
+        Ok(session)
     }
 }
 
@@ -1940,6 +2049,10 @@ impl TryFrom<&SessionState> for PersistedSessionState {
             session_state.consumed_interactive_attempt_markers.len(),
             "consumed_interactive_attempt_markers",
         )?;
+        ensure_consumed_registry_persisted_bound(
+            session_state.authorized_interactive_aggregate_markers.len(),
+            "authorized_interactive_aggregate_markers",
+        )?;
         if session_state.attempt_transition_records.len()
             > TBTC_SIGNER_MAX_ATTEMPT_TRANSITION_RECORDS_PER_SESSION
         {
@@ -1985,6 +2098,12 @@ impl TryFrom<&SessionState> for PersistedSessionState {
             .cloned()
             .collect::<Vec<_>>();
         aggregated_interactive_attempt_markers.sort_unstable();
+        let mut authorized_interactive_aggregate_markers = session_state
+            .authorized_interactive_aggregate_markers
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        authorized_interactive_aggregate_markers.sort_unstable();
 
         Ok(PersistedSessionState {
             dkg_request_fingerprint: session_state.dkg_request_fingerprint.clone(),
@@ -2012,6 +2131,8 @@ impl TryFrom<&SessionState> for PersistedSessionState {
             consumed_interactive_attempt_markers,
             aggregated_interactive_attempt_markers,
             bound_key_group: session_state.bound_key_group.clone(),
+            retired_interactive_at_unix: session_state.retired_interactive_at_unix,
+            authorized_interactive_aggregate_markers,
         })
     }
 }

--- a/pkg/tbtc/signer/src/engine/policy.rs
+++ b/pkg/tbtc/signer/src/engine/policy.rs
@@ -27,7 +27,7 @@ pub(crate) const BUILD_TX_RATE_LIMIT_TOKEN_SCALE: u128 = 1_000_000;
 
 pub(crate) const BUILD_TX_RATE_LIMIT_SECONDS_PER_MINUTE: u128 = 60;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct PolicyRateLimiterState {
     pub(crate) last_refill_unix: u64,
     pub(crate) token_microunits: u128,

--- a/pkg/tbtc/signer/src/engine/state.rs
+++ b/pkg/tbtc/signer/src/engine/state.rs
@@ -141,11 +141,17 @@ pub(crate) struct SessionState {
     // retry's BuildTaprootTx policy artifact keep working. Old retired entries
     // are evicted FIFO-by-time once the separate retirement budget is full.
     pub(crate) retired_interactive_at_unix: Option<u64>,
+    // Transient refcount pin for Aggregate's unlocked cryptographic section.
+    // The session owns one reference; an in-flight Aggregate clones it while
+    // holding the engine lock, and compaction skips any session with a clone.
+    // Never persisted: no operation can remain in flight across a restart.
+    pub(crate) aggregate_eviction_pin: Arc<()>,
     pub(crate) consumed_interactive_attempt_markers: HashSet<String>,
-    // Fixed-size SHA-256 bindings written atomically with Round2 consumption.
-    // Each marker authorizes Aggregate for exactly one
-    // (attempt_id, signing package, taproot root) tuple, including after a
-    // restart when the live nonce state is intentionally absent.
+    // Fixed-size SHA-256 bindings. Round2 writes an exact
+    // (attempt_id, signing package, taproot root) authorization; successful
+    // Aggregate replaces it with a package/root completion identity so the
+    // same attempt-less FROST package cannot fill completion storage under
+    // fresh canonical attempt ids. Both survive restart.
     pub(crate) authorized_interactive_aggregate_markers: HashSet<String>,
     // Phase 7.2b InteractiveAggregate completion markers: an attempt whose
     // aggregate signature has been produced is recorded here so a repeat
@@ -512,6 +518,7 @@ pub(crate) fn per_message_interactive_session(session: &SessionState) -> bool {
         interactive_signing,
         bound_key_group,
         retired_interactive_at_unix,
+        aggregate_eviction_pin,
         consumed_interactive_attempt_markers,
         authorized_interactive_aggregate_markers,
         aggregated_interactive_attempt_markers,
@@ -539,6 +546,7 @@ pub(crate) fn per_message_interactive_session(session: &SessionState) -> bool {
         heartbeat_rate_limiter,
         interactive_signing,
         retired_interactive_at_unix,
+        aggregate_eviction_pin,
         consumed_interactive_attempt_markers,
         authorized_interactive_aggregate_markers,
         aggregated_interactive_attempt_markers,
@@ -595,6 +603,7 @@ pub(crate) fn compact_retired_per_message_sessions(
             .filter_map(|(session_id, session)| {
                 if protected_session_id == Some(session_id.as_str())
                     || pending_session_ids.contains(session_id)
+                    || Arc::strong_count(&session.aggregate_eviction_pin) > 1
                 {
                     return None;
                 }

--- a/pkg/tbtc/signer/src/engine/state.rs
+++ b/pkg/tbtc/signer/src/engine/state.rs
@@ -217,6 +217,15 @@ pub(crate) const TBTC_SIGNER_MAX_ATTEMPT_TRANSITION_RECORDS_PER_SESSION: usize =
 
 pub(crate) static ENGINE_STATE: OnceLock<Mutex<EngineState>> = OnceLock::new();
 
+// Loading can rewrite a legacy or stale encrypted envelope in place. A
+// OnceLock serializes only the final in-memory installation, so it does not by
+// itself prevent concurrent first callers from racing those fallible storage
+// reads and migrations. Keep that entire path behind a process-local mutex
+// that is deliberately separate from STATE_FILE_LOCK: the loader resolves the
+// active path through STATE_FILE_LOCK and would deadlock if its slot guard were
+// held here.
+static ENGINE_STATE_INITIALIZATION_LOCK: Mutex<()> = Mutex::new(());
+
 pub(crate) static STATE_FILE_LOCK: OnceLock<Mutex<Option<StateFileLock>>> = OnceLock::new();
 
 pub(crate) static STATE_PATH_OVERRIDE_WARNED: OnceLock<()> = OnceLock::new();
@@ -327,12 +336,50 @@ pub(crate) fn state() -> Result<&'static Mutex<EngineState>, EngineError> {
     ensure_state_file_lock()?;
     warn_disabled_policy_gates();
 
-    if let Some(state) = ENGINE_STATE.get() {
+    initialize_engine_state_with_loader(
+        &ENGINE_STATE,
+        &ENGINE_STATE_INITIALIZATION_LOCK,
+        || {},
+        load_engine_state_from_storage,
+    )
+}
+
+/// Installs the first engine state while serializing the complete fallible load
+/// path, not just the final OnceLock write.
+///
+/// `after_initial_miss` is a no-op in production and lets concurrency tests
+/// deterministically place multiple callers past the optimistic fast path.
+/// The loader runs under `initialization_lock`; a failed load leaves
+/// `engine_state` unset so a later call can retry.
+pub(crate) fn initialize_engine_state_with_loader<'state, AfterInitialMiss, Load>(
+    engine_state: &'state OnceLock<Mutex<EngineState>>,
+    initialization_lock: &Mutex<()>,
+    after_initial_miss: AfterInitialMiss,
+    load: Load,
+) -> Result<&'state Mutex<EngineState>, EngineError>
+where
+    AfterInitialMiss: FnOnce(),
+    Load: FnOnce() -> Result<EngineState, EngineError>,
+{
+    if let Some(state) = engine_state.get() {
         return Ok(state);
     }
 
-    let loaded_state = load_engine_state_from_storage()?;
-    Ok(ENGINE_STATE.get_or_init(|| Mutex::new(loaded_state)))
+    after_initial_miss();
+
+    // The mutex protects no data of its own. Recovering its guard after a
+    // panic is safe, and the second OnceLock check determines whether the
+    // previous caller completed installation before panicking.
+    let _initialization_guard = initialization_lock
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    if let Some(state) = engine_state.get() {
+        return Ok(state);
+    }
+
+    let loaded_state = load()?;
+    Ok(engine_state.get_or_init(|| Mutex::new(loaded_state)))
 }
 
 pub(crate) fn state_file_path() -> Result<PathBuf, EngineError> {

--- a/pkg/tbtc/signer/src/engine/state.rs
+++ b/pkg/tbtc/signer/src/engine/state.rs
@@ -447,8 +447,110 @@ pub(crate) fn ensure_session_registry_persisted_bound(
     Ok(())
 }
 
+// A per-message interactive session is safe to reclaim once it has no live
+// nonce state and either completed aggregation or never accumulated any
+// durable/non-interactive state. Keep this predicate exhaustive: adding a new
+// SessionState field must force an explicit decision about whether reclaiming a
+// session carrying that field is safe.
+pub(crate) fn reclaimable_per_message_session(
+    session: &SessionState,
+    include_completed: bool,
+) -> bool {
+    let SessionState {
+        dkg_request_fingerprint,
+        dkg_key_packages,
+        dkg_public_key_package,
+        dkg_result,
+        sign_request_fingerprint,
+        sign_message_bytes,
+        round_state,
+        active_attempt_context,
+        attempt_transition_records,
+        consumed_attempt_ids,
+        consumed_sign_round_ids,
+        finalize_request_fingerprint,
+        signature_result,
+        consumed_finalize_round_ids,
+        consumed_finalize_request_fingerprints,
+        build_tx_request_fingerprint,
+        tx_result,
+        refresh_request_fingerprint,
+        refresh_result,
+        refresh_history,
+        refresh_count,
+        emergency_rekey_event,
+        heartbeat_rate_limiter,
+        interactive_signing,
+        bound_key_group,
+        consumed_interactive_attempt_markers,
+        aggregated_interactive_attempt_markers,
+    } = session;
+
+    // Open-created per-message sessions are bound to a wallet key but never own
+    // DKG material. Wallet/DKG sessions are permanent and must not be compacted.
+    let per_message_role = bound_key_group.is_some()
+        && dkg_request_fingerprint.is_none()
+        && dkg_key_packages.is_none()
+        && dkg_public_key_package.is_none()
+        && dkg_result.is_none();
+    if !per_message_role || !interactive_signing.is_empty() {
+        return false;
+    }
+
+    // These fields belong to other session workflows. Their presence makes the
+    // role ambiguous, so retain the entry. BuildTaprootTx fields are handled
+    // separately below because they are the policy artifact for this same
+    // per-message signing flow.
+    let carries_other_workflow_state = sign_request_fingerprint.is_some()
+        || sign_message_bytes.is_some()
+        || round_state.is_some()
+        || active_attempt_context.is_some()
+        || !attempt_transition_records.is_empty()
+        || !consumed_attempt_ids.is_empty()
+        || !consumed_sign_round_ids.is_empty()
+        || finalize_request_fingerprint.is_some()
+        || signature_result.is_some()
+        || !consumed_finalize_round_ids.is_empty()
+        || !consumed_finalize_request_fingerprints.is_empty()
+        || refresh_request_fingerprint.is_some()
+        || refresh_result.is_some()
+        || !refresh_history.is_empty()
+        || *refresh_count != 0
+        || emergency_rekey_event.is_some()
+        || heartbeat_rate_limiter.last_refill_unix != 0
+        || heartbeat_rate_limiter.token_microunits != 0
+        || heartbeat_rate_limiter.configured_rate_limit_per_minute != 0;
+    if carries_other_workflow_state {
+        return false;
+    }
+
+    // Successful aggregation is terminal for this per-message flow. Preserve
+    // its completion tombstone until capacity pressure requires compaction, so
+    // immediate/restart retries retain their existing typed error semantics.
+    if include_completed && !aggregated_interactive_attempt_markers.is_empty() {
+        return true;
+    }
+
+    // Abort/TTL shells with no consumed share and no transaction-policy artifact
+    // are safe to recreate from Open. A BuildTaprootTx artifact must survive a
+    // failed attempt because the outer retry loop reuses this stable session ID.
+    aggregated_interactive_attempt_markers.is_empty()
+        && consumed_interactive_attempt_markers.is_empty()
+        && build_tx_request_fingerprint.is_none()
+        && tx_result.is_none()
+}
+
+pub(crate) fn reclaim_per_message_sessions(
+    sessions: &mut HashMap<String, SessionState>,
+    include_completed: bool,
+) -> usize {
+    let before = sessions.len();
+    sessions.retain(|_, session| !reclaimable_per_message_session(session, include_completed));
+    before.saturating_sub(sessions.len())
+}
+
 pub(crate) fn ensure_session_insert_capacity(
-    sessions: &HashMap<String, SessionState>,
+    sessions: &mut HashMap<String, SessionState>,
     session_id: &str,
 ) -> Result<(), EngineError> {
     if sessions.contains_key(session_id) {
@@ -456,6 +558,12 @@ pub(crate) fn ensure_session_insert_capacity(
     }
 
     let max_sessions = max_sessions_limit();
+    if sessions.len() >= max_sessions {
+        // Completed per-message sessions are bounded tombstones, not wallet
+        // ownership state. Compact them only when a new session needs a slot;
+        // the caller's ensuing durable mutation persists the compacted map.
+        reclaim_per_message_sessions(sessions, true);
+    }
     if sessions.len() >= max_sessions {
         return Err(EngineError::Internal(format!(
             "session registry size [{}] reached max [{max_sessions}]; use an existing session_id or increase {}",

--- a/pkg/tbtc/signer/src/engine/state.rs
+++ b/pkg/tbtc/signer/src/engine/state.rs
@@ -135,11 +135,11 @@ pub(crate) struct SessionState {
     // after restart using only public material, and the full-lifetime role binding
     // prevents this per-signing session from later becoming an unrelated DKG owner.
     pub(crate) bound_key_group: Option<String>,
-    // Idle per-message entries move into a bounded persisted retirement tier
-    // instead of consuming the active-session budget forever. The full entry is
-    // retained temporarily so delayed Aggregate/verify-share calls and an outer
-    // retry's BuildTaprootTx policy artifact keep working. Old retired entries
-    // are evicted FIFO-by-time once the separate retirement budget is full.
+    // Idle per-message entries use the unoccupied portion of the shared persisted
+    // session budget. The full entry is retained temporarily so delayed
+    // Aggregate/verify-share calls and an outer retry's BuildTaprootTx policy
+    // artifact keep working. Old retired entries are evicted FIFO-by-time when a
+    // new active session needs their slot.
     pub(crate) retired_interactive_at_unix: Option<u64>,
     // Transient refcount pin for Aggregate's unlocked cryptographic section.
     // The session owns one reference; an in-flight Aggregate clones it while
@@ -458,6 +458,7 @@ pub(crate) fn active_session_count(sessions: &HashMap<String, SessionState>) -> 
         .count()
 }
 
+#[cfg(test)]
 pub(crate) fn retired_interactive_session_count(sessions: &HashMap<String, SessionState>) -> usize {
     sessions
         .values()
@@ -469,17 +470,10 @@ pub(crate) fn ensure_session_registry_persisted_bound(
     sessions: &HashMap<String, SessionState>,
 ) -> Result<(), EngineError> {
     let max_sessions = max_sessions_limit();
-    let active_count = active_session_count(sessions);
-    if active_count > max_sessions {
+    let session_count = sessions.len();
+    if session_count > max_sessions {
         return Err(EngineError::Internal(format!(
-            "persisted session registry size [{active_count}] exceeds max [{max_sessions}]"
-        )));
-    }
-
-    let retired_count = retired_interactive_session_count(sessions);
-    if retired_count > max_sessions {
-        return Err(EngineError::Internal(format!(
-            "persisted retired interactive session registry size [{retired_count}] exceeds max [{max_sessions}]"
+            "persisted session registry size [{session_count}] exceeds max [{max_sessions}]"
         )));
     }
 
@@ -563,9 +557,16 @@ pub(crate) fn retire_idle_per_message_sessions(
     engine_state: &mut EngineState,
     protected_session_id: Option<&str>,
 ) -> usize {
+    retire_idle_per_message_session_ids(engine_state, protected_session_id).len()
+}
+
+pub(crate) fn retire_idle_per_message_session_ids(
+    engine_state: &mut EngineState,
+    protected_session_id: Option<&str>,
+) -> Vec<String> {
     let retired_at = now_unix().max(1);
     let pending_session_ids = persistence_pending_session_ids();
-    let mut newly_retired = 0;
+    let mut newly_retired = Vec::new();
     for (session_id, session) in &mut engine_state.sessions {
         if !pending_session_ids.contains(session_id)
             && session.retired_interactive_at_unix.is_none()
@@ -573,7 +574,7 @@ pub(crate) fn retire_idle_per_message_sessions(
             && per_message_interactive_session(session)
         {
             session.retired_interactive_at_unix = Some(retired_at);
-            newly_retired += 1;
+            newly_retired.push(session_id.clone());
         }
     }
 
@@ -581,6 +582,7 @@ pub(crate) fn retire_idle_per_message_sessions(
         engine_state,
         protected_session_id,
     ));
+    newly_retired.retain(|session_id| engine_state.sessions.contains_key(session_id));
     newly_retired
 }
 
@@ -588,7 +590,18 @@ pub(crate) fn compact_retired_per_message_sessions(
     engine_state: &mut EngineState,
     protected_session_id: Option<&str>,
 ) -> Vec<(String, SessionState)> {
-    let max_retired = max_sessions_limit();
+    compact_retired_per_message_sessions_to_total(
+        engine_state,
+        max_sessions_limit(),
+        protected_session_id,
+    )
+}
+
+fn compact_retired_per_message_sessions_to_total(
+    engine_state: &mut EngineState,
+    max_total_sessions: usize,
+    protected_session_id: Option<&str>,
+) -> Vec<(String, SessionState)> {
     // A post-replacement persistence failure leaves the replacement snapshot's
     // marker in memory and records a process-local repair operation. Evicting
     // that session before a later successful snapshot would persist the
@@ -596,7 +609,11 @@ pub(crate) fn compact_retired_per_message_sessions(
     // session-scoped pending operation until a successful snapshot covers it.
     let pending_session_ids = persistence_pending_session_ids();
     let mut removed = Vec::new();
-    while retired_interactive_session_count(&engine_state.sessions) > max_retired {
+    // Schema version 1 readers predating retirement enforce this same bound on
+    // the TOTAL map. Retired tombstones therefore consume only the portion of
+    // the shared budget not occupied by active sessions; preserving a separate
+    // retired allowance would make an emergency binary rollback fail at load.
+    while engine_state.sessions.len() > max_total_sessions {
         let oldest = engine_state
             .sessions
             .iter()
@@ -637,17 +654,56 @@ pub(crate) fn restore_compacted_retired_sessions(
     }
 }
 
+fn has_evictable_retired_session(engine_state: &EngineState) -> bool {
+    let pending_session_ids = persistence_pending_session_ids();
+    engine_state.sessions.iter().any(|(session_id, session)| {
+        session.retired_interactive_at_unix.is_some()
+            && !pending_session_ids.contains(session_id)
+            && Arc::strong_count(&session.aggregate_eviction_pin) == 1
+    })
+}
+
+pub(crate) fn ensure_session_insert_admission_capacity(
+    engine_state: &EngineState,
+    session_id: &str,
+) -> Result<(), EngineError> {
+    if engine_state.sessions.contains_key(session_id) {
+        return Ok(());
+    }
+
+    let max_sessions = max_sessions_limit();
+    let active_count = active_session_count(&engine_state.sessions);
+    if active_count >= max_sessions {
+        return Err(EngineError::Internal(format!(
+            "active session registry size [{active_count}] reached max [{max_sessions}]; use an existing session_id or increase {}",
+            TBTC_SIGNER_MAX_SESSIONS_ENV
+        )));
+    }
+    if engine_state.sessions.len() >= max_sessions && !has_evictable_retired_session(engine_state) {
+        return Err(EngineError::Internal(format!(
+            "session registry size [{}] reached max [{max_sessions}] and no retired session is available for eviction; use an existing session_id or increase {}",
+            engine_state.sessions.len(),
+            TBTC_SIGNER_MAX_SESSIONS_ENV
+        )));
+    }
+
+    Ok(())
+}
+
 pub(crate) fn ensure_interactive_session_admission_capacity(
     engine_state: &EngineState,
     session_id: &str,
 ) -> Result<(), EngineError> {
-    let needs_active_slot = engine_state
-        .sessions
-        .get(session_id)
+    let existing_session = engine_state.sessions.get(session_id);
+    let needs_active_slot = existing_session
         .map(|session| session.retired_interactive_at_unix.is_some())
         .unwrap_or(true);
     if !needs_active_slot {
         return Ok(());
+    }
+
+    if existing_session.is_none() {
+        return ensure_session_insert_admission_capacity(engine_state, session_id);
     }
 
     let max_sessions = max_sessions_limit();
@@ -692,23 +748,33 @@ pub(crate) fn reactivate_retired_per_message_session(
 }
 
 pub(crate) fn ensure_session_insert_capacity(
-    sessions: &HashMap<String, SessionState>,
+    engine_state: &mut EngineState,
     session_id: &str,
-) -> Result<(), EngineError> {
-    if sessions.contains_key(session_id) {
-        return Ok(());
+) -> Result<Vec<(String, SessionState)>, EngineError> {
+    if engine_state.sessions.contains_key(session_id) {
+        return Ok(Vec::new());
     }
 
+    ensure_session_insert_admission_capacity(engine_state, session_id)?;
     let max_sessions = max_sessions_limit();
-    let active_count = active_session_count(sessions);
-    if active_count >= max_sessions {
+    // Reserve one slot for the caller's insertion. The returned tombstones let
+    // durable callers restore the exact pre-call map if persistence fails before
+    // replacing the state file.
+    let compacted = compact_retired_per_message_sessions_to_total(
+        engine_state,
+        max_sessions.saturating_sub(1),
+        None,
+    );
+    if engine_state.sessions.len() >= max_sessions {
+        restore_compacted_retired_sessions(engine_state, compacted);
         return Err(EngineError::Internal(format!(
-            "active session registry size [{active_count}] reached max [{max_sessions}]; use an existing session_id or increase {}",
+            "session registry size [{}] reached max [{max_sessions}] and no retired session is available for eviction; use an existing session_id or increase {}",
+            engine_state.sessions.len(),
             TBTC_SIGNER_MAX_SESSIONS_ENV
         )));
     }
 
-    Ok(())
+    Ok(compacted)
 }
 
 pub(crate) fn ensure_consumed_registry_insert_capacity(

--- a/pkg/tbtc/signer/src/engine/state.rs
+++ b/pkg/tbtc/signer/src/engine/state.rs
@@ -135,7 +135,18 @@ pub(crate) struct SessionState {
     // after restart using only public material, and the full-lifetime role binding
     // prevents this per-signing session from later becoming an unrelated DKG owner.
     pub(crate) bound_key_group: Option<String>,
+    // Idle per-message entries move into a bounded persisted retirement tier
+    // instead of consuming the active-session budget forever. The full entry is
+    // retained temporarily so delayed Aggregate/verify-share calls and an outer
+    // retry's BuildTaprootTx policy artifact keep working. Old retired entries
+    // are evicted FIFO-by-time once the separate retirement budget is full.
+    pub(crate) retired_interactive_at_unix: Option<u64>,
     pub(crate) consumed_interactive_attempt_markers: HashSet<String>,
+    // Fixed-size SHA-256 bindings written atomically with Round2 consumption.
+    // Each marker authorizes Aggregate for exactly one
+    // (attempt_id, signing package, taproot root) tuple, including after a
+    // restart when the live nonce state is intentionally absent.
+    pub(crate) authorized_interactive_aggregate_markers: HashSet<String>,
     // Phase 7.2b InteractiveAggregate completion markers: an attempt whose
     // aggregate signature has been produced is recorded here so a repeat
     // InteractiveAggregate is rejected (re-aggregation is not a recovery path;
@@ -434,28 +445,46 @@ pub(crate) fn ensure_consumed_registry_persisted_bound(
     Ok(())
 }
 
+pub(crate) fn active_session_count(sessions: &HashMap<String, SessionState>) -> usize {
+    sessions
+        .values()
+        .filter(|session| session.retired_interactive_at_unix.is_none())
+        .count()
+}
+
+pub(crate) fn retired_interactive_session_count(sessions: &HashMap<String, SessionState>) -> usize {
+    sessions
+        .values()
+        .filter(|session| session.retired_interactive_at_unix.is_some())
+        .count()
+}
+
 pub(crate) fn ensure_session_registry_persisted_bound(
-    session_count: usize,
+    sessions: &HashMap<String, SessionState>,
 ) -> Result<(), EngineError> {
     let max_sessions = max_sessions_limit();
-    if session_count > max_sessions {
+    let active_count = active_session_count(sessions);
+    if active_count > max_sessions {
         return Err(EngineError::Internal(format!(
-            "persisted session registry size [{session_count}] exceeds max [{max_sessions}]"
+            "persisted session registry size [{active_count}] exceeds max [{max_sessions}]"
+        )));
+    }
+
+    let retired_count = retired_interactive_session_count(sessions);
+    if retired_count > max_sessions {
+        return Err(EngineError::Internal(format!(
+            "persisted retired interactive session registry size [{retired_count}] exceeds max [{max_sessions}]"
         )));
     }
 
     Ok(())
 }
 
-// A per-message interactive session is safe to reclaim once it has no live
-// nonce state and either completed aggregation or never accumulated any
-// durable/non-interactive state. Keep this predicate exhaustive: adding a new
-// SessionState field must force an explicit decision about whether reclaiming a
-// session carrying that field is safe.
-pub(crate) fn reclaimable_per_message_session(
-    session: &SessionState,
-    include_completed: bool,
-) -> bool {
+// Production interactive signing uses one outer session per message. Such a
+// session is bound to a wallet key but never owns DKG material; DKG installation
+// enforces that role split. Keep this match exhaustive so a future SessionState
+// field forces an explicit retirement-safety decision here.
+pub(crate) fn per_message_interactive_session(session: &SessionState) -> bool {
     let SessionState {
         dkg_request_fingerprint,
         dkg_key_packages,
@@ -482,75 +511,179 @@ pub(crate) fn reclaimable_per_message_session(
         heartbeat_rate_limiter,
         interactive_signing,
         bound_key_group,
+        retired_interactive_at_unix,
         consumed_interactive_attempt_markers,
+        authorized_interactive_aggregate_markers,
         aggregated_interactive_attempt_markers,
     } = session;
 
-    // Open-created per-message sessions are bound to a wallet key but never own
-    // DKG material. Wallet/DKG sessions are permanent and must not be compacted.
-    let per_message_role = bound_key_group.is_some()
+    let _ = (
+        sign_request_fingerprint,
+        sign_message_bytes,
+        round_state,
+        active_attempt_context,
+        attempt_transition_records,
+        consumed_attempt_ids,
+        consumed_sign_round_ids,
+        finalize_request_fingerprint,
+        signature_result,
+        consumed_finalize_round_ids,
+        consumed_finalize_request_fingerprints,
+        build_tx_request_fingerprint,
+        tx_result,
+        refresh_request_fingerprint,
+        refresh_result,
+        refresh_history,
+        refresh_count,
+        emergency_rekey_event,
+        heartbeat_rate_limiter,
+        interactive_signing,
+        retired_interactive_at_unix,
+        consumed_interactive_attempt_markers,
+        authorized_interactive_aggregate_markers,
+        aggregated_interactive_attempt_markers,
+    );
+
+    bound_key_group.is_some()
         && dkg_request_fingerprint.is_none()
         && dkg_key_packages.is_none()
         && dkg_public_key_package.is_none()
-        && dkg_result.is_none();
-    if !per_message_role || !interactive_signing.is_empty() {
-        return false;
-    }
-
-    // These fields belong to other session workflows. Their presence makes the
-    // role ambiguous, so retain the entry. BuildTaprootTx fields are handled
-    // separately below because they are the policy artifact for this same
-    // per-message signing flow.
-    let carries_other_workflow_state = sign_request_fingerprint.is_some()
-        || sign_message_bytes.is_some()
-        || round_state.is_some()
-        || active_attempt_context.is_some()
-        || !attempt_transition_records.is_empty()
-        || !consumed_attempt_ids.is_empty()
-        || !consumed_sign_round_ids.is_empty()
-        || finalize_request_fingerprint.is_some()
-        || signature_result.is_some()
-        || !consumed_finalize_round_ids.is_empty()
-        || !consumed_finalize_request_fingerprints.is_empty()
-        || refresh_request_fingerprint.is_some()
-        || refresh_result.is_some()
-        || !refresh_history.is_empty()
-        || *refresh_count != 0
-        || emergency_rekey_event.is_some()
-        || heartbeat_rate_limiter.last_refill_unix != 0
-        || heartbeat_rate_limiter.token_microunits != 0
-        || heartbeat_rate_limiter.configured_rate_limit_per_minute != 0;
-    if carries_other_workflow_state {
-        return false;
-    }
-
-    // Successful aggregation is terminal for this per-message flow. Preserve
-    // its completion tombstone until capacity pressure requires compaction, so
-    // immediate/restart retries retain their existing typed error semantics.
-    if include_completed && !aggregated_interactive_attempt_markers.is_empty() {
-        return true;
-    }
-
-    // Abort/TTL shells with no consumed share and no transaction-policy artifact
-    // are safe to recreate from Open. A BuildTaprootTx artifact must survive a
-    // failed attempt because the outer retry loop reuses this stable session ID.
-    aggregated_interactive_attempt_markers.is_empty()
-        && consumed_interactive_attempt_markers.is_empty()
-        && build_tx_request_fingerprint.is_none()
-        && tx_result.is_none()
+        && dkg_result.is_none()
 }
 
-pub(crate) fn reclaim_per_message_sessions(
-    sessions: &mut HashMap<String, SessionState>,
-    include_completed: bool,
+pub(crate) fn retire_idle_per_message_sessions(
+    engine_state: &mut EngineState,
+    protected_session_id: Option<&str>,
 ) -> usize {
-    let before = sessions.len();
-    sessions.retain(|_, session| !reclaimable_per_message_session(session, include_completed));
-    before.saturating_sub(sessions.len())
+    let retired_at = now_unix().max(1);
+    let pending_session_ids = persistence_pending_session_ids();
+    let mut newly_retired = 0;
+    for (session_id, session) in &mut engine_state.sessions {
+        if !pending_session_ids.contains(session_id)
+            && session.retired_interactive_at_unix.is_none()
+            && session.interactive_signing.is_empty()
+            && per_message_interactive_session(session)
+        {
+            session.retired_interactive_at_unix = Some(retired_at);
+            newly_retired += 1;
+        }
+    }
+
+    drop(compact_retired_per_message_sessions(
+        engine_state,
+        protected_session_id,
+    ));
+    newly_retired
+}
+
+pub(crate) fn compact_retired_per_message_sessions(
+    engine_state: &mut EngineState,
+    protected_session_id: Option<&str>,
+) -> Vec<(String, SessionState)> {
+    let max_retired = max_sessions_limit();
+    // A post-replacement persistence failure leaves the replacement snapshot's
+    // marker in memory and records a process-local repair operation. Evicting
+    // that session before a later successful snapshot would persist the
+    // marker's absence and then clear the repair record. Protect every
+    // session-scoped pending operation until a successful snapshot covers it.
+    let pending_session_ids = persistence_pending_session_ids();
+    let mut removed = Vec::new();
+    while retired_interactive_session_count(&engine_state.sessions) > max_retired {
+        let oldest = engine_state
+            .sessions
+            .iter()
+            .filter_map(|(session_id, session)| {
+                if protected_session_id == Some(session_id.as_str())
+                    || pending_session_ids.contains(session_id)
+                {
+                    return None;
+                }
+                session
+                    .retired_interactive_at_unix
+                    .map(|retired_at| (retired_at, session_id.clone()))
+            })
+            .min();
+        let Some((_, oldest_session_id)) = oldest else {
+            break;
+        };
+        let removed_session = engine_state
+            .sessions
+            .remove(&oldest_session_id)
+            .expect("selected retired session existed under the held engine lock");
+        removed.push((oldest_session_id, removed_session));
+    }
+    removed
+}
+
+pub(crate) fn restore_compacted_retired_sessions(
+    engine_state: &mut EngineState,
+    removed: Vec<(String, SessionState)>,
+) {
+    for (session_id, session) in removed {
+        let previous = engine_state.sessions.insert(session_id, session);
+        debug_assert!(
+            previous.is_none(),
+            "a compacted retired session must not be recreated while the engine lock is held"
+        );
+    }
+}
+
+pub(crate) fn ensure_interactive_session_admission_capacity(
+    engine_state: &EngineState,
+    session_id: &str,
+) -> Result<(), EngineError> {
+    let needs_active_slot = engine_state
+        .sessions
+        .get(session_id)
+        .map(|session| session.retired_interactive_at_unix.is_some())
+        .unwrap_or(true);
+    if !needs_active_slot {
+        return Ok(());
+    }
+
+    let max_sessions = max_sessions_limit();
+    let active_count = active_session_count(&engine_state.sessions);
+    if active_count >= max_sessions {
+        return Err(EngineError::Internal(format!(
+            "active session registry size [{active_count}] reached max [{max_sessions}]; abort idle sessions or increase {}",
+            TBTC_SIGNER_MAX_SESSIONS_ENV
+        )));
+    }
+
+    Ok(())
+}
+
+pub(crate) fn reactivate_retired_per_message_session(
+    engine_state: &mut EngineState,
+    session_id: &str,
+) -> Result<(), EngineError> {
+    let is_retired = engine_state
+        .sessions
+        .get(session_id)
+        .is_some_and(|session| session.retired_interactive_at_unix.is_some());
+    if !is_retired {
+        return Ok(());
+    }
+
+    let max_sessions = max_sessions_limit();
+    let active_count = active_session_count(&engine_state.sessions);
+    if active_count >= max_sessions {
+        return Err(EngineError::Internal(format!(
+            "active session registry size [{active_count}] reached max [{max_sessions}]; abort idle sessions or increase {}",
+            TBTC_SIGNER_MAX_SESSIONS_ENV
+        )));
+    }
+
+    engine_state
+        .sessions
+        .get_mut(session_id)
+        .expect("retired session existed under the held engine lock")
+        .retired_interactive_at_unix = None;
+    Ok(())
 }
 
 pub(crate) fn ensure_session_insert_capacity(
-    sessions: &mut HashMap<String, SessionState>,
+    sessions: &HashMap<String, SessionState>,
     session_id: &str,
 ) -> Result<(), EngineError> {
     if sessions.contains_key(session_id) {
@@ -558,16 +691,10 @@ pub(crate) fn ensure_session_insert_capacity(
     }
 
     let max_sessions = max_sessions_limit();
-    if sessions.len() >= max_sessions {
-        // Completed per-message sessions are bounded tombstones, not wallet
-        // ownership state. Compact them only when a new session needs a slot;
-        // the caller's ensuing durable mutation persists the compacted map.
-        reclaim_per_message_sessions(sessions, true);
-    }
-    if sessions.len() >= max_sessions {
+    let active_count = active_session_count(sessions);
+    if active_count >= max_sessions {
         return Err(EngineError::Internal(format!(
-            "session registry size [{}] reached max [{max_sessions}]; use an existing session_id or increase {}",
-            sessions.len(),
+            "active session registry size [{active_count}] reached max [{max_sessions}]; use an existing session_id or increase {}",
             TBTC_SIGNER_MAX_SESSIONS_ENV
         )));
     }

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -4612,6 +4612,57 @@ fn build_taproot_tx_rejects_new_session_when_session_registry_is_at_capacity() {
 }
 
 #[test]
+fn per_message_session_compaction_preserves_wallet_and_inflight_state() {
+    let mut sessions = HashMap::new();
+
+    let mut wallet = SessionState::default();
+    wallet.dkg_result = Some(DkgResult {
+        session_id: "wallet".to_string(),
+        key_group: "wallet-key-group".to_string(),
+        participant_count: 3,
+        threshold: 2,
+        created_at_unix: now_unix(),
+    });
+    sessions.insert("wallet".to_string(), wallet);
+
+    let mut open_only = SessionState::default();
+    open_only.bound_key_group = Some("wallet-key-group".to_string());
+    sessions.insert("open-only".to_string(), open_only);
+
+    let mut consumed = SessionState::default();
+    consumed.bound_key_group = Some("wallet-key-group".to_string());
+    consumed
+        .consumed_interactive_attempt_markers
+        .insert(format!("m1@{}", "11".repeat(32)));
+    sessions.insert("consumed".to_string(), consumed);
+
+    let mut completed = SessionState::default();
+    completed.bound_key_group = Some("wallet-key-group".to_string());
+    completed
+        .aggregated_interactive_attempt_markers
+        .insert(format!("{}@{}@keypath", "22".repeat(32), "33".repeat(32)));
+    sessions.insert("completed".to_string(), completed);
+
+    let mut retry_policy = SessionState::default();
+    retry_policy.bound_key_group = Some("wallet-key-group".to_string());
+    retry_policy.build_tx_request_fingerprint = Some("policy-fingerprint".to_string());
+    sessions.insert("retry-policy".to_string(), retry_policy);
+
+    assert_eq!(reclaim_per_message_sessions(&mut sessions, false), 1);
+    assert!(!sessions.contains_key("open-only"));
+    assert!(sessions.contains_key("wallet"));
+    assert!(sessions.contains_key("consumed"));
+    assert!(sessions.contains_key("completed"));
+    assert!(sessions.contains_key("retry-policy"));
+
+    assert_eq!(reclaim_per_message_sessions(&mut sessions, true), 1);
+    assert!(!sessions.contains_key("completed"));
+    assert!(sessions.contains_key("wallet"));
+    assert!(sessions.contains_key("consumed"));
+    assert!(sessions.contains_key("retry-policy"));
+}
+
+#[test]
 fn persisted_session_state_rejects_empty_consumed_attempt_id() {
     let mut persisted = persisted_session_state_fixture();
     persisted.consumed_attempt_ids = vec!["".to_string()];
@@ -6608,7 +6659,9 @@ fn interactive_signs_across_sessions_by_key_group() {
     // are signable ONLY via the interactive path, could never sign. The single-session
     // tests miss this because they persist and sign under one id.
     let _guard = lock_test_state();
+    let state_path = configure_test_state_path("interactive_cross_session_compaction");
     reset_for_tests();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
 
     let key_packages = interactive_test_key_packages();
     let wallet_session = "wallet-dkg-session";
@@ -6740,6 +6793,41 @@ fn interactive_signs_across_sessions_by_key_group() {
     Secp256k1::verification_only()
         .verify_schnorr(&signature, &SecpMessage::from_digest(message), &public_key)
         .expect("cross-session interactive signing produces a valid BIP-340 signature");
+
+    // The completed per-message entry and its typed replay tombstone survive a
+    // restart while there is still capacity. Once a new durable session needs
+    // that slot, admission compacts the terminal entry without touching the
+    // wallet/DKG owner, and the ensuing BuildTaprootTx persist makes the
+    // compaction crash-durable.
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        assert_eq!(guard.sessions.len(), 2);
+        assert!(guard.sessions.contains_key(wallet_session));
+        assert!(guard.sessions.contains_key(signing_session));
+    }
+
+    let next_session = "next-roast-signing-session";
+    build_taproot_tx(build_policy_test_request(next_session))
+        .expect("a new message reclaims the completed per-message registry slot");
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        assert_eq!(guard.sessions.len(), 2);
+        assert!(guard.sessions.contains_key(wallet_session));
+        assert!(guard.sessions.contains_key(next_session));
+        assert!(
+            !guard.sessions.contains_key(signing_session),
+            "the completed per-message tombstone must be durably compacted"
+        );
+    }
+
+    std::env::remove_var(TBTC_SIGNER_MAX_SESSIONS_ENV);
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
+    clear_state_storage_policy_overrides();
 }
 
 #[test]
@@ -9933,8 +10021,36 @@ fn interactive_aggregate_rejects_repeat_aggregate_of_completed_attempt() {
         taproot_merkle_root_hex: None,
     };
 
-    // First aggregate completes the attempt.
-    interactive_aggregate(aggregate_request.clone()).expect("first interactive aggregate");
+    // First aggregate completes the attempt. The wire remains case-insensitive:
+    // a canonical 64-hex id is normalized before lookup and response emission.
+    let mut recased_request = aggregate_request.clone();
+    recased_request.attempt_id = recased_request.attempt_id.to_ascii_uppercase();
+    let aggregate = interactive_aggregate(recased_request).expect("first interactive aggregate");
+    assert_eq!(aggregate.attempt_id, opened.attempt_id);
+
+    // A valid package/share set cannot be replayed under a different, merely
+    // well-formed id. Only an id established by Open (live observer) or Round2
+    // (durable signer marker) may create completion state, so this replay cannot
+    // consume another bounded marker slot.
+    let mut unbound_request = aggregate_request.clone();
+    unbound_request.attempt_id = "aa".repeat(32);
+    assert_ne!(unbound_request.attempt_id, opened.attempt_id);
+    let err = interactive_aggregate(unbound_request)
+        .expect_err("an unbound aggregate attempt id must be rejected");
+    assert!(
+        matches!(err, EngineError::Validation(ref message) if message.contains("is not bound")),
+        "unexpected error: {err:?}"
+    );
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        assert_eq!(
+            guard.sessions[session_id]
+                .aggregated_interactive_attempt_markers
+                .len(),
+            1,
+            "an unbound replay must not consume aggregate-marker capacity"
+        );
+    }
 
     // Re-aggregating a completed attempt is rejected by the durable completion
     // marker rather than recomputed (re-aggregation is not a recovery path; a
@@ -9955,27 +10071,34 @@ fn interactive_aggregate_rejects_repeat_aggregate_of_completed_attempt() {
 }
 
 #[test]
-fn interactive_aggregate_rejects_empty_attempt_id() {
+fn interactive_aggregate_rejects_noncanonical_attempt_ids() {
     let _guard = lock_test_state();
     reset_for_tests();
 
-    // An empty attempt_id must be rejected before anything is persisted: the
-    // completion record is keyed by attempt_id and the reload path rejects an
-    // empty key, so persisting one would brick restart. The guard runs before
-    // the signing-package/share decode, so the placeholder inputs are never
-    // reached.
-    let err = interactive_aggregate(InteractiveAggregateRequest {
-        session_id: "interactive-aggregate-empty-attempt".to_string(),
-        attempt_id: String::new(),
-        signing_package_hex: String::new(),
-        signature_shares: vec![],
-        taproot_merkle_root_hex: None,
-    })
-    .expect_err("an empty attempt_id must be rejected");
-    assert!(
-        matches!(err, EngineError::Validation(ref m) if m.contains("attempt_id must not be empty")),
-        "unexpected error: {err:?}"
-    );
+    // Completion markers persist attempt_id verbatim as part of their key. The
+    // canonical derivation is a SHA-256 digest, so reject empty, oversized, and
+    // non-hex ids before decoding the other aggregate inputs or touching state.
+    for attempt_id in [
+        String::new(),
+        "a".repeat(63),
+        "a".repeat(65),
+        format!("0x{}", "aa".repeat(31)),
+        "zz".repeat(32),
+    ] {
+        let err = interactive_aggregate(InteractiveAggregateRequest {
+            session_id: "interactive-aggregate-invalid-attempt".to_string(),
+            attempt_id,
+            signing_package_hex: String::new(),
+            signature_shares: vec![],
+            taproot_merkle_root_hex: None,
+        })
+        .expect_err("a noncanonical attempt_id must be rejected");
+        assert!(
+            matches!(err, EngineError::Validation(ref message)
+                if message.contains("exactly 64 hexadecimal characters")),
+            "unexpected error: {err:?}"
+        );
+    }
 }
 
 #[test]
@@ -10515,7 +10638,7 @@ fn interactive_aggregate_sweeps_expired_sessions() {
     // SessionNotFound.
     let err = interactive_aggregate(InteractiveAggregateRequest {
         session_id: "interactive-aggregate-sweep-missing".to_string(),
-        attempt_id: "missing".to_string(),
+        attempt_id: "00".repeat(32),
         signing_package_hex: parseable_package,
         signature_shares: vec![parseable_share.signature_share],
         taproot_merkle_root_hex: None,

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -918,6 +918,119 @@ fn build_taproot_tx_persist_failures_roll_back_or_retry_durably() {
 }
 
 #[test]
+fn build_taproot_tx_restores_evicted_retirement_on_pre_replace_failure() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("build_tx_retired_slot_rollback");
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+
+    let retired_session = "build-slot-retired-replay-tombstone";
+    let consumed_marker = interactive_consumed_marker(&hash_hex(b"build-slot-attempt"), 1);
+    {
+        let mut guard = state().expect("state").lock().expect("engine lock");
+        guard.sessions.insert(
+            "build-slot-active-owner".to_string(),
+            SessionState::default(),
+        );
+        guard.sessions.insert(
+            retired_session.to_string(),
+            SessionState {
+                bound_key_group: Some("build-slot-wallet-key".to_string()),
+                retired_interactive_at_unix: Some(1),
+                consumed_interactive_attempt_markers: HashSet::from([consumed_marker.clone()]),
+                ..Default::default()
+            },
+        );
+        persist_engine_state_to_storage(&guard).expect("persist full shared session budget");
+    }
+
+    let newcomer = "build-slot-new-active";
+    let request = build_policy_test_request(newcomer);
+    set_persist_fault_injection_for_tests(PersistFaultInjectionPoint::AfterTempSyncBeforeRename);
+    let faulted = build_taproot_tx(request.clone())
+        .expect_err("pre-replacement Build fault rolls back slot reservation");
+    clear_persist_fault_injection_for_tests();
+    assert!(matches!(
+        faulted,
+        EngineError::Internal(ref message) if message.contains("injected persist fault")
+    ));
+    {
+        let guard = state().expect("state").lock().expect("engine lock");
+        assert_eq!(guard.sessions.len(), 2);
+        assert!(!guard.sessions.contains_key(newcomer));
+        assert!(guard.sessions[retired_session]
+            .consumed_interactive_attempt_markers
+            .contains(&consumed_marker));
+    }
+
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    build_taproot_tx(request).expect("healthy retry evicts the retired slot and persists");
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    {
+        let guard = state().expect("state").lock().expect("engine lock");
+        assert_eq!(guard.sessions.len(), 2);
+        assert!(guard.sessions.contains_key("build-slot-active-owner"));
+        assert!(guard.sessions.contains_key(newcomer));
+        assert!(!guard.sessions.contains_key(retired_session));
+    }
+
+    std::env::remove_var(TBTC_SIGNER_MAX_SESSIONS_ENV);
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
+fn build_taproot_tx_capacity_preflight_does_not_consume_policy_rate_token() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("build_tx_capacity_rate_preflight");
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+    std::env::set_var(TBTC_SIGNER_POLICY_RATE_LIMIT_PER_MINUTE_ENV, "1");
+
+    let retired_session = "build-rate-protected-retired";
+    let aggregate_pin = {
+        let mut guard = state().expect("state").lock().expect("engine lock");
+        guard.sessions.insert(
+            "build-rate-active-owner".to_string(),
+            SessionState::default(),
+        );
+        guard.sessions.insert(
+            retired_session.to_string(),
+            SessionState {
+                bound_key_group: Some("build-rate-wallet-key".to_string()),
+                retired_interactive_at_unix: Some(1),
+                ..Default::default()
+            },
+        );
+        Arc::clone(&guard.sessions[retired_session].aggregate_eviction_pin)
+    };
+
+    let request = build_policy_test_request("build-rate-new-active");
+    let rejected = build_taproot_tx(request.clone())
+        .expect_err("a pinned full registry must reject before policy charging");
+    assert!(matches!(
+        rejected,
+        EngineError::Internal(ref message)
+            if message.contains("no retired session is available for eviction")
+    ));
+
+    drop(aggregate_pin);
+    build_taproot_tx(request)
+        .expect("the first policy token remains available after capacity recovers");
+
+    std::env::remove_var(TBTC_SIGNER_POLICY_RATE_LIMIT_PER_MINUTE_ENV);
+    std::env::remove_var(TBTC_SIGNER_MAX_SESSIONS_ENV);
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
 fn production_profile_forces_provenance_gate_without_env_flag() {
     let _guard = lock_test_state();
     reset_for_tests();
@@ -1159,11 +1272,32 @@ fn persist_distributed_dkg_key_package_rejects_a_bound_signing_session() {
 }
 
 #[test]
-fn persist_distributed_dkg_key_package_pre_replace_failure_rolls_back() {
+fn persist_distributed_dkg_key_package_pre_replace_failure_restores_retired_slot() {
     let _guard = lock_test_state();
     let state_path = configure_test_state_path("distributed_dkg_persist_rollback");
     reset_for_tests();
     clear_state_storage_policy_overrides();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+
+    let retired_session = "distributed-dkg-retired-replay-tombstone";
+    let consumed_marker = interactive_consumed_marker(&hash_hex(b"distributed-dkg-attempt"), 1);
+    {
+        let mut guard = state().expect("engine state").lock().expect("engine lock");
+        guard.sessions.insert(
+            "distributed-dkg-active-owner".to_string(),
+            SessionState::default(),
+        );
+        guard.sessions.insert(
+            retired_session.to_string(),
+            SessionState {
+                bound_key_group: Some("distributed-dkg-retired-key".to_string()),
+                retired_interactive_at_unix: Some(1),
+                consumed_interactive_attempt_markers: HashSet::from([consumed_marker.clone()]),
+                ..Default::default()
+            },
+        );
+        persist_engine_state_to_storage(&guard).expect("persist full shared session budget");
+    }
 
     let session_id = "session-distributed-dkg-persist-rollback";
     let (native_public, native_key_packages) = sample_distributed_dkg_native_material(23);
@@ -1190,6 +1324,10 @@ fn persist_distributed_dkg_key_package_pre_replace_failure_rolls_back() {
             !guard.sessions.contains_key(session_id),
             "failed first persistence must not leave in-memory-only DKG material"
         );
+        assert!(guard.sessions[retired_session]
+            .consumed_interactive_attempt_markers
+            .contains(&consumed_marker));
+        assert_eq!(guard.sessions.len(), 2);
     }
 
     let result = persist_distributed_dkg_key_package(request)
@@ -1206,8 +1344,12 @@ fn persist_distributed_dkg_key_package_pre_replace_failure_rolls_back() {
         .dkg_key_packages
         .as_ref()
         .is_some_and(|packages| packages.contains_key(&1)));
+    assert_eq!(guard.sessions.len(), 2);
+    assert!(guard.sessions.contains_key("distributed-dkg-active-owner"));
+    assert!(!guard.sessions.contains_key(retired_session));
     drop(guard);
 
+    std::env::remove_var(TBTC_SIGNER_MAX_SESSIONS_ENV);
     reset_for_tests();
     cleanup_test_state_artifacts(&state_path);
     clear_state_storage_policy_overrides();
@@ -4257,8 +4399,10 @@ fn persisted_engine_state_rejects_session_registry_over_limit() {
 }
 
 #[test]
-fn persisted_engine_state_migrates_idle_per_message_entries_before_active_bound_check() {
+fn persisted_engine_state_compacts_migrated_idle_entries_to_legacy_total_bound() {
     let _guard = lock_test_state();
+    let state_path = configure_test_state_path("migrated_idle_total_bound_rewrite");
+    reset_for_tests();
     clear_state_storage_policy_overrides();
     std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
 
@@ -4292,21 +4436,50 @@ fn persisted_engine_state_migrates_idle_per_message_entries_before_active_bound_
         canary_rollout: CanaryRolloutState::default(),
     };
 
-    let loaded = EngineState::try_from(persisted)
-        .expect("legacy idle per-message entries migrate out of the active budget");
-    assert_eq!(loaded.sessions.len(), 3);
+    let loaded = EngineState::try_from(persisted.clone())
+        .expect("idle per-message entries migrate and compact to the shared total budget");
+    assert_eq!(loaded.sessions.len(), 2);
     assert_eq!(active_session_count(&loaded.sessions), 1);
-    assert_eq!(retired_interactive_session_count(&loaded.sessions), 2);
+    assert_eq!(retired_interactive_session_count(&loaded.sessions), 1);
     assert!(loaded.sessions["wallet"]
         .retired_interactive_at_unix
         .is_none());
+    assert!(!loaded.sessions.contains_key("aborted-message"));
     assert!(loaded.sessions["consumed-message"]
         .retired_interactive_at_unix
         .is_some());
-    assert!(loaded.sessions["aborted-message"]
-        .retired_interactive_at_unix
-        .is_some());
 
+    let encoded = PersistedEngineState::try_from(&loaded).expect("compacted state encodes");
+    assert!(
+        encoded.sessions.len() <= 2,
+        "the immediately previous schema-1 reader enforces this total bound"
+    );
+
+    // Exercise the real load path with a current encrypted envelope emitted by
+    // the flawed intermediate writer. Startup must replace the oversized file,
+    // not merely compact its in-memory copy, so an immediate rollback can read it.
+    let key_material = state_encryption_key_material().expect("test state key");
+    let oversized_envelope =
+        encode_encrypted_state_envelope(&persisted, &key_material).expect("oversized envelope");
+    std::fs::write(&state_path, oversized_envelope.as_slice())
+        .expect("write intermediate oversized state");
+    let reloaded = load_engine_state_from_storage().expect("load compacts and rewrites state");
+    assert_eq!(reloaded.sessions.len(), 2);
+
+    let rewritten_bytes = std::fs::read(&state_path).expect("read rewritten state");
+    let rewritten = match decode_persisted_state_storage_format(&rewritten_bytes)
+        .expect("decode rewritten state")
+    {
+        PersistedStateStorageFormat::EncryptedEnvelope { persisted, .. } => persisted,
+        PersistedStateStorageFormat::LegacyPlaintext(_) => {
+            panic!("rewrite must retain the encrypted envelope")
+        }
+    };
+    assert_eq!(rewritten.sessions.len(), 2);
+
+    std::env::remove_var(TBTC_SIGNER_MAX_SESSIONS_ENV);
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
     clear_state_storage_policy_overrides();
 }
 
@@ -4671,7 +4844,7 @@ fn build_taproot_tx_rejects_new_session_when_session_registry_is_at_capacity() {
 fn per_message_session_retirement_preserves_wallet_routing_and_retry_state() {
     let _guard = lock_test_state();
     clear_state_storage_policy_overrides();
-    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "4");
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "5");
 
     let mut engine_state = EngineState::default();
     engine_state.sessions.insert(
@@ -4756,7 +4929,7 @@ fn per_message_session_retirement_preserves_wallet_routing_and_retry_state() {
 }
 
 #[test]
-fn retired_per_message_session_tier_evicts_oldest_at_its_own_bound() {
+fn retired_per_message_sessions_share_the_total_bound_and_yield_to_admission() {
     let _guard = lock_test_state();
     clear_state_storage_policy_overrides();
     std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
@@ -4786,9 +4959,78 @@ fn retired_per_message_session_tier_evicts_oldest_at_its_own_bound() {
     assert!(engine_state.sessions.contains_key("newest"));
     assert_eq!(active_session_count(&engine_state.sessions), 0);
     assert_eq!(retired_interactive_session_count(&engine_state.sessions), 2);
-    ensure_session_insert_capacity(&engine_state.sessions, "fresh-active")
+    let reserved = ensure_session_insert_capacity(&mut engine_state, "fresh-active")
         .expect("bounded retirement cannot block active admission");
+    assert_eq!(
+        reserved
+            .iter()
+            .map(|(session_id, _)| session_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["middle"]
+    );
+    engine_state
+        .sessions
+        .insert("fresh-active".to_string(), SessionState::default());
+    assert_eq!(engine_state.sessions.len(), 2);
+    assert!(engine_state.sessions.contains_key("newest"));
+    assert!(engine_state.sessions.contains_key("fresh-active"));
 
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
+fn session_slot_reservation_preserves_pinned_and_persistence_pending_tombstones() {
+    let _guard = lock_test_state();
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "1");
+
+    let retired_session = "protected-retired-session";
+    let aggregated_marker = interactive_aggregated_marker(
+        &hash_hex(b"protected-attempt"),
+        &hash_hex(b"protected-message"),
+        None,
+    );
+    let mut engine_state = EngineState::default();
+    engine_state.sessions.insert(
+        retired_session.to_string(),
+        SessionState {
+            bound_key_group: Some("protected-retired-key".to_string()),
+            retired_interactive_at_unix: Some(1),
+            aggregated_interactive_attempt_markers: HashSet::from([aggregated_marker.clone()]),
+            ..Default::default()
+        },
+    );
+
+    let aggregate_pin = Arc::clone(&engine_state.sessions[retired_session].aggregate_eviction_pin);
+    let pinned_error = match ensure_session_insert_capacity(&mut engine_state, "new-active") {
+        Ok(_) => panic!("an in-flight Aggregate pin must block eviction"),
+        Err(error) => error,
+    };
+    assert!(matches!(pinned_error, EngineError::Internal(_)));
+    assert!(engine_state.sessions.contains_key(retired_session));
+    drop(aggregate_pin);
+
+    let pending = PersistencePendingOperation::InteractiveAggregate {
+        session_id: retired_session.to_string(),
+        aggregated_marker,
+    };
+    mark_persistence_pending(pending.clone());
+    let pending_error = match ensure_session_insert_capacity(&mut engine_state, "new-active") {
+        Ok(_) => panic!("an uncovered persistence marker must block eviction"),
+        Err(error) => error,
+    };
+    assert!(matches!(pending_error, EngineError::Internal(_)));
+    assert!(engine_state.sessions.contains_key(retired_session));
+    clear_persistence_pending_operation(&pending);
+
+    let removed = ensure_session_insert_capacity(&mut engine_state, "new-active")
+        .expect("the slot becomes available after both protections release");
+    assert_eq!(removed.len(), 1);
+    assert_eq!(removed[0].0, retired_session);
+    assert!(engine_state.sessions.is_empty());
+
+    std::env::remove_var(TBTC_SIGNER_MAX_SESSIONS_ENV);
     clear_state_storage_policy_overrides();
 }
 
@@ -6870,7 +7112,7 @@ fn interactive_signs_across_sessions_by_key_group() {
     let _guard = lock_test_state();
     let state_path = configure_test_state_path("interactive_cross_session_compaction");
     reset_for_tests();
-    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "3");
 
     let key_packages = interactive_test_key_packages();
     let wallet_session = "wallet-dkg-session";
@@ -7026,10 +7268,9 @@ fn interactive_signs_across_sessions_by_key_group() {
         .verify_schnorr(&signature, &SecpMessage::from_digest(message), &public_key)
         .expect("cross-session interactive signing produces a valid BIP-340 signature");
 
-    // The completed per-message entry moves into the separately bounded
-    // retirement tier. It retains wallet routing, exact Aggregate
-    // authorization, and typed replay markers across restart without consuming
-    // an active slot, so the next ordinary message is still admitted.
+    // With spare room in the shared total budget, the completed per-message
+    // entry retains wallet routing, exact Aggregate authorization, and typed
+    // replay markers across restart while the next message is admitted.
     simulate_process_restart_for_tests();
     reload_state_from_storage_for_tests();
     {
@@ -7062,7 +7303,7 @@ fn per_message_abort_and_expiry_retire_without_losing_policy_artifacts() {
     let _guard = lock_test_state();
     let state_path = configure_test_state_path("interactive_cross_session_abort_expiry_retirement");
     reset_for_tests();
-    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "4");
 
     let wallet_session = "retirement-wallet";
     let key_group = "retirement-wallet-key-group";
@@ -7094,11 +7335,28 @@ fn per_message_abort_and_expiry_retire_without_losing_policy_artifacts() {
         member_identifier: 1,
     })
     .expect("aborted flow round 1");
-    interactive_session_abort(InteractiveSessionAbortRequest {
+    let aborted = interactive_session_abort(InteractiveSessionAbortRequest {
         session_id: aborted_session.to_string(),
         attempt_id: Some(aborted_open.attempt_id),
     })
     .expect("abort retires the idle per-message entry");
+    assert!(aborted.aborted);
+
+    // The successful Abort itself is the durability boundary. Restart before
+    // any unrelated writer can accidentally flush the in-memory binding and
+    // retirement metadata; the Build-only shell must not return as an unbound
+    // active entry that consumes the shared session budget.
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = &guard.sessions[aborted_session];
+        assert_eq!(session.bound_key_group.as_deref(), Some(key_group));
+        assert!(session.retired_interactive_at_unix.is_some());
+        assert!(session.build_tx_request_fingerprint.is_some());
+        assert!(session.tx_result.is_some());
+        assert!(session.interactive_signing.is_empty());
+    }
     build_taproot_tx(aborted_build_request)
         .expect("retired abort entry retains its BuildTaprootTx cache");
 
@@ -7108,7 +7366,7 @@ fn per_message_abort_and_expiry_retire_without_losing_policy_artifacts() {
     let expired_open = open(expired_session, &[0x72; 32]).expect("expired flow opens");
     interactive_round1(InteractiveRound1Request {
         session_id: expired_session.to_string(),
-        attempt_id: expired_open.attempt_id,
+        attempt_id: expired_open.attempt_id.clone(),
         member_identifier: 1,
     })
     .expect("expired flow round 1");
@@ -7125,11 +7383,27 @@ fn per_message_abort_and_expiry_retire_without_losing_policy_artifacts() {
             .opened_at_unix
             .saturating_sub(interactive_session_ttl_seconds() + 1);
     }
-    interactive_session_abort(InteractiveSessionAbortRequest {
-        session_id: "retirement-sweep-trigger".to_string(),
-        attempt_id: None,
+    let expired = interactive_round1(InteractiveRound1Request {
+        session_id: expired_session.to_string(),
+        attempt_id: expired_open.attempt_id,
+        member_identifier: 1,
     })
-    .expect("unrelated abort sweeps the expired flow");
+    .expect_err("Round1 sweeps and rejects the expired flow");
+    assert!(matches!(expired, EngineError::SessionNotFound { .. }));
+
+    // Sweep-triggered expiry has Abort semantics and must be durable without a
+    // later Build/Round2 write accidentally closing the crash window.
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = &guard.sessions[expired_session];
+        assert_eq!(session.bound_key_group.as_deref(), Some(key_group));
+        assert!(session.retired_interactive_at_unix.is_some());
+        assert!(session.build_tx_request_fingerprint.is_some());
+        assert!(session.tx_result.is_some());
+        assert!(session.interactive_signing.is_empty());
+    }
 
     let next_session = "retirement-next-message";
     build_taproot_tx(build_policy_test_request(next_session))
@@ -7158,12 +7432,301 @@ fn per_message_abort_and_expiry_retire_without_losing_policy_artifacts() {
 }
 
 #[test]
-fn interactive_round2_pre_replace_failure_restores_compacted_tombstones() {
+fn first_open_persists_per_message_binding_before_restart() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("interactive_first_open_binding_restart");
+    reset_for_tests();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+
+    let wallet_session = "first-open-wallet";
+    let signing_session = "first-open-message";
+    let next_session = "first-open-next-message";
+    let key_group = "first-open-key-group";
+    let message = [0x79u8; 32];
+    let included = [1u16, 2];
+    ensure_interactive_dkg_session(wallet_session, key_group);
+    build_taproot_tx(build_policy_test_request(signing_session))
+        .expect("Build persists the initially unbound per-message shell");
+
+    interactive_session_open(InteractiveSessionOpenRequest {
+        session_id: signing_session.to_string(),
+        member_identifier: 1,
+        message_hex: hex::encode(message),
+        key_group: key_group.to_string(),
+        threshold: 2,
+        taproot_merkle_root_hex: None,
+        signing_intent: None,
+        attempt_context: interactive_test_attempt_context(
+            signing_session,
+            key_group,
+            &message,
+            &included,
+            1,
+        ),
+    })
+    .expect("the first Open durably binds the Build shell");
+
+    // No Round1, Abort, expiry, or unrelated writer closes this window: Open
+    // itself must be the durability boundary for the session's per-message role.
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = &guard.sessions[signing_session];
+        assert_eq!(session.bound_key_group.as_deref(), Some(key_group));
+        assert!(session.retired_interactive_at_unix.is_some());
+        assert!(session.interactive_signing.is_empty());
+        assert!(session.build_tx_request_fingerprint.is_some());
+        assert!(session.tx_result.is_some());
+    }
+
+    build_taproot_tx(build_policy_test_request(next_session))
+        .expect("the restarted Open shell yields its retired registry slot");
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        assert!(guard.sessions.contains_key(wallet_session));
+        assert!(guard.sessions.contains_key(next_session));
+        assert!(!guard.sessions.contains_key(signing_session));
+        assert_eq!(guard.sessions.len(), 2);
+    }
+
+    std::env::remove_var(TBTC_SIGNER_MAX_SESSIONS_ENV);
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
+fn first_open_binding_persist_failures_are_transactional_and_repairable() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("interactive_first_open_binding_faults");
+    reset_for_tests();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "3");
+
+    let wallet_session = "first-open-fault-wallet";
+    let pre_replace_session = "first-open-fault-pre";
+    let post_replace_session = "first-open-fault-post";
+    let retired_session = "first-open-fault-retired";
+    let key_group = "first-open-fault-key-group";
+    let included = [1u16, 2];
+    ensure_interactive_dkg_session(wallet_session, key_group);
+    let retired_marker = interactive_consumed_marker(&hash_hex(b"retired-attempt"), 1);
+    {
+        let mut guard = state().expect("state").lock().expect("lock");
+        guard.sessions.insert(
+            retired_session.to_string(),
+            SessionState {
+                bound_key_group: Some(key_group.to_string()),
+                retired_interactive_at_unix: Some(1),
+                consumed_interactive_attempt_markers: HashSet::from([retired_marker.clone()]),
+                ..Default::default()
+            },
+        );
+    }
+    build_taproot_tx(build_policy_test_request(post_replace_session))
+        .expect("persist baseline wallet, retired tombstone, and Build shell");
+
+    let request_for = |session_id: &str, message: [u8; 32]| InteractiveSessionOpenRequest {
+        session_id: session_id.to_string(),
+        member_identifier: 1,
+        message_hex: hex::encode(message),
+        key_group: key_group.to_string(),
+        threshold: 2,
+        taproot_merkle_root_hex: None,
+        signing_intent: None,
+        attempt_context: interactive_test_attempt_context(
+            session_id, key_group, &message, &included, 1,
+        ),
+    };
+
+    let pre_replace_request = request_for(pre_replace_session, [0x81; 32]);
+    set_persist_fault_injection_for_tests(PersistFaultInjectionPoint::AfterTempSyncBeforeRename);
+    let pre_replace = interactive_session_open(pre_replace_request.clone())
+        .expect_err("a pre-replacement binding fault must roll Open back");
+    clear_persist_fault_injection_for_tests();
+    assert!(matches!(
+        pre_replace,
+        EngineError::Internal(ref message) if message.contains("injected persist fault")
+    ));
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        assert!(!guard.sessions.contains_key(pre_replace_session));
+        let restored = &guard.sessions[retired_session];
+        assert_eq!(restored.retired_interactive_at_unix, Some(1));
+        assert!(restored
+            .consumed_interactive_attempt_markers
+            .contains(&retired_marker));
+        assert_eq!(guard.sessions.len(), 3);
+    }
+    interactive_session_open(pre_replace_request)
+        .expect("a healthy retry evicts the restored tombstone and opens");
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        assert!(!guard.sessions.contains_key(retired_session));
+        assert!(guard.sessions[pre_replace_session]
+            .interactive_signing
+            .contains_key(&1));
+        assert_eq!(guard.sessions.len(), 3);
+    }
+
+    let post_replace_request = request_for(post_replace_session, [0x82; 32]);
+    set_persist_fault_injection_for_tests(
+        PersistFaultInjectionPoint::AfterRenameBeforeDirectorySync,
+    );
+    let post_replace = interactive_session_open(post_replace_request.clone())
+        .expect_err("a post-replacement binding fault reports uncertain durability");
+    clear_persist_fault_injection_for_tests();
+    assert!(matches!(
+        post_replace,
+        EngineError::Internal(ref message) if message.contains("injected persist fault")
+    ));
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = &guard.sessions[post_replace_session];
+        assert_eq!(session.bound_key_group.as_deref(), Some(key_group));
+        assert!(session.retired_interactive_at_unix.is_some());
+        assert!(session.interactive_signing.is_empty());
+    }
+    assert!(interactive_state_persistence_pending());
+
+    set_persist_fault_injection_for_tests(PersistFaultInjectionPoint::AfterTempSyncBeforeRename);
+    interactive_session_open(post_replace_request.clone())
+        .expect_err("retry must repair the uncertain binding before reopening");
+    clear_persist_fault_injection_for_tests();
+    assert!(interactive_state_persistence_pending());
+    interactive_session_open(post_replace_request)
+        .expect("a healthy retry repairs, reactivates, and opens the session");
+    assert!(!interactive_state_persistence_pending());
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = &guard.sessions[post_replace_session];
+        assert_eq!(session.bound_key_group.as_deref(), Some(key_group));
+        assert!(session.retired_interactive_at_unix.is_none());
+        assert!(session.interactive_signing.contains_key(&1));
+        assert_eq!(guard.sessions.len(), 3);
+    }
+
+    std::env::remove_var(TBTC_SIGNER_MAX_SESSIONS_ENV);
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
+fn partial_member_expiry_persists_binding_before_restart() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("interactive_partial_expiry_binding_restart");
+    reset_for_tests();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+
+    let wallet_session = "partial-expiry-wallet";
+    let signing_session = "partial-expiry-message";
+    let next_session = "partial-expiry-next-message";
+    let key_group = "partial-expiry-key-group";
+    let message = [0x7au8; 32];
+    let included = [1u16, 2];
+    ensure_interactive_dkg_session(wallet_session, key_group);
+    build_taproot_tx(build_policy_test_request(signing_session))
+        .expect("Build persists the initially unbound per-message shell");
+
+    let open = |member_identifier| {
+        interactive_session_open(InteractiveSessionOpenRequest {
+            session_id: signing_session.to_string(),
+            member_identifier,
+            message_hex: hex::encode(message),
+            key_group: key_group.to_string(),
+            threshold: 2,
+            taproot_merkle_root_hex: None,
+            signing_intent: None,
+            attempt_context: interactive_test_attempt_context(
+                signing_session,
+                key_group,
+                &message,
+                &included,
+                1,
+            ),
+        })
+    };
+    let member_1 = open(1).expect("member 1 opens");
+    let member_2 = open(2).expect("member 2 opens");
+    assert_eq!(member_1.attempt_id, member_2.attempt_id);
+    for member_identifier in included {
+        interactive_round1(InteractiveRound1Request {
+            session_id: signing_session.to_string(),
+            attempt_id: member_1.attempt_id.clone(),
+            member_identifier,
+        })
+        .expect("both members create nonce state");
+    }
+
+    {
+        let mut guard = state().expect("state").lock().expect("lock");
+        let member = guard
+            .sessions
+            .get_mut(signing_session)
+            .expect("signing session remains live")
+            .interactive_signing
+            .get_mut(&1)
+            .expect("member 1 remains live");
+        member.opened_at_unix = member
+            .opened_at_unix
+            .saturating_sub(interactive_session_ttl_seconds() + 1);
+    }
+    let expired = interactive_round1(InteractiveRound1Request {
+        session_id: signing_session.to_string(),
+        attempt_id: member_1.attempt_id,
+        member_identifier: 1,
+    })
+    .expect_err("the expired member is removed before Round1 lookup");
+    assert!(matches!(expired, EngineError::SessionNotFound { .. }));
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = &guard.sessions[signing_session];
+        assert_eq!(session.bound_key_group.as_deref(), Some(key_group));
+        assert!(session.retired_interactive_at_unix.is_none());
+        assert!(!session.interactive_signing.contains_key(&1));
+        assert!(session.interactive_signing.contains_key(&2));
+    }
+
+    // The partial sweep is itself a durability boundary. Although member 2 is
+    // still live in memory, live nonces intentionally disappear at restart;
+    // the persisted binding lets load classify the shell as retired instead
+    // of restoring the old unbound Build entry as an active capacity leak.
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = &guard.sessions[signing_session];
+        assert_eq!(session.bound_key_group.as_deref(), Some(key_group));
+        assert!(session.retired_interactive_at_unix.is_some());
+        assert!(session.interactive_signing.is_empty());
+        assert!(session.build_tx_request_fingerprint.is_some());
+        assert!(session.tx_result.is_some());
+    }
+
+    build_taproot_tx(build_policy_test_request(next_session))
+        .expect("retired partial-expiry shell yields its shared registry slot");
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        assert!(guard.sessions.contains_key(wallet_session));
+        assert!(guard.sessions.contains_key(next_session));
+        assert!(!guard.sessions.contains_key(signing_session));
+        assert_eq!(guard.sessions.len(), 2);
+    }
+
+    std::env::remove_var(TBTC_SIGNER_MAX_SESSIONS_ENV);
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
+fn interactive_round2_pre_replace_failure_restores_staged_retirement() {
     let _guard = lock_test_state();
     let state_path = configure_test_state_path("round2_retirement_compaction_rollback");
     reset_for_tests();
     clear_state_storage_policy_overrides();
-    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "3");
 
     let key_packages = interactive_test_key_packages();
     let wallet_session = "wallet-round2-compaction-rollback";
@@ -7242,9 +7805,9 @@ fn interactive_round2_pre_replace_failure_restores_compacted_tombstones() {
     ));
     {
         let guard = state().expect("state").lock().expect("engine lock");
-        assert!(guard.sessions.contains_key("retired-oldest"));
+        assert!(!guard.sessions.contains_key("retired-oldest"));
         assert!(guard.sessions.contains_key("retired-newer"));
-        assert_eq!(retired_interactive_session_count(&guard.sessions), 2);
+        assert_eq!(retired_interactive_session_count(&guard.sessions), 1);
         let signing = &guard.sessions[signing_session];
         assert!(signing.retired_interactive_at_unix.is_none());
         assert!(signing.interactive_signing.contains_key(&1));
@@ -7277,7 +7840,7 @@ fn interactive_aggregate_pins_a_retired_session_while_the_engine_lock_is_release
     let state_path = configure_test_state_path("interactive_aggregate_retirement_pin");
     reset_for_tests();
     clear_state_storage_policy_overrides();
-    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "3");
 
     let wallet_session = "wallet-aggregate-retirement-pin";
     let signing_session = "roast-aggregate-retirement-pin";
@@ -7457,7 +8020,7 @@ fn retired_compaction_preserves_pending_marker_sessions_until_snapshot_covers_th
     let state_path = configure_test_state_path("retired_pending_marker_compaction");
     reset_for_tests();
     clear_state_storage_policy_overrides();
-    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "3");
 
     let key_packages = interactive_test_key_packages();
     let wallet_session = "wallet-retired-pending-marker";
@@ -9027,6 +9590,116 @@ fn interactive_abort_destroys_nonces_and_is_idempotent() {
     let reopened = open_interactive_for_test(session_id, key_group, &message, &included, 1, 1, 2)
         .expect("an aborted (never consumed) attempt may reopen");
     assert_eq!(reopened.attempt_id, opened.attempt_id);
+}
+
+#[test]
+fn interactive_abort_persist_failures_are_retryable_before_replace_and_fail_closed_after() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("interactive_abort_persist_durability");
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+
+    let wallet_session = "interactive-abort-persist-wallet";
+    let key_group = "interactive-abort-persist-key-group";
+    let included = [1u16, 2];
+    ensure_interactive_dkg_session(wallet_session, key_group);
+
+    let open_round1 = |session_id: &str, message: [u8; 32]| {
+        let opened = interactive_session_open(InteractiveSessionOpenRequest {
+            session_id: session_id.to_string(),
+            member_identifier: 1,
+            message_hex: hex::encode(message),
+            key_group: key_group.to_string(),
+            threshold: 2,
+            taproot_merkle_root_hex: None,
+            signing_intent: None,
+            attempt_context: interactive_test_attempt_context(
+                session_id, key_group, &message, &included, 1,
+            ),
+        })
+        .expect("per-message session opens");
+        interactive_round1(InteractiveRound1Request {
+            session_id: session_id.to_string(),
+            attempt_id: opened.attempt_id.clone(),
+            member_identifier: 1,
+        })
+        .expect("per-message session reaches Round1");
+        opened
+    };
+
+    let retryable_session = "interactive-abort-pre-replace";
+    let retryable = open_round1(retryable_session, [0xa2; 32]);
+    let retryable_request = InteractiveSessionAbortRequest {
+        session_id: retryable_session.to_string(),
+        attempt_id: Some(retryable.attempt_id),
+    };
+    set_persist_fault_injection_for_tests(PersistFaultInjectionPoint::AfterTempSyncBeforeRename);
+    let pre_replace = interactive_session_abort(retryable_request.clone())
+        .expect_err("a pre-replacement Abort fault must not consume live nonces");
+    clear_persist_fault_injection_for_tests();
+    assert!(matches!(
+        pre_replace,
+        EngineError::Internal(ref message) if message.contains("injected persist fault")
+    ));
+    {
+        let guard = state().expect("state").lock().expect("engine lock");
+        let session = &guard.sessions[retryable_session];
+        assert!(session.interactive_signing.contains_key(&1));
+        assert!(session.retired_interactive_at_unix.is_none());
+    }
+    assert!(
+        interactive_session_abort(retryable_request)
+            .expect("Abort retry persists and succeeds")
+            .aborted
+    );
+
+    let fail_closed_session = "interactive-abort-post-replace";
+    let fail_closed = open_round1(fail_closed_session, [0xa3; 32]);
+    let fail_closed_request = InteractiveSessionAbortRequest {
+        session_id: fail_closed_session.to_string(),
+        attempt_id: Some(fail_closed.attempt_id),
+    };
+    set_persist_fault_injection_for_tests(
+        PersistFaultInjectionPoint::AfterRenameBeforeDirectorySync,
+    );
+    let post_replace = interactive_session_abort(fail_closed_request.clone())
+        .expect_err("a post-replacement Abort fault reports uncertain directory durability");
+    clear_persist_fault_injection_for_tests();
+    assert!(matches!(
+        post_replace,
+        EngineError::Internal(ref message) if message.contains("injected persist fault")
+    ));
+    {
+        let guard = state().expect("state").lock().expect("engine lock");
+        let session = &guard.sessions[fail_closed_session];
+        assert!(session.interactive_signing.is_empty());
+        assert!(session.retired_interactive_at_unix.is_some());
+    }
+    assert!(interactive_state_persistence_pending());
+
+    set_persist_fault_injection_for_tests(PersistFaultInjectionPoint::AfterTempSyncBeforeRename);
+    interactive_session_abort(fail_closed_request.clone())
+        .expect_err("an idempotent retry must attempt the pending durability repair");
+    clear_persist_fault_injection_for_tests();
+    assert!(interactive_state_persistence_pending());
+    let repaired = interactive_session_abort(fail_closed_request)
+        .expect("a healthy idempotent retry repairs Abort durability");
+    assert!(!repaired.aborted);
+    assert!(!interactive_state_persistence_pending());
+
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    {
+        let guard = state().expect("state").lock().expect("engine lock");
+        let session = &guard.sessions[fail_closed_session];
+        assert_eq!(session.bound_key_group.as_deref(), Some(key_group));
+        assert!(session.retired_interactive_at_unix.is_some());
+        assert!(session.interactive_signing.is_empty());
+    }
+
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
+    clear_state_storage_policy_overrides();
 }
 
 #[test]

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -30,7 +30,7 @@ use std::{
 #[derive(Clone, Debug)]
 struct GenerateNoncesAndCommitmentsRequest {
     key_package_identifier: String,
-    key_package_hex: String,
+    key_package_hex: SecretHex,
 }
 
 #[derive(Clone, Debug)]
@@ -44,7 +44,7 @@ struct SignShareRequest {
     signing_package_hex: String,
     nonces_hex: String,
     key_package_identifier: String,
-    key_package_hex: String,
+    key_package_hex: SecretHex,
 }
 
 #[derive(Clone, Debug)]
@@ -67,13 +67,13 @@ struct AggregateResult {
 fn generate_nonces_and_commitments(
     mut request: GenerateNoncesAndCommitmentsRequest,
 ) -> Result<GenerateNoncesAndCommitmentsResult, EngineError> {
-    let key_package_hex = Zeroizing::new(std::mem::take(&mut request.key_package_hex));
+    let key_package_hex = std::mem::take(&mut request.key_package_hex);
     enforce_provenance_gate()?;
 
     let key_package = decode_key_package(
         "GenerateNoncesAndCommitments",
         &request.key_package_identifier,
-        &key_package_hex,
+        key_package_hex.expose_secret(),
     )?;
     let mut rng = zeroizing_rng_from_os();
     let (mut nonces, commitments) = frost::round1::commit(key_package.signing_share(), &mut rng);
@@ -105,7 +105,7 @@ fn generate_nonces_and_commitments(
 
 fn sign_share(mut request: SignShareRequest) -> Result<SignShareResult, EngineError> {
     let nonces_hex = Zeroizing::new(std::mem::take(&mut request.nonces_hex));
-    let key_package_hex = Zeroizing::new(std::mem::take(&mut request.key_package_hex));
+    let key_package_hex = std::mem::take(&mut request.key_package_hex);
     enforce_provenance_gate()?;
 
     let signing_package_bytes = decode_hex_field(
@@ -125,7 +125,7 @@ fn sign_share(mut request: SignShareRequest) -> Result<SignShareResult, EngineEr
     let key_package_result = decode_key_package(
         "SignShare",
         &request.key_package_identifier,
-        &key_package_hex,
+        key_package_hex.expose_secret(),
     );
     let key_package = match key_package_result {
         Ok(key_package) => key_package,
@@ -437,7 +437,7 @@ fn deterministic_interactive_dkg_fixture(seed: u8) -> InteractiveDkgFixture {
                     sender_identifier: Some(frost_identifier_to_go_string(
                         participant_identifiers[&sender_id],
                     )),
-                    package_hex: hex::encode(package.serialize().expect("round2 package")),
+                    package_hex: hex::encode(package.serialize().expect("round2 package")).into(),
                 });
         }
     }
@@ -468,7 +468,7 @@ fn deterministic_interactive_dkg_fixture(seed: u8) -> InteractiveDkgFixture {
         part3_requests.insert(
             id,
             DkgPart3Request {
-                secret_package_hex: hex::encode(secret_package_bytes),
+                secret_package_hex: hex::encode(secret_package_bytes).into(),
                 round1_packages: round1_packages_for(id),
                 round2_packages: round2_packages_by_recipient
                     .get(&id)
@@ -1125,7 +1125,8 @@ fn sample_distributed_dkg_native_material(
             member,
             crate::api::NativeFrostKeyPackage {
                 identifier: frost_identifier_to_go_string(*key_package.identifier()),
-                data_hex: hex::encode(key_package.serialize().expect("serialize key package")),
+                data_hex: hex::encode(key_package.serialize().expect("serialize key package"))
+                    .into(),
             },
         );
     }
@@ -1663,7 +1664,7 @@ fn persist_distributed_dkg_key_package_rejects_signing_share_not_deriving_to_pub
             participant_count: 3,
             key_package: crate::api::NativeFrostKeyPackage {
                 identifier: frost_identifier_to_go_string(*key_package_1.identifier()),
-                data_hex: hex::encode(corrupt_data),
+                data_hex: hex::encode(corrupt_data).into(),
             },
             public_key_package: native_public,
         })
@@ -6749,7 +6750,8 @@ fn ensure_interactive_dkg_session(
         let mut frost_key_packages = BTreeMap::new();
         for (id, key_package) in &native {
             let deserialized = frost::keys::KeyPackage::deserialize(
-                &hex::decode(&key_package.data_hex).expect("fixture key package hex decodes"),
+                &hex::decode(key_package.data_hex.expose_secret())
+                    .expect("fixture key package hex decodes"),
             )
             .expect("fixture key package deserializes");
             frost_key_packages.insert(*id, deserialized);
@@ -13220,7 +13222,7 @@ fn verify_signature_share_tweaked_root_matches_aggregate() {
     .expect("member 1 tweaked Round2 share")
     .signature_share_hex;
     let share2 = sign_tweaked(
-        &key_packages[&2].data_hex,
+        key_packages[&2].data_hex.expose_secret(),
         &member2.nonces_hex,
         &signing_package_hex,
     );
@@ -13273,7 +13275,7 @@ fn verify_signature_share_tweaked_root_matches_aggregate() {
         ],
     );
     let bogus_share2 = sign_tweaked(
-        &key_packages[&2].data_hex,
+        key_packages[&2].data_hex.expose_secret(),
         &bogus_member2.nonces_hex,
         &other_package_hex,
     );

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -743,6 +743,8 @@ fn persisted_session_state_fixture() -> PersistedSessionState {
         consumed_interactive_attempt_markers: vec![],
         aggregated_interactive_attempt_markers: vec![],
         bound_key_group: None,
+        retired_interactive_at_unix: None,
+        authorized_interactive_aggregate_markers: vec![],
     }
 }
 
@@ -4255,6 +4257,60 @@ fn persisted_engine_state_rejects_session_registry_over_limit() {
 }
 
 #[test]
+fn persisted_engine_state_migrates_idle_per_message_entries_before_active_bound_check() {
+    let _guard = lock_test_state();
+    clear_state_storage_policy_overrides();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+
+    let mut wallet = persisted_session_state_fixture();
+    wallet.dkg_result = Some(DkgResult {
+        session_id: "wallet".to_string(),
+        key_group: "wallet-key-group".to_string(),
+        participant_count: 3,
+        threshold: 2,
+        created_at_unix: 1,
+    });
+    let mut consumed_message = persisted_session_state_fixture();
+    consumed_message.bound_key_group = Some("wallet-key-group".to_string());
+    consumed_message.consumed_interactive_attempt_markers =
+        vec![interactive_consumed_marker(&"11".repeat(32), 1)];
+    consumed_message.authorized_interactive_aggregate_markers = vec!["22".repeat(32)];
+    let mut aborted_message = persisted_session_state_fixture();
+    aborted_message.bound_key_group = Some("wallet-key-group".to_string());
+    aborted_message.build_tx_request_fingerprint = Some("policy-fingerprint".to_string());
+
+    let persisted = PersistedEngineState {
+        schema_version: PERSISTED_STATE_SCHEMA_VERSION,
+        sessions: HashMap::from([
+            ("wallet".to_string(), wallet),
+            ("consumed-message".to_string(), consumed_message),
+            ("aborted-message".to_string(), aborted_message),
+        ]),
+        refresh_epoch_counter: 0,
+        operator_fault_scores: BTreeMap::new(),
+        quarantined_operator_identifiers: vec![],
+        canary_rollout: CanaryRolloutState::default(),
+    };
+
+    let loaded = EngineState::try_from(persisted)
+        .expect("legacy idle per-message entries migrate out of the active budget");
+    assert_eq!(loaded.sessions.len(), 3);
+    assert_eq!(active_session_count(&loaded.sessions), 1);
+    assert_eq!(retired_interactive_session_count(&loaded.sessions), 2);
+    assert!(loaded.sessions["wallet"]
+        .retired_interactive_at_unix
+        .is_none());
+    assert!(loaded.sessions["consumed-message"]
+        .retired_interactive_at_unix
+        .is_some());
+    assert!(loaded.sessions["aborted-message"]
+        .retired_interactive_at_unix
+        .is_some());
+
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
 fn persisted_engine_state_rejects_duplicate_dkg_key_group_owners() {
     let mut owner_a = persisted_session_state_fixture();
     owner_a.dkg_result = Some(DkgResult {
@@ -4612,54 +4668,166 @@ fn build_taproot_tx_rejects_new_session_when_session_registry_is_at_capacity() {
 }
 
 #[test]
-fn per_message_session_compaction_preserves_wallet_and_inflight_state() {
-    let mut sessions = HashMap::new();
+fn per_message_session_retirement_preserves_wallet_routing_and_retry_state() {
+    let _guard = lock_test_state();
+    clear_state_storage_policy_overrides();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "4");
 
-    let mut wallet = SessionState::default();
-    wallet.dkg_result = Some(DkgResult {
-        session_id: "wallet".to_string(),
-        key_group: "wallet-key-group".to_string(),
-        participant_count: 3,
-        threshold: 2,
-        created_at_unix: now_unix(),
-    });
-    sessions.insert("wallet".to_string(), wallet);
+    let mut engine_state = EngineState::default();
+    engine_state.sessions.insert(
+        "wallet".to_string(),
+        SessionState {
+            dkg_result: Some(DkgResult {
+                session_id: "wallet".to_string(),
+                key_group: "wallet-key-group".to_string(),
+                participant_count: 3,
+                threshold: 2,
+                created_at_unix: now_unix(),
+            }),
+            ..Default::default()
+        },
+    );
+    engine_state.sessions.insert(
+        "open-only".to_string(),
+        SessionState {
+            bound_key_group: Some("wallet-key-group".to_string()),
+            ..Default::default()
+        },
+    );
+    engine_state.sessions.insert(
+        "consumed".to_string(),
+        SessionState {
+            bound_key_group: Some("wallet-key-group".to_string()),
+            consumed_interactive_attempt_markers: HashSet::from([interactive_consumed_marker(
+                &"11".repeat(32),
+                1,
+            )]),
+            authorized_interactive_aggregate_markers: HashSet::from(["22".repeat(32)]),
+            ..Default::default()
+        },
+    );
+    engine_state.sessions.insert(
+        "completed".to_string(),
+        SessionState {
+            bound_key_group: Some("wallet-key-group".to_string()),
+            aggregated_interactive_attempt_markers: HashSet::from([format!(
+                "{}@{}@keypath",
+                "33".repeat(32),
+                "44".repeat(32)
+            )]),
+            ..Default::default()
+        },
+    );
+    engine_state.sessions.insert(
+        "retry-policy".to_string(),
+        SessionState {
+            bound_key_group: Some("wallet-key-group".to_string()),
+            build_tx_request_fingerprint: Some("policy-fingerprint".to_string()),
+            ..Default::default()
+        },
+    );
 
-    let mut open_only = SessionState::default();
-    open_only.bound_key_group = Some("wallet-key-group".to_string());
-    sessions.insert("open-only".to_string(), open_only);
+    assert_eq!(retire_idle_per_message_sessions(&mut engine_state, None), 4);
+    assert_eq!(active_session_count(&engine_state.sessions), 1);
+    assert_eq!(retired_interactive_session_count(&engine_state.sessions), 4);
+    assert!(engine_state.sessions["wallet"]
+        .retired_interactive_at_unix
+        .is_none());
+    assert_eq!(
+        engine_state.sessions["retry-policy"].build_tx_request_fingerprint,
+        Some("policy-fingerprint".to_string())
+    );
+    assert!(engine_state.sessions["consumed"]
+        .authorized_interactive_aggregate_markers
+        .contains(&"22".repeat(32)));
 
-    let mut consumed = SessionState::default();
-    consumed.bound_key_group = Some("wallet-key-group".to_string());
-    consumed
-        .consumed_interactive_attempt_markers
-        .insert(format!("m1@{}", "11".repeat(32)));
-    sessions.insert("consumed".to_string(), consumed);
+    reactivate_retired_per_message_session(&mut engine_state, "retry-policy")
+        .expect("retired retry state reactivates");
+    assert_eq!(active_session_count(&engine_state.sessions), 2);
+    assert!(engine_state.sessions["retry-policy"]
+        .retired_interactive_at_unix
+        .is_none());
+    assert_eq!(
+        engine_state.sessions["retry-policy"].build_tx_request_fingerprint,
+        Some("policy-fingerprint".to_string())
+    );
 
-    let mut completed = SessionState::default();
-    completed.bound_key_group = Some("wallet-key-group".to_string());
-    completed
-        .aggregated_interactive_attempt_markers
-        .insert(format!("{}@{}@keypath", "22".repeat(32), "33".repeat(32)));
-    sessions.insert("completed".to_string(), completed);
+    clear_state_storage_policy_overrides();
+}
 
-    let mut retry_policy = SessionState::default();
-    retry_policy.bound_key_group = Some("wallet-key-group".to_string());
-    retry_policy.build_tx_request_fingerprint = Some("policy-fingerprint".to_string());
-    sessions.insert("retry-policy".to_string(), retry_policy);
+#[test]
+fn retired_per_message_session_tier_evicts_oldest_at_its_own_bound() {
+    let _guard = lock_test_state();
+    clear_state_storage_policy_overrides();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
 
-    assert_eq!(reclaim_per_message_sessions(&mut sessions, false), 1);
-    assert!(!sessions.contains_key("open-only"));
-    assert!(sessions.contains_key("wallet"));
-    assert!(sessions.contains_key("consumed"));
-    assert!(sessions.contains_key("completed"));
-    assert!(sessions.contains_key("retry-policy"));
+    let mut engine_state = EngineState::default();
+    for (session_id, retired_at) in [("oldest", 1), ("middle", 2), ("newest", 3)] {
+        engine_state.sessions.insert(
+            session_id.to_string(),
+            SessionState {
+                bound_key_group: Some("wallet-key-group".to_string()),
+                retired_interactive_at_unix: Some(retired_at),
+                consumed_interactive_attempt_markers: HashSet::from([interactive_consumed_marker(
+                    &hash_hex(session_id.as_bytes()),
+                    1,
+                )]),
+                ..Default::default()
+            },
+        );
+    }
 
-    assert_eq!(reclaim_per_message_sessions(&mut sessions, true), 1);
-    assert!(!sessions.contains_key("completed"));
-    assert!(sessions.contains_key("wallet"));
-    assert!(sessions.contains_key("consumed"));
-    assert!(sessions.contains_key("retry-policy"));
+    assert_eq!(
+        compact_retired_per_message_sessions(&mut engine_state, Some("newest")).len(),
+        1
+    );
+    assert!(!engine_state.sessions.contains_key("oldest"));
+    assert!(engine_state.sessions.contains_key("middle"));
+    assert!(engine_state.sessions.contains_key("newest"));
+    assert_eq!(active_session_count(&engine_state.sessions), 0);
+    assert_eq!(retired_interactive_session_count(&engine_state.sessions), 2);
+    ensure_session_insert_capacity(&engine_state.sessions, "fresh-active")
+        .expect("bounded retirement cannot block active admission");
+
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
+fn idle_per_message_session_stays_active_while_marker_persistence_is_pending() {
+    let _guard = lock_test_state();
+    reset_for_tests();
+
+    let session_id = "pending-idle-per-message";
+    let aggregated_marker = interactive_aggregated_marker(
+        &hash_hex(b"pending-idle-attempt"),
+        &hash_hex(b"pending-idle-message"),
+        None,
+    );
+    let pending_operation = PersistencePendingOperation::InteractiveAggregate {
+        session_id: session_id.to_string(),
+        aggregated_marker: aggregated_marker.clone(),
+    };
+    let mut engine_state = EngineState::default();
+    engine_state.sessions.insert(
+        session_id.to_string(),
+        SessionState {
+            bound_key_group: Some("pending-idle-key-group".to_string()),
+            aggregated_interactive_attempt_markers: HashSet::from([aggregated_marker]),
+            ..Default::default()
+        },
+    );
+    mark_persistence_pending(pending_operation.clone());
+
+    assert_eq!(retire_idle_per_message_sessions(&mut engine_state, None), 0);
+    assert!(engine_state.sessions[session_id]
+        .retired_interactive_at_unix
+        .is_none());
+
+    clear_persistence_pending_operation(&pending_operation);
+    assert_eq!(retire_idle_per_message_sessions(&mut engine_state, None), 1);
+    assert!(engine_state.sessions[session_id]
+        .retired_interactive_at_unix
+        .is_some());
 }
 
 #[test]
@@ -6757,6 +6925,29 @@ fn interactive_signs_across_sessions_by_key_group() {
     })
     .expect("member 2 round 2 under the signing session");
 
+    // Non-coordinator signers stop after Round2. The now-idle outer entry must
+    // leave the active budget immediately, while its exact package
+    // authorization remains durable for a delayed coordinator Aggregate.
+    let next_session = "next-roast-signing-session";
+    build_taproot_tx(build_policy_test_request(next_session))
+        .expect("a new message uses the active slot freed after Round2");
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        assert_eq!(active_session_count(&guard.sessions), 2);
+        assert_eq!(retired_interactive_session_count(&guard.sessions), 1);
+        assert!(guard.sessions[signing_session]
+            .retired_interactive_at_unix
+            .is_some());
+        assert_eq!(
+            guard.sessions[signing_session]
+                .authorized_interactive_aggregate_markers
+                .len(),
+            1
+        );
+    }
+
     // interactive_aggregate resolves the group public key by key_group from the wallet
     // session and produces a valid BIP-340 signature over the distinct signing session.
     let aggregated = interactive_aggregate(InteractiveAggregateRequest {
@@ -6794,40 +6985,423 @@ fn interactive_signs_across_sessions_by_key_group() {
         .verify_schnorr(&signature, &SecpMessage::from_digest(message), &public_key)
         .expect("cross-session interactive signing produces a valid BIP-340 signature");
 
-    // The completed per-message entry and its typed replay tombstone survive a
-    // restart while there is still capacity. Once a new durable session needs
-    // that slot, admission compacts the terminal entry without touching the
-    // wallet/DKG owner, and the ensuing BuildTaprootTx persist makes the
-    // compaction crash-durable.
+    // The completed per-message entry moves into the separately bounded
+    // retirement tier. It retains wallet routing, exact Aggregate
+    // authorization, and typed replay markers across restart without consuming
+    // an active slot, so the next ordinary message is still admitted.
     simulate_process_restart_for_tests();
     reload_state_from_storage_for_tests();
     {
         let guard = state().expect("state").lock().expect("lock");
-        assert_eq!(guard.sessions.len(), 2);
+        assert_eq!(guard.sessions.len(), 3);
         assert!(guard.sessions.contains_key(wallet_session));
         assert!(guard.sessions.contains_key(signing_session));
-    }
-
-    let next_session = "next-roast-signing-session";
-    build_taproot_tx(build_policy_test_request(next_session))
-        .expect("a new message reclaims the completed per-message registry slot");
-    simulate_process_restart_for_tests();
-    reload_state_from_storage_for_tests();
-    {
-        let guard = state().expect("state").lock().expect("lock");
-        assert_eq!(guard.sessions.len(), 2);
-        assert!(guard.sessions.contains_key(wallet_session));
         assert!(guard.sessions.contains_key(next_session));
-        assert!(
-            !guard.sessions.contains_key(signing_session),
-            "the completed per-message tombstone must be durably compacted"
+        assert!(guard.sessions[signing_session]
+            .retired_interactive_at_unix
+            .is_some());
+        assert_eq!(
+            guard.sessions[signing_session]
+                .authorized_interactive_aggregate_markers
+                .len(),
+            1
         );
+        assert_eq!(active_session_count(&guard.sessions), 2);
+        assert_eq!(retired_interactive_session_count(&guard.sessions), 1);
     }
 
     std::env::remove_var(TBTC_SIGNER_MAX_SESSIONS_ENV);
     reset_for_tests();
     cleanup_test_state_artifacts(&state_path);
     clear_state_storage_policy_overrides();
+}
+
+#[test]
+fn per_message_abort_and_expiry_retire_without_losing_policy_artifacts() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("interactive_cross_session_abort_expiry_retirement");
+    reset_for_tests();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+
+    let wallet_session = "retirement-wallet";
+    let key_group = "retirement-wallet-key-group";
+    let included = [1u16, 2];
+    ensure_interactive_dkg_session(wallet_session, key_group);
+
+    let open = |session_id: &str, message: &[u8; 32]| {
+        interactive_session_open(InteractiveSessionOpenRequest {
+            session_id: session_id.to_string(),
+            member_identifier: 1,
+            message_hex: hex::encode(message),
+            key_group: key_group.to_string(),
+            threshold: 2,
+            taproot_merkle_root_hex: None,
+            signing_intent: None,
+            attempt_context: interactive_test_attempt_context(
+                session_id, key_group, message, &included, 1,
+            ),
+        })
+    };
+
+    let aborted_session = "retired-aborted-message";
+    let aborted_build_request = build_policy_test_request(aborted_session);
+    build_taproot_tx(aborted_build_request.clone()).expect("aborted flow builds policy artifact");
+    let aborted_open = open(aborted_session, &[0x71; 32]).expect("aborted flow opens");
+    interactive_round1(InteractiveRound1Request {
+        session_id: aborted_session.to_string(),
+        attempt_id: aborted_open.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("aborted flow round 1");
+    interactive_session_abort(InteractiveSessionAbortRequest {
+        session_id: aborted_session.to_string(),
+        attempt_id: Some(aborted_open.attempt_id),
+    })
+    .expect("abort retires the idle per-message entry");
+    build_taproot_tx(aborted_build_request)
+        .expect("retired abort entry retains its BuildTaprootTx cache");
+
+    let expired_session = "retired-expired-message";
+    build_taproot_tx(build_policy_test_request(expired_session))
+        .expect("expired flow builds policy artifact");
+    let expired_open = open(expired_session, &[0x72; 32]).expect("expired flow opens");
+    interactive_round1(InteractiveRound1Request {
+        session_id: expired_session.to_string(),
+        attempt_id: expired_open.attempt_id,
+        member_identifier: 1,
+    })
+    .expect("expired flow round 1");
+    {
+        let mut guard = state().expect("state").lock().expect("lock");
+        let interactive = guard
+            .sessions
+            .get_mut(expired_session)
+            .expect("expired session exists")
+            .interactive_signing
+            .get_mut(&1)
+            .expect("expired flow remains live");
+        interactive.opened_at_unix = interactive
+            .opened_at_unix
+            .saturating_sub(interactive_session_ttl_seconds() + 1);
+    }
+    interactive_session_abort(InteractiveSessionAbortRequest {
+        session_id: "retirement-sweep-trigger".to_string(),
+        attempt_id: None,
+    })
+    .expect("unrelated abort sweeps the expired flow");
+
+    let next_session = "retirement-next-message";
+    build_taproot_tx(build_policy_test_request(next_session))
+        .expect("retired abort and expiry entries do not exhaust active admission");
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        assert_eq!(active_session_count(&guard.sessions), 2);
+        assert_eq!(retired_interactive_session_count(&guard.sessions), 2);
+        for retired_session in [aborted_session, expired_session] {
+            let session = &guard.sessions[retired_session];
+            assert!(session.retired_interactive_at_unix.is_some());
+            assert!(session.build_tx_request_fingerprint.is_some());
+            assert!(session.tx_result.is_some());
+            assert!(session.interactive_signing.is_empty());
+        }
+        assert!(guard.sessions.contains_key(wallet_session));
+        assert!(guard.sessions.contains_key(next_session));
+    }
+
+    std::env::remove_var(TBTC_SIGNER_MAX_SESSIONS_ENV);
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
+fn interactive_round2_pre_replace_failure_restores_compacted_tombstones() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("round2_retirement_compaction_rollback");
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+
+    let key_packages = interactive_test_key_packages();
+    let wallet_session = "wallet-round2-compaction-rollback";
+    let signing_session = "roast-round2-compaction-rollback";
+    let key_group = "round2-compaction-rollback-key-group";
+    let message = [0x73u8; 32];
+    let included = [1u16, 2];
+    ensure_interactive_dkg_session(wallet_session, key_group);
+    {
+        let mut guard = state().expect("state").lock().expect("engine lock");
+        for (session_id, retired_at) in [("retired-oldest", 1), ("retired-newer", 2)] {
+            guard.sessions.insert(
+                session_id.to_string(),
+                SessionState {
+                    bound_key_group: Some(key_group.to_string()),
+                    retired_interactive_at_unix: Some(retired_at),
+                    ..Default::default()
+                },
+            );
+        }
+        persist_engine_state_to_storage(&guard).expect("persist initial retired tier");
+    }
+
+    let opened = interactive_session_open(InteractiveSessionOpenRequest {
+        session_id: signing_session.to_string(),
+        member_identifier: 1,
+        message_hex: hex::encode(message),
+        key_group: key_group.to_string(),
+        threshold: 2,
+        taproot_merkle_root_hex: None,
+        signing_intent: None,
+        attempt_context: interactive_test_attempt_context(
+            signing_session,
+            key_group,
+            &message,
+            &included,
+            1,
+        ),
+    })
+    .expect("signing session opens");
+    let round1 = interactive_round1(InteractiveRound1Request {
+        session_id: signing_session.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("member 1 round 1");
+    let member2 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("member 2 commitments");
+    let signing_package_hex = interactive_package_for_test(
+        &message,
+        vec![
+            NativeFrostCommitment {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round1.commitments_hex,
+            },
+            member2.commitment,
+        ],
+    );
+    let round2_request = InteractiveRound2Request {
+        session_id: signing_session.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+        signing_package_hex,
+    };
+
+    set_persist_fault_injection_for_tests(PersistFaultInjectionPoint::AfterTempSyncBeforeRename);
+    let faulted = interactive_round2(round2_request.clone())
+        .expect_err("the injected pre-replacement fault must fail Round2");
+    clear_persist_fault_injection_for_tests();
+    assert!(matches!(
+        faulted,
+        EngineError::Internal(ref message) if message.contains("injected persist fault")
+    ));
+    {
+        let guard = state().expect("state").lock().expect("engine lock");
+        assert!(guard.sessions.contains_key("retired-oldest"));
+        assert!(guard.sessions.contains_key("retired-newer"));
+        assert_eq!(retired_interactive_session_count(&guard.sessions), 2);
+        let signing = &guard.sessions[signing_session];
+        assert!(signing.retired_interactive_at_unix.is_none());
+        assert!(signing.interactive_signing.contains_key(&1));
+        assert!(!interactive_attempt_consumed(
+            &signing.consumed_interactive_attempt_markers,
+            &opened.attempt_id,
+            1,
+        ));
+    }
+
+    interactive_round2(round2_request)
+        .expect("the same live nonces remain usable once persistence recovers");
+    {
+        let guard = state().expect("state").lock().expect("engine lock");
+        assert!(!guard.sessions.contains_key("retired-oldest"));
+        assert!(guard.sessions.contains_key("retired-newer"));
+        assert!(guard.sessions[signing_session]
+            .retired_interactive_at_unix
+            .is_some());
+        assert_eq!(retired_interactive_session_count(&guard.sessions), 2);
+    }
+
+    clear_state_storage_policy_overrides();
+    cleanup_test_state_artifacts(&state_path);
+}
+
+#[test]
+fn retired_compaction_preserves_pending_marker_sessions_until_snapshot_covers_them() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("retired_pending_marker_compaction");
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+
+    let key_packages = interactive_test_key_packages();
+    let wallet_session = "wallet-retired-pending-marker";
+    let round2_session = "a-round2-pending-marker";
+    let aggregate_session = "b-aggregate-pending-marker";
+    let evictable_session = "c-evictable-retired-marker";
+    let key_group = "retired-pending-marker-key-group";
+    let message = [0x74u8; 32];
+    let included = [1u16, 2];
+    ensure_interactive_dkg_session(wallet_session, key_group);
+
+    let opened = interactive_session_open(InteractiveSessionOpenRequest {
+        session_id: round2_session.to_string(),
+        member_identifier: 1,
+        message_hex: hex::encode(message),
+        key_group: key_group.to_string(),
+        threshold: 2,
+        taproot_merkle_root_hex: None,
+        signing_intent: None,
+        attempt_context: interactive_test_attempt_context(
+            round2_session,
+            key_group,
+            &message,
+            &included,
+            1,
+        ),
+    })
+    .expect("pending-marker session opens");
+    let round1 = interactive_round1(InteractiveRound1Request {
+        session_id: round2_session.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("pending-marker member round 1");
+    let member2 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("pending-marker member 2 commitments");
+    let signing_package_hex = interactive_package_for_test(
+        &message,
+        vec![
+            NativeFrostCommitment {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round1.commitments_hex,
+            },
+            member2.commitment,
+        ],
+    );
+    let round2_request = InteractiveRound2Request {
+        session_id: round2_session.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+        signing_package_hex,
+    };
+    let consumed_marker = interactive_consumed_marker(&opened.attempt_id, 1);
+
+    set_persist_fault_injection_for_tests(
+        PersistFaultInjectionPoint::AfterRenameBeforeDirectorySync,
+    );
+    let faulted = interactive_round2(round2_request.clone())
+        .expect_err("the injected post-replacement fault must leave a pending marker");
+    clear_persist_fault_injection_for_tests();
+    assert!(matches!(
+        faulted,
+        EngineError::Internal(ref message) if message.contains("injected persist fault")
+    ));
+    assert!(interactive_round2_persistence_pending(
+        round2_session,
+        &consumed_marker
+    ));
+
+    let aggregated_marker = interactive_aggregated_marker(
+        &hash_hex(b"aggregate-attempt"),
+        &hash_hex(b"aggregate-message"),
+        None,
+    );
+    {
+        let mut guard = state().expect("state").lock().expect("engine lock");
+        guard
+            .sessions
+            .get_mut(round2_session)
+            .expect("Round2 pending session exists")
+            .retired_interactive_at_unix = Some(1);
+        guard.sessions.insert(
+            aggregate_session.to_string(),
+            SessionState {
+                bound_key_group: Some(key_group.to_string()),
+                retired_interactive_at_unix: Some(2),
+                aggregated_interactive_attempt_markers: HashSet::from([aggregated_marker.clone()]),
+                ..Default::default()
+            },
+        );
+        guard.sessions.insert(
+            evictable_session.to_string(),
+            SessionState {
+                bound_key_group: Some(key_group.to_string()),
+                retired_interactive_at_unix: Some(3),
+                ..Default::default()
+            },
+        );
+    }
+    mark_persistence_pending(PersistencePendingOperation::InteractiveAggregate {
+        session_id: aggregate_session.to_string(),
+        aggregated_marker: aggregated_marker.clone(),
+    });
+    assert!(interactive_aggregate_persistence_pending(
+        aggregate_session,
+        &aggregated_marker
+    ));
+
+    {
+        let mut guard = state().expect("state").lock().expect("engine lock");
+        let removed = compact_retired_per_message_sessions(&mut guard, None);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].0, evictable_session);
+        assert!(guard.sessions.contains_key(round2_session));
+        assert!(guard.sessions.contains_key(aggregate_session));
+        persist_engine_state_to_storage(&guard)
+            .expect("a successful snapshot covers both protected markers");
+    }
+    assert!(!interactive_round2_persistence_pending(
+        round2_session,
+        &consumed_marker
+    ));
+    assert!(!interactive_aggregate_persistence_pending(
+        aggregate_session,
+        &aggregated_marker
+    ));
+
+    let uncovered_session = "missing-pending-marker-session";
+    let uncovered_marker = interactive_consumed_marker(&hash_hex(b"missing-attempt"), 1);
+    let uncovered_operation = PersistencePendingOperation::InteractiveRound2 {
+        session_id: uncovered_session.to_string(),
+        consumed_marker: uncovered_marker.clone(),
+    };
+    mark_persistence_pending(uncovered_operation.clone());
+    {
+        let guard = state().expect("state").lock().expect("engine lock");
+        persist_engine_state_to_storage(&guard)
+            .expect("an unrelated snapshot can succeed without the missing marker");
+    }
+    assert!(
+        interactive_round2_persistence_pending(uncovered_session, &uncovered_marker),
+        "a snapshot that omits the exact marker must not clear its repair obligation"
+    );
+    clear_persistence_pending_operation(&uncovered_operation);
+
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    {
+        let guard = state().expect("state").lock().expect("engine lock");
+        assert!(guard.sessions[round2_session]
+            .consumed_interactive_attempt_markers
+            .contains(&consumed_marker));
+        assert!(guard.sessions[aggregate_session]
+            .aggregated_interactive_attempt_markers
+            .contains(&aggregated_marker));
+    }
+    let replay = interactive_round2(round2_request)
+        .expect_err("the covered Round2 marker remains fail-closed after restart");
+    assert!(matches!(replay, EngineError::ConsumedNonceReplay { .. }));
+
+    clear_state_storage_policy_overrides();
+    cleanup_test_state_artifacts(&state_path);
 }
 
 #[test]
@@ -7365,12 +7939,10 @@ fn interactive_round2_completion_marker_binds_taproot_root() {
 }
 
 #[test]
-fn interactive_aggregate_cleanup_is_message_bound() {
-    // The aggregate's finalized-sibling cleanup matches the full identity
-    // (attempt_id + message + root). A mismatched aggregate - a VALID package for a
-    // DIFFERENT message submitted under a live attempt's id - must NOT delete that
-    // attempt's live nonce state (its message differs), mirroring the completion
-    // marker's message binding.
+fn interactive_aggregate_rejects_mismatched_message_without_cleanup() {
+    // Aggregate authorization binds the canonical signing package, including
+    // its message. A valid package for another message cannot create completion
+    // state or delete the authorized attempt's live nonce state.
     let _guard = lock_test_state();
     reset_for_tests();
 
@@ -7421,14 +7993,18 @@ fn interactive_aggregate_cleanup_is_message_bound() {
         key_package_hex: key_packages[&2].data_hex.clone(),
     })
     .expect("stateless share 2 over B");
-    interactive_aggregate(InteractiveAggregateRequest {
+    let err = interactive_aggregate(InteractiveAggregateRequest {
         session_id: session_id.to_string(),
         attempt_id: opened.attempt_id.clone(),
         signing_package_hex: package_b,
         signature_shares: vec![share1_b.signature_share, share2_b.signature_share],
         taproot_merkle_root_hex: None,
     })
-    .expect("aggregate over message B succeeds under message A's attempt id");
+    .expect_err("aggregate over message B must not use message A's attempt id");
+    assert!(
+        matches!(err, EngineError::Validation(ref message) if message.contains("not authorized")),
+        "unexpected error: {err:?}"
+    );
 
     // The live message-A seat must survive: the cleanup is message-bound.
     {
@@ -7438,6 +8014,7 @@ fn interactive_aggregate_cleanup_is_message_bound() {
             session.interactive_signing.contains_key(&1),
             "a mismatched-message aggregate must not delete the live message-A seat"
         );
+        assert!(session.aggregated_interactive_attempt_markers.is_empty());
     }
 }
 
@@ -8439,6 +9016,77 @@ fn interactive_heartbeat_intent_opens_and_releases_round2_share_under_firewall()
     drop(guard);
 
     clear_state_storage_policy_overrides();
+}
+
+#[test]
+fn interactive_heartbeat_capacity_rejection_does_not_consume_wallet_token() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("heartbeat_capacity_preflight");
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+    std::env::set_var(TBTC_SIGNER_POLICY_HEARTBEAT_RATE_LIMIT_PER_MINUTE_ENV, "1");
+
+    let wallet_session = "wallet-heartbeat-capacity-preflight";
+    let key_group = "heartbeat-capacity-preflight-key-group";
+    let signing_session = "roast-heartbeat-capacity-preflight";
+    let included = [1u16, 2];
+    ensure_interactive_dkg_session(wallet_session, key_group);
+    {
+        let mut guard = state().expect("state").lock().expect("engine lock");
+        guard.sessions.insert(
+            "active-capacity-filler".to_string(),
+            SessionState::default(),
+        );
+        assert_eq!(active_session_count(&guard.sessions), 2);
+    }
+
+    let heartbeat_message = heartbeat_message_for_test(100);
+    let signing_message = heartbeat_signing_message_for_test(&heartbeat_message);
+    let request = InteractiveSessionOpenRequest {
+        session_id: signing_session.to_string(),
+        member_identifier: 1,
+        message_hex: hex::encode(signing_message),
+        key_group: key_group.to_string(),
+        threshold: 2,
+        taproot_merkle_root_hex: None,
+        signing_intent: Some(heartbeat_signing_intent_for_test(&heartbeat_message)),
+        attempt_context: interactive_test_attempt_context(
+            signing_session,
+            key_group,
+            &signing_message,
+            &included,
+            1,
+        ),
+    };
+
+    let rejected = interactive_session_open(request.clone())
+        .expect_err("a full active tier must reject a fresh heartbeat session");
+    assert!(matches!(
+        rejected,
+        EngineError::Internal(ref message) if message.contains("active session registry size")
+    ));
+    {
+        let mut guard = state().expect("state").lock().expect("engine lock");
+        let limiter = &guard.sessions[wallet_session].heartbeat_rate_limiter;
+        assert_eq!(limiter.last_refill_unix, 0);
+        assert_eq!(limiter.token_microunits, 0);
+        assert_eq!(limiter.configured_rate_limit_per_minute, 0);
+        guard.sessions.remove("active-capacity-filler");
+    }
+
+    interactive_session_open(request)
+        .expect("the capacity-rejected call must leave the wallet's token available");
+    {
+        let guard = state().expect("state").lock().expect("engine lock");
+        let limiter = &guard.sessions[wallet_session].heartbeat_rate_limiter;
+        assert_eq!(limiter.configured_rate_limit_per_minute, 1);
+        assert_eq!(limiter.token_microunits, 0);
+    }
+
+    clear_state_storage_policy_overrides();
+    cleanup_test_state_artifacts(&state_path);
 }
 
 #[test]
@@ -10029,16 +10677,35 @@ fn interactive_aggregate_rejects_repeat_aggregate_of_completed_attempt() {
     assert_eq!(aggregate.attempt_id, opened.attempt_id);
 
     // A valid package/share set cannot be replayed under a different, merely
-    // well-formed id. Only an id established by Open (live observer) or Round2
-    // (durable signer marker) may create completion state, so this replay cannot
-    // consume another bounded marker slot.
+    // well-formed id.
     let mut unbound_request = aggregate_request.clone();
     unbound_request.attempt_id = "aa".repeat(32);
     assert_ne!(unbound_request.attempt_id, opened.attempt_id);
     let err = interactive_aggregate(unbound_request)
         .expect_err("an unbound aggregate attempt id must be rejected");
     assert!(
-        matches!(err, EngineError::Validation(ref message) if message.contains("is not bound")),
+        matches!(err, EngineError::Validation(ref message) if message.contains("not authorized")),
+        "unexpected error: {err:?}"
+    );
+
+    // Merely opening the next canonical attempt (and even producing fresh
+    // Round1 commitments) must not authorize the prior attempt's package. The
+    // old ID-only binding allowed this loop to add one completion marker per
+    // Open until the 128-entry cap blocked legitimate work.
+    let reopened = open_interactive_for_test(session_id, key_group, &message, &included, 2, 1, 2)
+        .expect("next canonical attempt opens");
+    interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: reopened.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("next canonical attempt produces fresh commitments");
+    let mut rebound_replay = aggregate_request.clone();
+    rebound_replay.attempt_id = reopened.attempt_id;
+    let err = interactive_aggregate(rebound_replay)
+        .expect_err("a fresh Open must not authorize an old signing package");
+    assert!(
+        matches!(err, EngineError::Validation(ref message) if message.contains("not authorized")),
         "unexpected error: {err:?}"
     );
     {
@@ -10048,7 +10715,7 @@ fn interactive_aggregate_rejects_repeat_aggregate_of_completed_attempt() {
                 .aggregated_interactive_attempt_markers
                 .len(),
             1,
-            "an unbound replay must not consume aggregate-marker capacity"
+            "a replay under a freshly opened canonical id must not consume marker capacity"
         );
     }
 
@@ -10469,11 +11136,12 @@ fn interactive_aggregate_names_all_invalid_share_culprits() {
     let opened = open_interactive_for_test(session_id, key_group, &message, &included, 1, 1, 2)
         .expect("opens");
 
-    let real1 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
-        key_package_identifier: key_packages[&1].identifier.clone(),
-        key_package_hex: key_packages[&1].data_hex.clone(),
+    let real1 = interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
     })
-    .expect("member 1 nonces");
+    .expect("member 1 live authorization commitment");
     let real2 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
         key_package_identifier: key_packages[&2].identifier.clone(),
         key_package_hex: key_packages[&2].data_hex.clone(),
@@ -10481,7 +11149,13 @@ fn interactive_aggregate_names_all_invalid_share_culprits() {
     .expect("member 2 nonces");
     let signing_package_hex = interactive_package_for_test(
         &message,
-        vec![real1.commitment.clone(), real2.commitment.clone()],
+        vec![
+            NativeFrostCommitment {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: real1.commitments_hex,
+            },
+            real2.commitment.clone(),
+        ],
     );
 
     // Each member signs a different (2-party) package over another message, so
@@ -11119,17 +11793,27 @@ fn verify_signature_share_tweaked_root_matches_aggregate() {
     let included = [1u16, 2];
     let key_packages = ensure_interactive_dkg_session(session_id, key_group);
 
-    // The attempt's opened root is independent of the root passed to verify /
-    // aggregate (both take it as a parameter), so open with None and drive the
-    // tweaked path purely through the verify/aggregate root arguments.
-    let opened = open_interactive_for_test(session_id, key_group, &message, &included, 1, 1, 2)
-        .expect("opens");
-
-    let member1 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
-        key_package_identifier: key_packages[&1].identifier.clone(),
-        key_package_hex: key_packages[&1].data_hex.clone(),
+    let taproot_merkle_root = [0x11u8; 32];
+    let taproot_merkle_root_hex = hex::encode(taproot_merkle_root);
+    let opened = interactive_session_open(InteractiveSessionOpenRequest {
+        session_id: session_id.to_string(),
+        member_identifier: 1,
+        message_hex: hex::encode(message),
+        key_group: key_group.to_string(),
+        threshold: 2,
+        taproot_merkle_root_hex: Some(taproot_merkle_root_hex.clone()),
+        signing_intent: None,
+        attempt_context: interactive_test_attempt_context(
+            session_id, key_group, &message, &included, 1,
+        ),
     })
-    .expect("member 1 nonces");
+    .expect("opens with the tweaked root");
+    let member1 = interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("member 1 interactive nonces");
     let member2 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
         key_package_identifier: key_packages[&2].identifier.clone(),
         key_package_hex: key_packages[&2].data_hex.clone(),
@@ -11137,11 +11821,14 @@ fn verify_signature_share_tweaked_root_matches_aggregate() {
     .expect("member 2 nonces");
     let signing_package_hex = interactive_package_for_test(
         &message,
-        vec![member1.commitment.clone(), member2.commitment.clone()],
+        vec![
+            NativeFrostCommitment {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: member1.commitments_hex.clone(),
+            },
+            member2.commitment.clone(),
+        ],
     );
-
-    let taproot_merkle_root = [0x11u8; 32];
-    let taproot_merkle_root_hex = hex::encode(taproot_merkle_root);
 
     // Produce a TWEAKED round-2 share: sign_with_tweak signs under a
     // taproot-tweaked key package, exactly the production taproot signing path.
@@ -11167,11 +11854,14 @@ fn verify_signature_share_tweaked_root_matches_aggregate() {
         hex::encode(share.serialize())
     };
 
-    let share1 = sign_tweaked(
-        &key_packages[&1].data_hex,
-        &member1.nonces_hex,
-        &signing_package_hex,
-    );
+    let share1 = interactive_round2(InteractiveRound2Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+        signing_package_hex: signing_package_hex.clone(),
+    })
+    .expect("member 1 tweaked Round2 share")
+    .signature_share_hex;
     let share2 = sign_tweaked(
         &key_packages[&2].data_hex,
         &member2.nonces_hex,
@@ -11221,7 +11911,7 @@ fn verify_signature_share_tweaked_root_matches_aggregate() {
             bogus_member2.commitment.clone(),
             NativeFrostCommitment {
                 identifier: key_packages[&1].identifier.clone(),
-                data_hex: member1.commitment.data_hex.clone(),
+                data_hex: member1.commitments_hex,
             },
         ],
     );

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -5358,6 +5358,115 @@ fn restart_reload_recovers_persisted_state_across_operation_types() {
 }
 
 #[test]
+fn first_engine_state_load_is_serialized_across_callers() {
+    let engine_state = std::sync::Arc::new(OnceLock::<Mutex<EngineState>>::new());
+    let initialization_lock = std::sync::Arc::new(Mutex::new(()));
+    let initial_miss_barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let load_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    let callers = (0..2)
+        .map(|_| {
+            let engine_state = std::sync::Arc::clone(&engine_state);
+            let initialization_lock = std::sync::Arc::clone(&initialization_lock);
+            let initial_miss_barrier = std::sync::Arc::clone(&initial_miss_barrier);
+            let load_count = std::sync::Arc::clone(&load_count);
+
+            std::thread::spawn(move || {
+                let initialized = initialize_engine_state_with_loader(
+                    &engine_state,
+                    &initialization_lock,
+                    || {
+                        // Both callers must pass the optimistic OnceLock check
+                        // before either may enter the serialized loader path.
+                        initial_miss_barrier.wait();
+                    },
+                    || {
+                        let invocation =
+                            load_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        Ok(EngineState {
+                            refresh_epoch_counter: invocation as u64 + 41,
+                            ..EngineState::default()
+                        })
+                    },
+                )
+                .expect("concurrent initialization");
+
+                let state_pointer = std::ptr::from_ref(initialized) as usize;
+                let refresh_epoch_counter = initialized
+                    .lock()
+                    .expect("initialized engine state lock")
+                    .refresh_epoch_counter;
+                (state_pointer, refresh_epoch_counter)
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let results = callers
+        .into_iter()
+        .map(|caller| caller.join().expect("initialization caller"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        load_count.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "only one first caller may load or migrate persistent state"
+    );
+    assert_eq!(results[0].0, results[1].0);
+    assert_eq!(results[0].1, 41);
+    assert_eq!(results[1].1, 41);
+}
+
+#[test]
+fn failed_engine_state_load_remains_retryable() {
+    let engine_state = OnceLock::<Mutex<EngineState>>::new();
+    let initialization_lock = Mutex::new(());
+    let load_count = std::sync::atomic::AtomicUsize::new(0);
+
+    let first_error = match initialize_engine_state_with_loader(
+        &engine_state,
+        &initialization_lock,
+        || {},
+        || {
+            load_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(EngineError::Internal(
+                "intentional first-load failure".to_string(),
+            ))
+        },
+    ) {
+        Ok(_) => panic!("failed loader must not initialize engine state"),
+        Err(error) => error,
+    };
+    expect_internal_error_contains(first_error, "intentional first-load failure");
+    assert!(
+        engine_state.get().is_none(),
+        "a fallible load must leave the OnceLock unset"
+    );
+
+    let initialized = initialize_engine_state_with_loader(
+        &engine_state,
+        &initialization_lock,
+        || {},
+        || {
+            load_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(EngineState {
+                refresh_epoch_counter: 73,
+                ..EngineState::default()
+            })
+        },
+    )
+    .expect("retry after failed state load");
+
+    assert_eq!(load_count.load(std::sync::atomic::Ordering::SeqCst), 2);
+    assert_eq!(
+        initialized
+            .lock()
+            .expect("initialized engine state lock")
+            .refresh_epoch_counter,
+        73
+    );
+}
+
+#[test]
 #[cfg(unix)]
 fn state_lock_rejects_multi_process_contention() {
     let _guard = lock_test_state();

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -6626,6 +6626,47 @@ fn interactive_package_for_test(
     .signing_package_hex
 }
 
+fn stateless_package_and_shares_for_test(
+    message_bytes: &[u8],
+    signer_ids: &[u16],
+    key_packages: &BTreeMap<u16, crate::api::NativeFrostKeyPackage>,
+) -> (String, Vec<NativeFrostSignatureShare>) {
+    let generated = signer_ids
+        .iter()
+        .map(|signer_id| {
+            let key_package = &key_packages[signer_id];
+            let nonces = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
+                key_package_identifier: key_package.identifier.clone(),
+                key_package_hex: key_package.data_hex.clone(),
+            })
+            .expect("stateless signer nonces");
+            (*signer_id, nonces)
+        })
+        .collect::<Vec<_>>();
+    let signing_package_hex = interactive_package_for_test(
+        message_bytes,
+        generated
+            .iter()
+            .map(|(_, generated)| generated.commitment.clone())
+            .collect(),
+    );
+    let signature_shares = generated
+        .into_iter()
+        .map(|(signer_id, generated)| {
+            let key_package = &key_packages[&signer_id];
+            sign_share(SignShareRequest {
+                signing_package_hex: signing_package_hex.clone(),
+                nonces_hex: generated.nonces_hex,
+                key_package_identifier: key_package.identifier.clone(),
+                key_package_hex: key_package.data_hex.clone(),
+            })
+            .expect("stateless signature share")
+            .signature_share
+        })
+        .collect();
+    (signing_package_hex, signature_shares)
+}
+
 // Regression for the deferred state-key resolution: a Round2 whose persist
 // fails because the state-key command fails must NOT leave the consumption
 // marker set (which would burn the attempt in-process). The key is resolved
@@ -7228,6 +7269,186 @@ fn interactive_round2_pre_replace_failure_restores_compacted_tombstones() {
 
     clear_state_storage_policy_overrides();
     cleanup_test_state_artifacts(&state_path);
+}
+
+#[test]
+fn interactive_aggregate_pins_a_retired_session_while_the_engine_lock_is_released() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("interactive_aggregate_retirement_pin");
+    reset_for_tests();
+    clear_state_storage_policy_overrides();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+
+    let wallet_session = "wallet-aggregate-retirement-pin";
+    let signing_session = "roast-aggregate-retirement-pin";
+    let filler_session = "retired-aggregate-pin-filler";
+    let newcomer_session = "retired-aggregate-pin-newcomer";
+    let key_group = "aggregate-retirement-pin-key-group";
+    let message = [0x75u8; 32];
+    let included = [1u16, 2];
+    let key_packages = ensure_interactive_dkg_session(wallet_session, key_group);
+
+    let opened = interactive_session_open(InteractiveSessionOpenRequest {
+        session_id: signing_session.to_string(),
+        member_identifier: 1,
+        message_hex: hex::encode(message),
+        key_group: key_group.to_string(),
+        threshold: 2,
+        taproot_merkle_root_hex: None,
+        signing_intent: None,
+        attempt_context: interactive_test_attempt_context(
+            signing_session,
+            key_group,
+            &message,
+            &included,
+            1,
+        ),
+    })
+    .expect("per-message signing session opens");
+    let round1 = interactive_round1(InteractiveRound1Request {
+        session_id: signing_session.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("member 1 round 1");
+    let member2 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("member 2 nonces");
+    let signing_package_hex = interactive_package_for_test(
+        &message,
+        vec![
+            NativeFrostCommitment {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round1.commitments_hex,
+            },
+            member2.commitment.clone(),
+        ],
+    );
+    let round2 = interactive_round2(InteractiveRound2Request {
+        session_id: signing_session.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+        signing_package_hex: signing_package_hex.clone(),
+    })
+    .expect("member 1 round 2");
+    let member2_share = sign_share(SignShareRequest {
+        signing_package_hex: signing_package_hex.clone(),
+        nonces_hex: member2.nonces_hex,
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("member 2 share");
+    let aggregate_request = InteractiveAggregateRequest {
+        session_id: signing_session.to_string(),
+        attempt_id: opened.attempt_id,
+        signing_package_hex,
+        signature_shares: vec![
+            NativeFrostSignatureShare {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round2.signature_share_hex,
+            },
+            member2_share.signature_share,
+        ],
+        taproot_merkle_root_hex: None,
+    };
+
+    {
+        let mut guard = state().expect("state").lock().expect("engine lock");
+        let target = guard
+            .sessions
+            .get_mut(signing_session)
+            .expect("Round2 retains the retired signing tombstone");
+        assert!(target.retired_interactive_at_unix.is_some());
+        target.retired_interactive_at_unix = Some(1);
+        guard.sessions.insert(
+            filler_session.to_string(),
+            SessionState {
+                bound_key_group: Some(key_group.to_string()),
+                retired_interactive_at_unix: Some(2),
+                ..Default::default()
+            },
+        );
+        persist_engine_state_to_storage(&guard).expect("persist full retired tier");
+    }
+
+    struct AggregateReleaseGuard(
+        Option<std::thread::JoinHandle<Result<InteractiveAggregateResult, EngineError>>>,
+    );
+    impl Drop for AggregateReleaseGuard {
+        fn drop(&mut self) {
+            release_interactive_aggregate_unlock_for_tests();
+            if let Some(handle) = self.0.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    arm_interactive_aggregate_unlock_hold_for_tests();
+    let aggregate = std::thread::spawn(move || interactive_aggregate(aggregate_request));
+    let mut release_guard = AggregateReleaseGuard(Some(aggregate));
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !interactive_aggregate_unlock_held_for_tests() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "Aggregate did not reach its unlocked cryptographic section"
+        );
+        std::thread::yield_now();
+    }
+
+    {
+        let mut guard = state().expect("state").lock().expect("engine lock");
+        assert_eq!(
+            Arc::strong_count(&guard.sessions[signing_session].aggregate_eviction_pin),
+            2,
+            "the in-flight Aggregate must hold the transient eviction pin"
+        );
+        guard.sessions.insert(
+            newcomer_session.to_string(),
+            SessionState {
+                bound_key_group: Some(key_group.to_string()),
+                retired_interactive_at_unix: Some(3),
+                ..Default::default()
+            },
+        );
+        let removed = compact_retired_per_message_sessions(&mut guard, Some(newcomer_session));
+        assert_eq!(
+            removed
+                .iter()
+                .map(|(id, _)| id.as_str())
+                .collect::<Vec<_>>(),
+            vec![filler_session],
+            "compaction must skip the older but in-flight Aggregate target"
+        );
+        assert!(guard.sessions.contains_key(signing_session));
+    }
+
+    release_interactive_aggregate_unlock_for_tests();
+    let aggregate = release_guard
+        .0
+        .take()
+        .expect("aggregate thread handle")
+        .join()
+        .expect("aggregate thread does not panic")
+        .expect("aggregate succeeds after concurrent retirement compaction");
+    drop(release_guard);
+    assert_eq!(aggregate.session_id, signing_session);
+    {
+        let guard = state().expect("state").lock().expect("engine lock");
+        let target = &guard.sessions[signing_session];
+        assert_eq!(
+            Arc::strong_count(&target.aggregate_eviction_pin),
+            1,
+            "the transient eviction pin releases after Aggregate completes"
+        );
+        assert_eq!(target.aggregated_interactive_attempt_markers.len(), 1);
+    }
+
+    std::env::remove_var(TBTC_SIGNER_MAX_SESSIONS_ENV);
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
+    clear_state_storage_policy_overrides();
 }
 
 #[test]
@@ -9556,6 +9777,78 @@ fn interactive_open_does_not_use_wallet_session_transaction_artifact() {
 }
 
 #[test]
+fn interactive_round2_writes_a_consumed_marker_readable_by_the_previous_schema1_binary() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("interactive_round2_rollback_marker");
+    reset_for_tests();
+
+    let session_id = "interactive-round2-rollback-marker";
+    let key_group = "interactive-test-key-group";
+    let message = [0xe2u8; 32];
+    let included = [1u16, 2];
+    let key_packages = ensure_interactive_dkg_session(session_id, key_group);
+    let opened = open_interactive_for_test(session_id, key_group, &message, &included, 1, 1, 2)
+        .expect("interactive attempt opens");
+    let round1 = interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("round 1");
+    let member2 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("member 2 nonces");
+    let signing_package_hex = interactive_package_for_test(
+        &message,
+        vec![
+            NativeFrostCommitment {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round1.commitments_hex,
+            },
+            member2.commitment,
+        ],
+    );
+    interactive_round2(InteractiveRound2Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+        signing_package_hex,
+    })
+    .expect("round 2 persists consumption before releasing the share");
+
+    let previous_schema1_marker = format!("m1@{}", opened.attempt_id);
+    assert_eq!(
+        interactive_consumed_marker(&opened.attempt_id, 1),
+        previous_schema1_marker,
+        "schema-1 state must keep the marker representation understood by the prior binary"
+    );
+
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    let guard = state().expect("state").lock().expect("lock");
+    let markers = &guard.sessions[session_id].consumed_interactive_attempt_markers;
+    let previous_binary_reports_consumed =
+        markers.contains(&previous_schema1_marker) || markers.contains(&opened.attempt_id);
+    assert!(
+        previous_binary_reports_consumed,
+        "the immediately previous schema-1 reader must fail closed after rollback"
+    );
+    drop(guard);
+
+    let transitional_v2 = HashSet::from([format!("{previous_schema1_marker}@v2")]);
+    assert!(
+        interactive_attempt_consumed(&transitional_v2, &opened.attempt_id, 1),
+        "current readers retain fail-closed support for transitional @v2 markers"
+    );
+
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
 fn interactive_consumed_marker_is_case_insensitive() {
     let _guard = lock_test_state();
     reset_for_tests();
@@ -10517,6 +10810,197 @@ fn interactive_open_rejects_phantom_included_participant() {
 }
 
 #[test]
+fn interactive_aggregate_allows_an_elected_coordinator_outside_the_signing_subset() {
+    let _guard = lock_test_state();
+    reset_for_tests();
+
+    let session_id = "interactive-nonsigning-coordinator";
+    let key_group = "interactive-test-key-group";
+    let message = [0x49u8; 32];
+    let included = [1u16, 2, 3];
+    let key_packages = ensure_interactive_dkg_session(session_id, key_group);
+    let attempt_context =
+        interactive_test_attempt_context(session_id, key_group, &message, &included, 1);
+    let coordinator = attempt_context.coordinator_identifier;
+    let signing_subset = included
+        .iter()
+        .copied()
+        .filter(|member| *member != coordinator)
+        .collect::<Vec<_>>();
+    assert_eq!(signing_subset.len(), 2);
+
+    let opened = interactive_session_open(InteractiveSessionOpenRequest {
+        session_id: session_id.to_string(),
+        member_identifier: coordinator,
+        message_hex: hex::encode(message),
+        key_group: key_group.to_string(),
+        threshold: 2,
+        taproot_merkle_root_hex: None,
+        signing_intent: None,
+        attempt_context,
+    })
+    .expect("elected coordinator opens the attempt");
+    interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: coordinator,
+    })
+    .expect("elected coordinator joins commitment collection");
+
+    let (signing_package_hex, signature_shares) =
+        stateless_package_and_shares_for_test(&message, &signing_subset, &key_packages);
+    let aggregate_request = InteractiveAggregateRequest {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        signing_package_hex,
+        signature_shares,
+        taproot_merkle_root_hex: None,
+    };
+    let aggregate = interactive_aggregate(aggregate_request.clone())
+        .expect("an elected coordinator need not be one of the first threshold responders");
+    assert_eq!(aggregate.attempt_id, opened.attempt_id);
+
+    let guard = state().expect("state").lock().expect("lock");
+    let session = &guard.sessions[session_id];
+    assert!(
+        !interactive_attempt_consumed(
+            &session.consumed_interactive_attempt_markers,
+            &opened.attempt_id,
+            coordinator,
+        ),
+        "the coordinator did not release a share"
+    );
+    assert!(
+        session.interactive_signing.is_empty(),
+        "successful aggregation retires the coordinator's unused nonce handle"
+    );
+    assert_eq!(
+        session.aggregated_interactive_attempt_markers.len(),
+        1,
+        "the successful attempt consumes one completion slot"
+    );
+    drop(guard);
+
+    // The coordinator-only fallback cannot bind an inner FROST package to an
+    // attempt id because the package carries no such field. Its durable
+    // package identity must therefore reject the same valid package/share set
+    // under a fresh canonical coordinator attempt, including after restart.
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    let next_attempt_number = (2..=32)
+        .find(|attempt_number| {
+            interactive_test_attempt_context(
+                session_id,
+                key_group,
+                &message,
+                &included,
+                *attempt_number,
+            )
+            .coordinator_identifier
+                == coordinator
+        })
+        .expect("coordinator recurs within bounded RFC-21 rotation");
+    let next_context = interactive_test_attempt_context(
+        session_id,
+        key_group,
+        &message,
+        &included,
+        next_attempt_number,
+    );
+    let reopened = interactive_session_open(InteractiveSessionOpenRequest {
+        session_id: session_id.to_string(),
+        member_identifier: coordinator,
+        message_hex: hex::encode(message),
+        key_group: key_group.to_string(),
+        threshold: 2,
+        taproot_merkle_root_hex: None,
+        signing_intent: None,
+        attempt_context: next_context,
+    })
+    .expect("fresh canonical coordinator attempt opens after restart");
+    interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: reopened.attempt_id.clone(),
+        member_identifier: coordinator,
+    })
+    .expect("fresh coordinator attempt reaches live authorization");
+
+    let mut replay = aggregate_request;
+    replay.attempt_id = reopened.attempt_id;
+    let error = interactive_aggregate(replay)
+        .expect_err("a completed package cannot consume a second attempt marker");
+    assert!(
+        matches!(error, EngineError::Validation(ref message) if message.contains("already aggregated")),
+        "unexpected replay error: {error:?}"
+    );
+    let guard = state().expect("state").lock().expect("lock");
+    assert_eq!(
+        guard.sessions[session_id]
+            .aggregated_interactive_attempt_markers
+            .len(),
+        1,
+        "cross-attempt package replay must not amplify persistent completion state"
+    );
+}
+
+#[test]
+fn interactive_aggregate_does_not_authorize_an_omitted_noncoordinator_observer() {
+    let _guard = lock_test_state();
+    reset_for_tests();
+
+    let session_id = "interactive-omitted-observer";
+    let key_group = "interactive-test-key-group";
+    let message = [0x48u8; 32];
+    let included = [1u16, 2, 3];
+    let key_packages = ensure_interactive_dkg_session(session_id, key_group);
+    let attempt_context =
+        interactive_test_attempt_context(session_id, key_group, &message, &included, 1);
+    let observer = included
+        .iter()
+        .copied()
+        .find(|member| *member != attempt_context.coordinator_identifier)
+        .expect("included set has a non-coordinator");
+    let signing_subset = included
+        .iter()
+        .copied()
+        .filter(|member| *member != observer)
+        .collect::<Vec<_>>();
+
+    let opened = interactive_session_open(InteractiveSessionOpenRequest {
+        session_id: session_id.to_string(),
+        member_identifier: observer,
+        message_hex: hex::encode(message),
+        key_group: key_group.to_string(),
+        threshold: 2,
+        taproot_merkle_root_hex: None,
+        signing_intent: None,
+        attempt_context,
+    })
+    .expect("observer opens the attempt");
+    interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: observer,
+    })
+    .expect("observer produces a commitment before the first-t subset freezes");
+    let (signing_package_hex, signature_shares) =
+        stateless_package_and_shares_for_test(&message, &signing_subset, &key_packages);
+
+    let error = interactive_aggregate(InteractiveAggregateRequest {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id,
+        signing_package_hex,
+        signature_shares,
+        taproot_merkle_root_hex: None,
+    })
+    .expect_err("an omitted observer cannot claim coordinator authorization");
+    assert!(
+        matches!(error, EngineError::Validation(ref message) if message.contains("not authorized")),
+        "unexpected error: {error:?}"
+    );
+}
+
+#[test]
 fn interactive_aggregate_produces_and_self_verifies_bip340() {
     let _guard = lock_test_state();
     reset_for_tests();
@@ -10831,7 +11315,16 @@ fn interactive_aggregate_completion_marker_survives_process_restart() {
         ],
         taproot_merkle_root_hex: None,
     };
-    interactive_aggregate(aggregate_request.clone()).expect("first interactive aggregate");
+    set_persist_fault_injection_for_tests(PersistFaultInjectionPoint::AfterTempSyncBeforeRename);
+    let faulted = interactive_aggregate(aggregate_request.clone())
+        .expect_err("a pre-replacement persistence fault must roll Aggregate state back");
+    clear_persist_fault_injection_for_tests();
+    assert!(
+        matches!(faulted, EngineError::Internal(ref message) if message.contains("injected persist fault")),
+        "unexpected fault: {faulted:?}"
+    );
+    interactive_aggregate(aggregate_request.clone())
+        .expect("the exact authorization and package remain retryable after rollback");
 
     // The completion marker is the only durable interactive artifact (live
     // nonce state is gone after restart by construction). It must survive a
@@ -11103,6 +11596,12 @@ fn interactive_aggregate_rejects_invalid_share_fail_closed() {
         candidate_culprits,
         vec![2],
         "only the cheating member 2 must be named: {candidate_culprits:?}"
+    );
+    let guard = state().expect("state").lock().expect("lock");
+    assert_eq!(
+        Arc::strong_count(&guard.sessions[session_id].aggregate_eviction_pin),
+        1,
+        "an Aggregate crypto error must release its transient eviction pin"
     );
 }
 

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -12168,6 +12168,191 @@ fn interactive_aggregate_post_rename_persist_failure_finalizes_attempt_and_retry
 }
 
 #[test]
+fn interactive_aggregate_post_rename_repair_retires_session_and_releases_capacity() {
+    let _guard = lock_test_state();
+    let state_path = configure_test_state_path("interactive_aggregate_post_rename");
+    reset_for_tests();
+    std::env::set_var(TBTC_SIGNER_MAX_SESSIONS_ENV, "2");
+
+    let wallet_session_id = "interactive-aggregate-post-rename-wallet";
+    let session_id = "interactive-aggregate-post-rename";
+    let next_session_id = "interactive-aggregate-post-rename-next";
+    let key_group = "interactive-test-key-group";
+    let message = [0x50u8; 32];
+    let included = [1u16, 2, 3];
+    let key_packages = ensure_interactive_dkg_session(wallet_session_id, key_group);
+    build_taproot_tx(build_policy_test_request(session_id))
+        .expect("Build persists the cross-session policy shell");
+
+    let open_member = |member_identifier| {
+        interactive_session_open(InteractiveSessionOpenRequest {
+            session_id: session_id.to_string(),
+            member_identifier,
+            message_hex: hex::encode(message),
+            key_group: key_group.to_string(),
+            threshold: 2,
+            taproot_merkle_root_hex: None,
+            signing_intent: None,
+            attempt_context: interactive_test_attempt_context(
+                session_id, key_group, &message, &included, 1,
+            ),
+        })
+    };
+    let opened = open_member(1).expect("member 1 opens");
+    let round1 = interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("member 1 round 1");
+
+    let sibling = open_member(3).expect("unsigned sibling opens");
+    assert_eq!(sibling.attempt_id, opened.attempt_id);
+    interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: sibling.attempt_id,
+        member_identifier: 3,
+    })
+    .expect("unsigned sibling creates live nonces");
+
+    let member2 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("member 2 nonces");
+    let signing_package_hex = interactive_package_for_test(
+        &message,
+        vec![
+            NativeFrostCommitment {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round1.commitments_hex,
+            },
+            member2.commitment.clone(),
+        ],
+    );
+    let round2 = interactive_round2(InteractiveRound2Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+        signing_package_hex: signing_package_hex.clone(),
+    })
+    .expect("member 1 round 2 share");
+    let member2_share = sign_share(SignShareRequest {
+        signing_package_hex: signing_package_hex.clone(),
+        nonces_hex: member2.nonces_hex,
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("member 2 share");
+
+    let aggregate_request = InteractiveAggregateRequest {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        signing_package_hex,
+        signature_shares: vec![
+            crate::api::NativeFrostSignatureShare {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round2.signature_share_hex,
+            },
+            member2_share.signature_share,
+        ],
+        taproot_merkle_root_hex: None,
+    };
+    let aggregated_marker =
+        interactive_aggregated_marker(&opened.attempt_id, &hash_hex(&message), None);
+
+    set_persist_fault_injection_for_tests(
+        PersistFaultInjectionPoint::AfterRenameBeforeDirectorySync,
+    );
+    let faulted = interactive_aggregate(aggregate_request.clone())
+        .expect_err("post-rename persist fault must report aggregate failure");
+    clear_persist_fault_injection_for_tests();
+    assert!(
+        matches!(faulted, EngineError::Internal(ref text) if text.contains("injected persist fault")),
+        "unexpected error: {faulted:?}"
+    );
+
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = guard.sessions.get(session_id).expect("session exists");
+        assert!(session
+            .aggregated_interactive_attempt_markers
+            .contains(&aggregated_marker));
+        assert!(
+            !session.interactive_signing.contains_key(&3),
+            "a retained completion marker must destroy an unsigned sibling's live nonces"
+        );
+    }
+    assert!(interactive_aggregate_persistence_pending(
+        session_id,
+        &aggregated_marker
+    ));
+
+    set_persist_fault_injection_for_tests(PersistFaultInjectionPoint::AfterTempSyncBeforeRename);
+    let failed_flush = interactive_aggregate(aggregate_request.clone())
+        .expect_err("a failed pending completion flush must not reach the completion gate");
+    clear_persist_fault_injection_for_tests();
+    assert!(matches!(
+        failed_flush,
+        EngineError::Internal(ref message) if message.contains("injected persist fault")
+    ));
+    assert!(interactive_aggregate_persistence_pending(
+        session_id,
+        &aggregated_marker
+    ));
+
+    // A different successful full-state writer is allowed to cover and clear
+    // the Aggregate repair. Retirement must already be staged so this unrelated
+    // snapshot cannot clear pending while leaving an active, nonce-free shell.
+    build_taproot_tx(build_policy_test_request(wallet_session_id))
+        .expect("an unrelated wallet Build persists the full engine snapshot");
+    assert!(!interactive_aggregate_persistence_pending(
+        session_id,
+        &aggregated_marker
+    ));
+
+    // With pending already cleared by the unrelated writer, the exact retry
+    // still rejects the completed attempt and must not duplicate its marker.
+    let retry = interactive_aggregate(aggregate_request)
+        .expect_err("in-process retry rejects the completed attempt");
+    assert!(
+        matches!(
+            retry,
+            EngineError::InteractiveAttemptAlreadyAggregated { .. }
+        ),
+        "unexpected retry error: {retry:?}"
+    );
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = &guard.sessions[session_id];
+        assert!(session
+            .aggregated_interactive_attempt_markers
+            .contains(&aggregated_marker));
+        assert_eq!(session.aggregated_interactive_attempt_markers.len(), 1);
+        assert!(session.interactive_signing.is_empty());
+        assert!(
+            session.retired_interactive_at_unix.is_some(),
+            "repair must retire the completed per-message session immediately"
+        );
+        assert_eq!(active_session_count(&guard.sessions), 1);
+    }
+    build_taproot_tx(build_policy_test_request(next_session_id))
+        .expect("the repaired Aggregate session yields its shared registry slot");
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        assert!(guard.sessions.contains_key(wallet_session_id));
+        assert!(guard.sessions.contains_key(next_session_id));
+        assert!(!guard.sessions.contains_key(session_id));
+        assert_eq!(guard.sessions.len(), 2);
+    }
+
+    std::env::remove_var(TBTC_SIGNER_MAX_SESSIONS_ENV);
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
 fn interactive_aggregate_rejects_invalid_share_fail_closed() {
     let _guard = lock_test_state();
     reset_for_tests();

--- a/pkg/tbtc/signer/src/engine/transaction.rs
+++ b/pkg/tbtc/signer/src/engine/transaction.rs
@@ -100,8 +100,10 @@ pub fn build_taproot_tx(request: BuildTaprootTxRequest) -> Result<TransactionRes
             });
         }
     }
-    ensure_session_insert_capacity(&guard.sessions, &request.session_id)?;
-
+    // Capacity rejection must precede policy rate-limit consumption. This is a
+    // read-only preflight; the transactional reservation still occurs after all
+    // request validation, immediately before the durable mutation.
+    ensure_session_insert_admission_capacity(&guard, &request.session_id)?;
     // BuildTaprootTx is an assembly-only step. Input prevout values and scripts
     // are trusted caller-supplied metadata and are not verified against chain
     // state. Both are nevertheless required because BIP-341 SIGHASH_DEFAULT
@@ -267,6 +269,9 @@ pub fn build_taproot_tx(request: BuildTaprootTxRequest) -> Result<TransactionRes
     // caching only; this session entry may intentionally not have DKG/signing
     // state populated.
     let build_session_id = result.session_id.clone();
+    // All request and policy validation is complete. Reserve the durable
+    // session slot now so a rejected request cannot evict a replay tombstone.
+    let compacted_retired_sessions = ensure_session_insert_capacity(&mut guard, &build_session_id)?;
     let accepted_request_fingerprint = request_fingerprint.clone();
     let previous_build_state = guard.sessions.get(&build_session_id).map(|session| {
         (
@@ -298,6 +303,9 @@ pub fn build_taproot_tx(request: BuildTaprootTxRequest) -> Result<TransactionRes
             session.tx_result = previous_result;
         } else {
             guard.sessions.remove(&build_session_id);
+        }
+        if !state_file_replaced {
+            restore_compacted_retired_sessions(&mut guard, compacted_retired_sessions);
         }
         return Err(persist_error);
     }

--- a/pkg/tbtc/signer/src/engine/transaction.rs
+++ b/pkg/tbtc/signer/src/engine/transaction.rs
@@ -100,7 +100,7 @@ pub fn build_taproot_tx(request: BuildTaprootTxRequest) -> Result<TransactionRes
             });
         }
     }
-    ensure_session_insert_capacity(&mut guard.sessions, &request.session_id)?;
+    ensure_session_insert_capacity(&guard.sessions, &request.session_id)?;
 
     // BuildTaprootTx is an assembly-only step. Input prevout values and scripts
     // are trusted caller-supplied metadata and are not verified against chain

--- a/pkg/tbtc/signer/src/engine/transaction.rs
+++ b/pkg/tbtc/signer/src/engine/transaction.rs
@@ -100,7 +100,7 @@ pub fn build_taproot_tx(request: BuildTaprootTxRequest) -> Result<TransactionRes
             });
         }
     }
-    ensure_session_insert_capacity(&guard.sessions, &request.session_id)?;
+    ensure_session_insert_capacity(&mut guard.sessions, &request.session_id)?;
 
     // BuildTaprootTx is an assembly-only step. Input prevout values and scripts
     // are trusted caller-supplied metadata and are not verified against chain

--- a/pkg/tbtc/signer/src/engine/verify_share.rs
+++ b/pkg/tbtc/signer/src/engine/verify_share.rs
@@ -89,7 +89,7 @@ pub fn verify_signature_share(
         // guarantee (an abandoned interactive nonce handle gone within the TTL of
         // inactivity) must hold even when the only post-expiry traffic is
         // verify-share blame rechecks. Mirrors InteractiveAggregate.
-        sweep_expired_interactive_state(&mut guard);
+        sweep_expired_interactive_state_durably(&mut guard)?;
         // The public key package is a WALLET-level asset resolved by key_group, so a
         // per-signing session (a distinct RoastSessionID) can be blame-checked. The
         // key_group is this signing session's own DKG (co-located) or the one bound at

--- a/pkg/tbtc/signer/src/lib.rs
+++ b/pkg/tbtc/signer/src/lib.rs
@@ -647,7 +647,7 @@ mod tests {
             let result: DkgPart1Result =
                 serde_json::from_slice(&payload).expect("part1 response decode");
             assert_eq!(result.package.identifier, participant_identifiers[&id]);
-            assert!(!result.secret_package_hex.is_empty());
+            assert!(!result.secret_package_hex.expose_secret().is_empty());
             assert!(!result.package.package_hex.is_empty());
             part1_results.insert(id, result);
         }


### PR DESCRIPTION
## Stack

Rust signer review-fix stack 1 of 3.

- Base: `extraction/frost-signer-mirror-2026-05-26` (#4005)
- Follow-up: #4158 — DKG secret zeroization
- Final: #4159 — startup load serialization

## What changed

- Require Aggregate attempt IDs to be canonical SHA-256 hex, and bind fixed-size Aggregate authorization to the validated attempt, signing package, and taproot root.
- Allow the elected coordinator to aggregate a validated attempt without requiring that coordinator to be part of the frozen signing subset.
- Keep consumed markers readable by the immediately previous schema-1 binary, and pin a retired session for the full unlocked Aggregate operation.
- Reclaim completed per-message sessions through bounded retirement while keeping every persisted schema-1 snapshot within the legacy total `TBTC_SIGNER_MAX_SESSIONS` limit.
- Reserve new session slots by transactionally evicting the oldest eligible retired tombstone; protect pending and in-flight Aggregate sessions, and restore evicted replay state after pre-replacement Build/DKG/Open failures.
- Persist the first per-message Open binding before success, and make Abort plus full or partial TTL expiry crash-durable. Post-replacement uncertainty remains fail-closed behind a repair marker.
- Stage retirement before registering a post-rename Aggregate repair, so either the exact retry or an unrelated full-state writer durably covers completion and retirement before clearing pending protection.
- Compact and immediately rewrite oversized intermediate schema-1 state during load so emergency rollback remains available.

## Review findings addressed

- P1: reclaim per-message sessions after completion.
- P2: validate Aggregate attempt IDs before persistence.
- P1: allow non-signing coordinators to aggregate.
- P1: preserve consumed markers across binary rollback.
- P2: pin sessions while aggregation is in flight.
- P1: preserve the previous total-session bound on disk.
- P2: make Abort-driven retirement crash-durable.
- P2: retire the session after an Aggregate repair.

Retired per-message tombstones use only the unoccupied portion of the shared legacy-compatible total session budget. Live wallet/DKG sessions are never classified as retireable.

## Verification

- `cargo fmt --manifest-path pkg/tbtc/signer/Cargo.toml -- --check`
- `cargo check --locked --manifest-path pkg/tbtc/signer/Cargo.toml --all-targets`
- `cargo clippy --locked --manifest-path pkg/tbtc/signer/Cargo.toml --all-targets -- -D warnings`
- `cargo test --locked --manifest-path pkg/tbtc/signer/Cargo.toml` (259 passed, 1 ignored; the ignored multiprocess helper passes in its child process; 28 binary and 1 integration test passed)
- `cargo test --locked --manifest-path pkg/tbtc/signer/Cargo.toml formal_verification_`
- `pkg/tbtc/signer/scripts/run_phase5_chaos_suite.sh` (all 6 scenarios passed)
- `git diff --check`

CI is authoritative for the TLA+ model and dependency-audit gates.
