### PR TITLE
fix(kube): replace dead keep-test Electrum endpoint

### DIFF
--- a/infrastructure/kube/keep-test/tbtc-v2-maintainer/kustomization.yaml
+++ b/infrastructure/kube/keep-test/tbtc-v2-maintainer/kustomization.yaml
@@ -16,7 +16,7 @@ configMapGenerator:
       - config/tbtc-v2-guardian-0-keyfile
   - name: electrum-api-testnet
     literals:
-      - electrumx-url-wss=wss://electrumx-server.test.tbtc.network:8443
+      - electrumx-url-wss=wss://electrum.testnet.boar.network:443/QxbJgaSLUHqrgAa9BW7bDpnGPxrlhnCa
 
 secretGenerator:
   - name: tbtc-v2-maintainer-eth-accounts-password


### PR DESCRIPTION
## Summary

- replace the unreachable keep-test Electrum WSS endpoint used by the TBTC v2 minter and guardian
- align the deployment with the BOAR testnet endpoint already used by the embedded configuration and integration tests
- preserve the existing ConfigMap and StatefulSet wiring

The legacy endpoint timed out during connection testing, while the replacement completed an Electrum WSS connection successfully.

## Validation

- git diff --check
- repository-wide search confirms the legacy hostname is gone
- kubectl kustomize infrastructure/kube/keep-test/tbtc-v2-maintainer, using temporary placeholder files for the gitignored password secrets
- targeted Electrum WSS integration connection test

Fixes #4163
