### PR TITLE
fix(tbtc/signer): serialize initial state loading

### DIFF
--- a/pkg/tbtc/signer/src/engine/state.rs
+++ b/pkg/tbtc/signer/src/engine/state.rs
@@ -217,6 +217,15 @@ pub(crate) const TBTC_SIGNER_MAX_ATTEMPT_TRANSITION_RECORDS_PER_SESSION: usize =
 
 pub(crate) static ENGINE_STATE: OnceLock<Mutex<EngineState>> = OnceLock::new();
 
+// Loading can rewrite a legacy or stale encrypted envelope in place. A
+// OnceLock serializes only the final in-memory installation, so it does not by
+// itself prevent concurrent first callers from racing those fallible storage
+// reads and migrations. Keep that entire path behind a process-local mutex
+// that is deliberately separate from STATE_FILE_LOCK: the loader resolves the
+// active path through STATE_FILE_LOCK and would deadlock if its slot guard were
+// held here.
+static ENGINE_STATE_INITIALIZATION_LOCK: Mutex<()> = Mutex::new(());
+
 pub(crate) static STATE_FILE_LOCK: OnceLock<Mutex<Option<StateFileLock>>> = OnceLock::new();
 
 pub(crate) static STATE_PATH_OVERRIDE_WARNED: OnceLock<()> = OnceLock::new();
@@ -327,12 +336,50 @@ pub(crate) fn state() -> Result<&'static Mutex<EngineState>, EngineError> {
     ensure_state_file_lock()?;
     warn_disabled_policy_gates();
 
