### PR TITLE
fix(spv): allow proofs longer than 144 headers

### DIFF
--- a/pkg/maintainer/spv/spv.go
+++ b/pkg/maintainer/spv/spv.go
@@ -20,9 +20,6 @@ import (
 
 var logger = log.Logger("keep-maintainer-spv")
 
-// The length of the Bitcoin difficulty epoch in blocks.
-const difficultyEpochLength = 2016
-
 // minDifficultyTarget matches the Bridge's BTCUtils.DIFF1_TARGET.
 var minDifficultyTarget = blockchain.CompactToBig(0x1d00ffff)
 

--- a/pkg/maintainer/spv/spv.go
+++ b/pkg/maintainer/spv/spv.go
@@ -22,11 +22,6 @@ var logger = log.Logger("keep-maintainer-spv")
 // The length of the Bitcoin difficulty epoch in blocks.
 const difficultyEpochLength = 2016
 
-// The maximum number of block headers allowed in a single SPV proof. Bounds
-// the forward walk over headers when computing required confirmations
-// (relevant on testnet4 where long runs of minimum-difficulty blocks occur).
-const maxProofHeaders = 144
-
 func Initialize(
 	ctx context.Context,
 	config Config,
@@ -375,13 +370,6 @@ func getProofInfo(
 	headerCount := uint(0)
 
 	for {
-		if headerCount >= maxProofHeaders {
-			// Could not find a decisive header or accumulate enough
-			// difficulty within a sane number of headers. Skip the
-			// transaction; it may become provable later.
-			return false, 0, 0, nil
-		}
-
 		blockHeight := proofStartBlock + uint64(headerCount)
 		if blockHeight > uint64(latestBlockHeight) {
 			// Not enough mined blocks yet to assemble the proof. Report the

--- a/pkg/maintainer/spv/spv.go
+++ b/pkg/maintainer/spv/spv.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcd/blockchain"
 	"github.com/keep-network/keep-core/pkg/tbtc"
 
 	"github.com/ipfs/go-log/v2"
@@ -21,6 +22,9 @@ var logger = log.Logger("keep-maintainer-spv")
 
 // The length of the Bitcoin difficulty epoch in blocks.
 const difficultyEpochLength = 2016
+
+// minDifficultyTarget matches the Bridge's BTCUtils.DIFF1_TARGET.
+var minDifficultyTarget = blockchain.CompactToBig(0x1d00ffff)
 
 func Initialize(
 	ctx context.Context,
@@ -387,13 +391,22 @@ func getProofInfo(
 			)
 		}
 
+		headerTarget := header.Target()
+		if headerTarget.Sign() <= 0 {
+			return false, 0, 0, fmt.Errorf(
+				"invalid target [%v] for block header at height [%v]",
+				headerTarget,
+				blockHeight,
+			)
+		}
+
 		headerDiff := header.Difficulty()
 		headerCount++
 		observedDiff.Add(observedDiff, headerDiff)
 
 		if requestedDiff == nil {
 			// Still looking for the decisive header.
-			if skipMinDifficulty && headerDiff.Cmp(one) == 0 {
+			if skipMinDifficulty && headerTarget.Cmp(minDifficultyTarget) == 0 {
 				continue
 			}
 

--- a/pkg/maintainer/spv/spv_test.go
+++ b/pkg/maintainer/spv/spv_test.go
@@ -147,19 +147,27 @@ func TestGetProofInfo(t *testing.T) {
 			expectedAccumulatedConfirmations: 0,
 			expectedRequiredConfirmations:    0,
 		},
-		// A run of minimum-difficulty headers longer than maxProofHeaders
-		// never reaches a decisive header.
-		"minimum difficulty run exceeds header bound": {
-			transactionConfirmations: 150,
+		// Long testnet4 runs of minimum-difficulty headers must not prevent a
+		// proof from reaching a later decisive header. The Bridge consumes the
+		// full header chain, so the maintainer must do the same. After 144 DIFF1
+		// headers, the previous-epoch difficulty 16 header binds the requested
+		// difficulty and brings the observed total above 6*16=96.
+		"decisive header follows long minimum difficulty run": {
+			transactionConfirmations: 145,
 			currentEpochDifficulty:   diff(32),
 			previousEpochDifficulty:  diff(16),
-			headerDifficultyAt:       func(uint) *big.Int { return diff(1) },
-			headersFrom:              proofStart,
-			headersTo:                proofStart + 149,
+			headerDifficultyAt: func(h uint) *big.Int {
+				if h < proofStart+144 {
+					return diff(1)
+				}
+				return diff(16)
+			},
+			headersFrom: proofStart,
+			headersTo:   proofStart + 144,
 
-			expectedIsProofWithinRelayRange:  false,
-			expectedAccumulatedConfirmations: 0,
-			expectedRequiredConfirmations:    0,
+			expectedIsProofWithinRelayRange:  true,
+			expectedAccumulatedConfirmations: 145,
+			expectedRequiredConfirmations:    145,
 		},
 		// The chain tip is reached before enough difficulty is accumulated.
 		// The reported requirement is one header more than currently exists,

--- a/pkg/maintainer/spv/spv_test.go
+++ b/pkg/maintainer/spv/spv_test.go
@@ -27,7 +27,9 @@ func TestGetProofInfo(t *testing.T) {
 		currentEpochDifficulty           *big.Int
 		previousEpochDifficulty          *big.Int
 		headerDifficultyAt               func(uint) *big.Int
+		headerAt                         func(uint) *bitcoin.BlockHeader
 		headersFrom, headersTo           uint
+		expectedError                    string
 		expectedIsProofWithinRelayRange  bool
 		expectedAccumulatedConfirmations uint
 		expectedRequiredConfirmations    uint
@@ -147,6 +149,41 @@ func TestGetProofInfo(t *testing.T) {
 			expectedAccumulatedConfirmations: 0,
 			expectedRequiredConfirmations:    0,
 		},
+		// This header's target is harder than the exact DIFF1 target, but its
+		// integer difficulty rounds down to one. The Bridge does not skip it;
+		// it treats it as the decisive header and rejects it because it matches
+		// neither relay epoch difficulty. The maintainer must do the same.
+		"non-DIFF1 target rounding to difficulty one is not skipped": {
+			transactionConfirmations: 1,
+			currentEpochDifficulty:   diff(32),
+			previousEpochDifficulty:  diff(16),
+			headerAt: func(uint) *bitcoin.BlockHeader {
+				return &bitcoin.BlockHeader{Bits: 0x1d00aaaa}
+			},
+			headersFrom: proofStart,
+			headersTo:   proofStart,
+
+			expectedIsProofWithinRelayRange:  false,
+			expectedAccumulatedConfirmations: 0,
+			expectedRequiredConfirmations:    0,
+		},
+		// Compact bits can decode to a zero target. Reject it before calling
+		// BlockHeader.Difficulty, which would otherwise divide by zero.
+		"zero target is rejected": {
+			transactionConfirmations: 1,
+			currentEpochDifficulty:   diff(32),
+			previousEpochDifficulty:  diff(16),
+			headerAt: func(uint) *bitcoin.BlockHeader {
+				return &bitcoin.BlockHeader{Bits: 0}
+			},
+			headersFrom:   proofStart,
+			headersTo:     proofStart,
+			expectedError: "invalid target [0] for block header at height [790270]",
+
+			expectedIsProofWithinRelayRange:  false,
+			expectedAccumulatedConfirmations: 0,
+			expectedRequiredConfirmations:    0,
+		},
 		// Long testnet4 runs of minimum-difficulty headers must not prevent a
 		// proof from reaching a later decisive header. The Bridge consumes the
 		// full header chain, so the maintainer must do the same. After 144 DIFF1
@@ -199,13 +236,21 @@ func TestGetProofInfo(t *testing.T) {
 			localChain := newLocalChain()
 
 			btcChain := newLocalBitcoinChain()
-			if err := populateBlockHeaders(
-				btcChain,
-				test.headersFrom,
-				test.headersTo,
-				test.headerDifficultyAt,
-			); err != nil {
-				t.Fatal(err)
+			if test.headerAt != nil {
+				for h := test.headersFrom; h <= test.headersTo; h++ {
+					if err := btcChain.addBlockHeader(h, test.headerAt(h)); err != nil {
+						t.Fatal(err)
+					}
+				}
+			} else {
+				if err := populateBlockHeaders(
+					btcChain,
+					test.headersFrom,
+					test.headersTo,
+					test.headerDifficultyAt,
+				); err != nil {
+					t.Fatal(err)
+				}
 			}
 			btcChain.addTransactionConfirmations(
 				transactionHash,
@@ -229,7 +274,18 @@ func TestGetProofInfo(t *testing.T) {
 					localChain,
 					localChain,
 				)
-			if err != nil {
+			if test.expectedError != "" {
+				if err == nil {
+					t.Fatalf("expected error containing [%v]", test.expectedError)
+				}
+				if !strings.Contains(err.Error(), test.expectedError) {
+					t.Fatalf(
+						"unexpected error\nexpected to contain: [%v]\nactual: [%v]",
+						test.expectedError,
+						err,
+					)
+				}
+			} else if err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
## Summary

- remove the client-only 144-header cap from the SPV proof walk
- keep walking through mined headers until the proof has enough work or reaches the Bitcoin chain tip
- skip only headers whose decoded target exactly matches the Bridge DIFF1 target
- reject non-positive header targets before calculating difficulty

## Regression coverage

- 144 DIFF1 headers followed by a decisive difficulty-16 header
- non-DIFF1 bits 0x1d00aaaa, whose integer difficulty rounds to one, remain decisive
- zero-target compact bits return a proof error instead of panicking

## Testing

- go test -count=1 ./pkg/maintainer/spv
- go test ./pkg/maintainer/...

Stacked on #4039. The temporary base branch mirrors #4039 at 832c1168cedaf7841c4dc76d92b2913c54f61a84; retarget this PR to main after #4039 merges.