### PR TITLE
refactor(spv): isolate btcd script classification

### DIFF
--- a/pkg/maintainer/spv/deposit_sweep.go
+++ b/pkg/maintainer/spv/deposit_sweep.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/keep-network/keep-core/pkg/tbtc"
 
-	"github.com/btcsuite/btcd/txscript"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
@@ -156,10 +155,10 @@ func parseDepositSweepTransactionInputs(
 
 		publicKeyScript := previousTransaction.Outputs[outpointIndex].PublicKeyScript
 		value := previousTransaction.Outputs[outpointIndex].Value
-		scriptClass := txscript.GetScriptClass(publicKeyScript)
+		scriptType := bitcoin.GetScriptType(publicKeyScript)
 
-		if scriptClass == txscript.PubKeyHashTy ||
-			scriptClass == txscript.WitnessV0PubKeyHashTy {
+		if scriptType == bitcoin.P2PKHScript ||
+			scriptType == bitcoin.P2WPKHScript {
 			// The input is P2PKH or P2WPKH, so we found main UTXO. There should
 			// be at most one main UTXO. If any input of this kind has already
 			// been found, report an error.
@@ -177,8 +176,8 @@ func parseDepositSweepTransactionInputs(
 						"inputs",
 				)
 			}
-		} else if scriptClass == txscript.ScriptHashTy ||
-			scriptClass == txscript.WitnessV0ScriptHashTy {
+		} else if scriptType == bitcoin.P2SHScript ||
+			scriptType == bitcoin.P2WSHScript {
 			// The input is P2SH or P2WSH, so we found a deposit input. All
 			// the deposits should have the same vault set or no vault at all.
 			// If the vault if different than the vault from any previous


### PR DESCRIPTION
## Summary

- replace pkg/maintainer/spv's direct txscript classification with the existing bitcoin.GetScriptType abstraction
- preserve P2PKH, P2WPKH, P2SH, and P2WSH handling
- remove the last direct btcd import from pkg/maintainer/spv

## Testing

- go test ./pkg/bitcoin
- go test ./pkg/maintainer/spv
- go test -count=1 ./pkg/maintainer/...

Fixes #3677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated transaction input classification to use the application’s Bitcoin script type handling.
  * Preserved existing detection and validation behavior for main and deposit inputs.
  * Removed an unnecessary underlying script-processing dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->