-    if let Some(state) = ENGINE_STATE.get() {
+    initialize_engine_state_with_loader(
+        &ENGINE_STATE,
+        &ENGINE_STATE_INITIALIZATION_LOCK,
+        || {},
+        load_engine_state_from_storage,
+    )
+}
+
+/// Installs the first engine state while serializing the complete fallible load
+/// path, not just the final OnceLock write.
+///
+/// `after_initial_miss` is a no-op in production and lets concurrency tests
+/// deterministically place multiple callers past the optimistic fast path.
+/// The loader runs under `initialization_lock`; a failed load leaves
+/// `engine_state` unset so a later call can retry.
+pub(crate) fn initialize_engine_state_with_loader<'state, AfterInitialMiss, Load>(
+    engine_state: &'state OnceLock<Mutex<EngineState>>,
+    initialization_lock: &Mutex<()>,
+    after_initial_miss: AfterInitialMiss,
+    load: Load,
+) -> Result<&'state Mutex<EngineState>, EngineError>
+where
+    AfterInitialMiss: FnOnce(),
+    Load: FnOnce() -> Result<EngineState, EngineError>,
+{
+    if let Some(state) = engine_state.get() {
         return Ok(state);
     }
 
-    let loaded_state = load_engine_state_from_storage()?;
-    Ok(ENGINE_STATE.get_or_init(|| Mutex::new(loaded_state)))
+    after_initial_miss();
+
+    // The mutex protects no data of its own. Recovering its guard after a
+    // panic is safe, and the second OnceLock check determines whether the
+    // previous caller completed installation before panicking.
+    let _initialization_guard = initialization_lock
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    if let Some(state) = engine_state.get() {
+        return Ok(state);
+    }
+
+    let loaded_state = load()?;
+    Ok(engine_state.get_or_init(|| Mutex::new(loaded_state)))
 }
 
 pub(crate) fn state_file_path() -> Result<PathBuf, EngineError> {

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -5358,6 +5358,115 @@ fn restart_reload_recovers_persisted_state_across_operation_types() {
 }
 
 #[test]
+fn first_engine_state_load_is_serialized_across_callers() {
+    let engine_state = std::sync::Arc::new(OnceLock::<Mutex<EngineState>>::new());
+    let initialization_lock = std::sync::Arc::new(Mutex::new(()));
+    let initial_miss_barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let load_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    let callers = (0..2)
+        .map(|_| {
+            let engine_state = std::sync::Arc::clone(&engine_state);
+            let initialization_lock = std::sync::Arc::clone(&initialization_lock);
+            let initial_miss_barrier = std::sync::Arc::clone(&initial_miss_barrier);
+            let load_count = std::sync::Arc::clone(&load_count);
+
+            std::thread::spawn(move || {
+                let initialized = initialize_engine_state_with_loader(
+                    &engine_state,
+                    &initialization_lock,
+                    || {
+                        // Both callers must pass the optimistic OnceLock check
+                        // before either may enter the serialized loader path.
+                        initial_miss_barrier.wait();
+                    },
+                    || {
+                        let invocation =
+                            load_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        Ok(EngineState {
+                            refresh_epoch_counter: invocation as u64 + 41,
+                            ..EngineState::default()
+                        })
+                    },
+                )
+                .expect("concurrent initialization");
+
+                let state_pointer = std::ptr::from_ref(initialized) as usize;
+                let refresh_epoch_counter = initialized
+                    .lock()
+                    .expect("initialized engine state lock")
+                    .refresh_epoch_counter;
+                (state_pointer, refresh_epoch_counter)
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let results = callers
+        .into_iter()
+        .map(|caller| caller.join().expect("initialization caller"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        load_count.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "only one first caller may load or migrate persistent state"
+    );
+    assert_eq!(results[0].0, results[1].0);
+    assert_eq!(results[0].1, 41);
+    assert_eq!(results[1].1, 41);
+}
+
+#[test]
+fn failed_engine_state_load_remains_retryable() {
+    let engine_state = OnceLock::<Mutex<EngineState>>::new();
+    let initialization_lock = Mutex::new(());
+    let load_count = std::sync::atomic::AtomicUsize::new(0);
+
+    let first_error = match initialize_engine_state_with_loader(
+        &engine_state,
+        &initialization_lock,
+        || {},
+        || {
+            load_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(EngineError::Internal(
+                "intentional first-load failure".to_string(),
+            ))
+        },
+    ) {
+        Ok(_) => panic!("failed loader must not initialize engine state"),
+        Err(error) => error,
+    };
+    expect_internal_error_contains(first_error, "intentional first-load failure");
+    assert!(
+        engine_state.get().is_none(),
+        "a fallible load must leave the OnceLock unset"
+    );
+
+    let initialized = initialize_engine_state_with_loader(
+        &engine_state,
+        &initialization_lock,
+        || {},
+        || {
+            load_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(EngineState {
+                refresh_epoch_counter: 73,
+                ..EngineState::default()
+            })
+        },
+    )
+    .expect("retry after failed state load");
+
+    assert_eq!(load_count.load(std::sync::atomic::Ordering::SeqCst), 2);
+    assert_eq!(
+        initialized
+            .lock()
+            .expect("initialized engine state lock")
+            .refresh_epoch_counter,
+        73
+    );
+}
+
+#[test]
 #[cfg(unix)]
 fn state_lock_rejects_multi_process_contention() {
     let _guard = lock_test_state();


### PR DESCRIPTION
## Stack

Rust signer review-fix stack 3 of 3.

- Depends on: #4158, which depends on #4157
- Ultimate base: `extraction/frost-signer-mirror-2026-05-26` (#4005)

Merge #4157 and #4158 first, then retarget this PR down the stack.

## What changed

- Serialize the complete first fallible state load and migration behind a dedicated process-local initialization mutex.
- Double-check the OnceLock after acquiring the initializer mutex so concurrent first callers invoke the loader and any in-place migration only once.
- Keep the initializer separate from `STATE_FILE_LOCK`, avoiding lock-order recursion when the loader resolves the active state path.
- Recover the initializer token after mutex poisoning and leave the OnceLock unset after load errors so later calls can retry.
- Add deterministic concurrency and failure-retry regressions against the same helper used by production `state()`.

## Review finding addressed

- P2: serialize first-time state loading and migration.

## Verification

- `cargo fmt --manifest-path pkg/tbtc/signer/Cargo.toml -- --check`
- `cargo check --locked --manifest-path pkg/tbtc/signer/Cargo.toml --all-targets`
- `cargo clippy --locked --manifest-path pkg/tbtc/signer/Cargo.toml --all-targets -- -D warnings`
- `cargo test --locked --manifest-path pkg/tbtc/signer/Cargo.toml` (263 passed, 1 ignored; the ignored multiprocess helper passes in its child process; 28 binary and 1 integration test passed)
- `cargo test --locked --manifest-path pkg/tbtc/signer/Cargo.toml formal_verification_`
- `pkg/tbtc/signer/scripts/run_phase5_chaos_suite.sh` (all 6 scenarios passed)
- `git diff --check`

CI is authoritative for the TLA+ model and dependency-audit gates.
