### PR TITLE
Replace deprecated elliptic key encoding

### DIFF
--- a/pkg/bitcoin/script_test.go
+++ b/pkg/bitcoin/script_test.go
@@ -1,16 +1,13 @@
 package bitcoin
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
 	"encoding/hex"
 	"fmt"
 	"reflect"
 	"testing"
 
-	"github.com/btcsuite/btcd/btcec"
-
 	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/crypto/secp256k1"
 )
 
 func TestNewScriptFromVarLenData(t *testing.T) {
@@ -161,11 +158,9 @@ func TestPublicKeyHash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	x, y := elliptic.Unmarshal(btcec.S256(), publicKeyBytes)
-	publicKey := &ecdsa.PublicKey{
-		Curve: btcec.S256(),
-		X:     x,
-		Y:     y,
+	publicKey, err := secp256k1.Unmarshal(publicKeyBytes)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	result := PublicKeyHash(publicKey)

--- a/pkg/bitcoin/transaction_test.go
+++ b/pkg/bitcoin/transaction_test.go
@@ -2,14 +2,12 @@ package bitcoin
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"encoding/hex"
 	"reflect"
 	"testing"
 
-	"github.com/btcsuite/btcd/btcec"
-
 	"github.com/keep-network/keep-core/internal/testutils"
+	"github.com/keep-network/keep-core/pkg/crypto/secp256k1"
 )
 
 func TestTransaction_SerializeRoundtrip(t *testing.T) {
@@ -296,10 +294,9 @@ func hexToHash(t *testing.T, hex string) Hash {
 }
 
 func hexToPublicKet(t *testing.T, hex string) *ecdsa.PublicKey {
-	x, y := elliptic.Unmarshal(btcec.S256(), hexToSlice(t, hex))
-	return &ecdsa.PublicKey{
-		Curve: btcec.S256(),
-		X:     x,
-		Y:     y,
+	publicKey, err := secp256k1.Unmarshal(hexToSlice(t, hex))
+	if err != nil {
+		t.Fatal(err)
 	}
+	return publicKey
 }

--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -3,7 +3,6 @@ package ethereum
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -26,6 +25,7 @@ import (
 	ecdsacontract "github.com/keep-network/keep-core/pkg/chain/ethereum/ecdsa/gen/contract"
 	tbtcabi "github.com/keep-network/keep-core/pkg/chain/ethereum/tbtc/gen/abi"
 	tbtccontract "github.com/keep-network/keep-core/pkg/chain/ethereum/tbtc/gen/contract"
+	"github.com/keep-network/keep-core/pkg/crypto/secp256k1"
 	"github.com/keep-network/keep-core/pkg/internal/byteutils"
 	"github.com/keep-network/keep-core/pkg/operator"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
@@ -896,11 +896,7 @@ func (tc *TbtcChain) CalculateDKGResultSignatureHash(
 	misbehavedMembersIndexes []group.MemberIndex,
 	startBlock uint64,
 ) (dkg.ResultSignatureHash, error) {
-	groupPublicKeyBytes := elliptic.Marshal(
-		groupPublicKey.Curve,
-		groupPublicKey.X,
-		groupPublicKey.Y,
-	)
+	groupPublicKeyBytes := secp256k1.Marshal(groupPublicKey)
 	// Crop the 04 prefix as the calculateDKGResultSignatureHash function
 	// expects an unprefixed 64-byte public key,
 	unprefixedGroupPublicKeyBytes := groupPublicKeyBytes[1:]
@@ -1138,11 +1134,7 @@ func (tc *TbtcChain) SubmitInactivityClaim(
 func (tc *TbtcChain) CalculateInactivityClaimHash(
 	claim *inactivity.ClaimPreimage,
 ) (inactivity.ClaimHash, error) {
-	walletPublicKeyBytes := elliptic.Marshal(
-		claim.WalletPublicKey.Curve,
-		claim.WalletPublicKey.X,
-		claim.WalletPublicKey.Y,
-	)
+	walletPublicKeyBytes := secp256k1.Marshal(claim.WalletPublicKey)
 	// Crop the 04 prefix as the calculateInactivityClaimHash function expects
 	// an unprefixed 64-byte public key,
 	unprefixedGroupPublicKeyBytes := walletPublicKeyBytes[1:]

--- a/pkg/crypto/secp256k1/public_key.go
+++ b/pkg/crypto/secp256k1/public_key.go
@@ -4,12 +4,26 @@ package secp256k1
 
 import (
 	"crypto/ecdsa"
+	"crypto/elliptic"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec"
 )
 
 const uncompressedPublicKeyPrefix = byte(0x04)
+
+// isSecp256k1 checks that the given curve parameters describe the secp256k1
+// curve. The comparison uses the field prime and group order instead of the
+// curve name so that keys held with any secp256k1 implementation are
+// accepted, regardless of how that implementation labels itself.
+func isSecp256k1(params *elliptic.CurveParams) bool {
+	s256 := btcec.S256().Params()
+	return params != nil &&
+		params.P != nil &&
+		params.N != nil &&
+		params.P.Cmp(s256.P) == 0 &&
+		params.N.Cmp(s256.N) == 0
+}
 
 // Marshal converts a secp256k1 public key to the 65-byte uncompressed form
 // specified in SEC 1, Version 2.0, Section 2.3.3.
@@ -19,7 +33,7 @@ func Marshal(publicKey *ecdsa.PublicKey) []byte {
 		publicKey.Curve == nil ||
 		publicKey.X == nil ||
 		publicKey.Y == nil ||
-		publicKey.Curve.Params().Name != curve.Params().Name ||
+		!isSecp256k1(publicKey.Curve.Params()) ||
 		publicKey.X.Sign() < 0 ||
 		publicKey.Y.Sign() < 0 ||
 		publicKey.X.Cmp(curve.Params().P) >= 0 ||

--- a/pkg/crypto/secp256k1/public_key.go
+++ b/pkg/crypto/secp256k1/public_key.go
@@ -1,0 +1,53 @@
+// Package secp256k1 provides helpers for encoding and decoding secp256k1
+// public keys.
+package secp256k1
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec"
+)
+
+const uncompressedPublicKeyPrefix = byte(0x04)
+
+// Marshal converts a secp256k1 public key to the 65-byte uncompressed form
+// specified in SEC 1, Version 2.0, Section 2.3.3.
+func Marshal(publicKey *ecdsa.PublicKey) []byte {
+	curve := btcec.S256()
+	if publicKey == nil ||
+		publicKey.Curve == nil ||
+		publicKey.X == nil ||
+		publicKey.Y == nil ||
+		publicKey.Curve.Params().Name != curve.Params().Name ||
+		!curve.IsOnCurve(publicKey.X, publicKey.Y) {
+		panic("invalid secp256k1 public key")
+	}
+
+	return (*btcec.PublicKey)(publicKey).SerializeUncompressed()
+}
+
+// Unmarshal converts a 65-byte uncompressed SEC 1 encoding to a secp256k1
+// public key.
+func Unmarshal(bytes []byte) (*ecdsa.PublicKey, error) {
+	if len(bytes) != btcec.PubKeyBytesLenUncompressed {
+		return nil, fmt.Errorf(
+			"invalid uncompressed public key length: [%v]",
+			len(bytes),
+		)
+	}
+
+	if bytes[0] != uncompressedPublicKeyPrefix {
+		return nil, fmt.Errorf(
+			"invalid uncompressed public key prefix: [0x%x]",
+			bytes[0],
+		)
+	}
+
+	publicKey, err := btcec.ParsePubKey(bytes, btcec.S256())
+	if err != nil {
+		return nil, fmt.Errorf("invalid secp256k1 public key: [%w]", err)
+	}
+
+	return publicKey.ToECDSA(), nil
+}

--- a/pkg/crypto/secp256k1/public_key.go
+++ b/pkg/crypto/secp256k1/public_key.go
@@ -20,6 +20,10 @@ func Marshal(publicKey *ecdsa.PublicKey) []byte {
 		publicKey.X == nil ||
 		publicKey.Y == nil ||
 		publicKey.Curve.Params().Name != curve.Params().Name ||
+		publicKey.X.Sign() < 0 ||
+		publicKey.Y.Sign() < 0 ||
+		publicKey.X.Cmp(curve.Params().P) >= 0 ||
+		publicKey.Y.Cmp(curve.Params().P) >= 0 ||
 		!curve.IsOnCurve(publicKey.X, publicKey.Y) {
 		panic("invalid secp256k1 public key")
 	}

--- a/pkg/crypto/secp256k1/public_key_test.go
+++ b/pkg/crypto/secp256k1/public_key_test.go
@@ -82,6 +82,7 @@ func TestUnmarshalMalformedPublicKey(t *testing.T) {
 
 func TestMarshalRejectsInvalidPublicKey(t *testing.T) {
 	p256 := elliptic.P256()
+	secp256k1 := btcec.S256()
 	tests := map[string]*ecdsa.PublicKey{
 		"nil": nil,
 		"non-secp256k1 curve": {
@@ -90,9 +91,46 @@ func TestMarshalRejectsInvalidPublicKey(t *testing.T) {
 			Y:     p256.Params().Gy,
 		},
 		"point off the curve": {
-			Curve: btcec.S256(),
+			Curve: secp256k1,
 			X:     new(big.Int),
 			Y:     new(big.Int),
+		},
+		"negative x coordinate": {
+			Curve: secp256k1,
+			X:     big.NewInt(-1),
+			Y:     new(big.Int).Set(secp256k1.Params().Gy),
+		},
+		"negative y coordinate": {
+			Curve: secp256k1,
+			X:     new(big.Int).Set(secp256k1.Params().Gx),
+			Y:     big.NewInt(-1),
+		},
+		"oversized x coordinate": {
+			Curve: secp256k1,
+			X: new(big.Int).Add(
+				new(big.Int).Set(secp256k1.Params().P),
+				big.NewInt(1),
+			),
+			Y: new(big.Int).Set(secp256k1.Params().Gy),
+		},
+		"oversized y coordinate": {
+			Curve: secp256k1,
+			X:     new(big.Int).Set(secp256k1.Params().Gx),
+			Y: new(big.Int).Add(
+				new(big.Int).Set(secp256k1.Params().P),
+				big.NewInt(1),
+			),
+		},
+		"shifted generator coordinates": {
+			Curve: secp256k1,
+			X: new(big.Int).Lsh(
+				new(big.Int).Set(secp256k1.Params().Gx),
+				8,
+			),
+			Y: new(big.Int).Lsh(
+				new(big.Int).Set(secp256k1.Params().Gy),
+				8,
+			),
 		},
 	}
 

--- a/pkg/crypto/secp256k1/public_key_test.go
+++ b/pkg/crypto/secp256k1/public_key_test.go
@@ -1,0 +1,110 @@
+package secp256k1
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec"
+)
+
+func TestPublicKeyRoundtrip(t *testing.T) {
+	expected, err := hex.DecodeString(
+		"0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798" +
+			"483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	curve := btcec.S256()
+	publicKey := &ecdsa.PublicKey{
+		Curve: curve,
+		X:     curve.Params().Gx,
+		Y:     curve.Params().Gy,
+	}
+
+	marshaled := Marshal(publicKey)
+	if hex.EncodeToString(marshaled) != hex.EncodeToString(expected) {
+		t.Fatalf(
+			"unexpected public key encoding\nexpected: %x\nactual:   %x",
+			expected,
+			marshaled,
+		)
+	}
+
+	unmarshaled, err := Unmarshal(marshaled)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if unmarshaled.Curve.Params().Name != publicKey.Curve.Params().Name ||
+		unmarshaled.X.Cmp(publicKey.X) != 0 ||
+		unmarshaled.Y.Cmp(publicKey.Y) != 0 {
+		t.Fatal("unexpected public key after roundtrip")
+	}
+}
+
+func TestUnmarshalMalformedPublicKey(t *testing.T) {
+	compressed, err := hex.DecodeString(
+		"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hybrid, err := hex.DecodeString(
+		"0679be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798" +
+			"483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string][]byte{
+		"empty":               nil,
+		"compressed":          compressed,
+		"hybrid":              hybrid,
+		"invalid prefix":      append([]byte{0x05}, make([]byte, 64)...),
+		"point off the curve": append([]byte{0x04}, make([]byte, 64)...),
+	}
+
+	for testName, bytes := range tests {
+		t.Run(testName, func(t *testing.T) {
+			if _, err := Unmarshal(bytes); err == nil {
+				t.Fatal("expected an error for malformed public key")
+			}
+		})
+	}
+}
+
+func TestMarshalRejectsInvalidPublicKey(t *testing.T) {
+	p256 := elliptic.P256()
+	tests := map[string]*ecdsa.PublicKey{
+		"nil": nil,
+		"non-secp256k1 curve": {
+			Curve: p256,
+			X:     p256.Params().Gx,
+			Y:     p256.Params().Gy,
+		},
+		"point off the curve": {
+			Curve: btcec.S256(),
+			X:     new(big.Int),
+			Y:     new(big.Int),
+		},
+	}
+
+	for testName, publicKey := range tests {
+		t.Run(testName, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("expected a panic for an invalid public key")
+				}
+			}()
+
+			Marshal(publicKey)
+		})
+	}
+}

--- a/pkg/crypto/secp256k1/public_key_test.go
+++ b/pkg/crypto/secp256k1/public_key_test.go
@@ -80,6 +80,37 @@ func TestUnmarshalMalformedPublicKey(t *testing.T) {
 	}
 }
 
+func TestMarshalAcceptsRelabeledSecp256k1Curve(t *testing.T) {
+	// A secp256k1 key may be held with a curve implementation that labels
+	// itself differently than btcec (e.g. a plain elliptic.CurveParams
+	// copy). Such keys must marshal successfully because the curve is
+	// identified by its parameters, not by its name.
+	relabeled := *btcec.S256().Params()
+	relabeled.Name = "relabeled-secp256k1"
+
+	publicKey := &ecdsa.PublicKey{
+		Curve: &relabeled,
+		X:     new(big.Int).Set(btcec.S256().Params().Gx),
+		Y:     new(big.Int).Set(btcec.S256().Params().Gy),
+	}
+
+	marshaled := Marshal(publicKey)
+
+	if len(marshaled) != btcec.PubKeyBytesLenUncompressed {
+		t.Fatalf("unexpected marshaled length: [%v]", len(marshaled))
+	}
+
+	unmarshaled, err := Unmarshal(marshaled)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if unmarshaled.X.Cmp(publicKey.X) != 0 ||
+		unmarshaled.Y.Cmp(publicKey.Y) != 0 {
+		t.Fatal("unexpected public key after roundtrip")
+	}
+}
+
 func TestMarshalRejectsInvalidPublicKey(t *testing.T) {
 	p256 := elliptic.P256()
 	secp256k1 := btcec.S256()

--- a/pkg/protocol/inactivity/member_test.go
+++ b/pkg/protocol/inactivity/member_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"encoding/hex"
 	"fmt"
 	"math/big"
@@ -14,9 +13,9 @@ import (
 	"github.com/keep-network/keep-core/internal/testutils"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/chain/local_v1"
+	"github.com/keep-network/keep-core/pkg/crypto/secp256k1"
 	"github.com/keep-network/keep-core/pkg/operator"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
-	"github.com/keep-network/keep-core/pkg/tecdsa"
 )
 
 func TestShouldAcceptMessage(t *testing.T) {
@@ -558,14 +557,10 @@ func (mrs *mockClaimSubmitter) SubmitClaim(
 }
 
 func unmarshalPublicKey(bytes []byte) *ecdsa.PublicKey {
-	x, y := elliptic.Unmarshal(
-		tecdsa.Curve,
-		bytes,
-	)
-
-	return &ecdsa.PublicKey{
-		Curve: tecdsa.Curve,
-		X:     x,
-		Y:     y,
+	publicKey, err := secp256k1.Unmarshal(bytes)
+	if err != nil {
+		panic(err)
 	}
+
+	return publicKey
 }

--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -3,7 +3,6 @@ package tbtc
 import (
 	"bytes"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -18,6 +17,7 @@ import (
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/chain/local_v1"
+	"github.com/keep-network/keep-core/pkg/crypto/secp256k1"
 	"github.com/keep-network/keep-core/pkg/internal/byteutils"
 	"github.com/keep-network/keep-core/pkg/operator"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
@@ -391,11 +391,7 @@ func (lc *localChain) AssembleDKGResult(
 	signatures map[group.MemberIndex][]byte,
 	groupSelectionResult *GroupSelectionResult,
 ) (*DKGChainResult, error) {
-	groupPublicKeyBytes := elliptic.Marshal(
-		groupPublicKey.Curve,
-		groupPublicKey.X,
-		groupPublicKey.Y,
-	)
+	groupPublicKeyBytes := secp256k1.Marshal(groupPublicKey)
 
 	signingMembersIndexes := make([]group.MemberIndex, 0)
 	signaturesConcatenation := make([]byte, 0)

--- a/pkg/tbtc/coordination_test.go
+++ b/pkg/tbtc/coordination_test.go
@@ -284,7 +284,7 @@ func TestCoordinationExecutor_Coordinate(t *testing.T) {
 	operator3 := generateOperator(3)
 
 	coordinatedWallet := wallet{
-		publicKey: unmarshalPublicKey(publicKeyHex),
+		publicKey: mustUnmarshalPublicKey(t, publicKeyHex),
 		signingGroupOperators: []chain.Address{
 			operator2.address,
 			operator3.address,
@@ -461,7 +461,7 @@ func TestCoordinationExecutor_GetSeed(t *testing.T) {
 
 	coordinatedWallet := wallet{
 		// Set only relevant fields.
-		publicKey: unmarshalPublicKey(publicKeyHex),
+		publicKey: mustUnmarshalPublicKey(t, publicKeyHex),
 	}
 
 	executor := &coordinationExecutor{
@@ -952,7 +952,7 @@ func TestCoordinationExecutor_ExecuteLeaderRoutine(t *testing.T) {
 
 	coordinatedWallet := wallet{
 		// Set only relevant fields.
-		publicKey: unmarshalPublicKey(publicKeyHex),
+		publicKey: mustUnmarshalPublicKey(t, publicKeyHex),
 	}
 
 	// Deliberately use an unsorted list of members indexes to make sure the
@@ -1220,7 +1220,7 @@ func TestCoordinationExecutor_ExecuteFollowerRoutine(t *testing.T) {
 	follower2 := generateOperator()
 
 	coordinatedWallet := wallet{
-		publicKey: unmarshalPublicKey(publicKeyHex),
+		publicKey: mustUnmarshalPublicKey(t, publicKeyHex),
 		signingGroupOperators: []chain.Address{
 			follower1.address,
 			follower2.address,
@@ -1460,7 +1460,7 @@ func TestCoordinationExecutor_ExecuteFollowerRoutine_WithIdleLeader(t *testing.T
 	follower2 := generateOperator()
 
 	coordinatedWallet := wallet{
-		publicKey: unmarshalPublicKey(publicKeyHex),
+		publicKey: mustUnmarshalPublicKey(t, publicKeyHex),
 		signingGroupOperators: []chain.Address{
 			follower1,
 			follower2,

--- a/pkg/tbtc/heartbeat_test.go
+++ b/pkg/tbtc/heartbeat_test.go
@@ -60,7 +60,7 @@ func TestHeartbeatAction_HappyPath(t *testing.T) {
 		logger,
 		hostChain,
 		wallet{
-			publicKey: unmarshalPublicKey(walletPublicKeyHex),
+			publicKey: mustUnmarshalPublicKey(t, walletPublicKeyHex),
 		},
 		mockExecutor,
 		proposal,
@@ -139,7 +139,7 @@ func TestHeartbeatAction_OperatorUnstaking(t *testing.T) {
 		logger,
 		hostChain,
 		wallet{
-			publicKey: unmarshalPublicKey(walletPublicKeyHex),
+			publicKey: mustUnmarshalPublicKey(t, walletPublicKeyHex),
 		},
 		mockExecutor,
 		proposal,
@@ -202,7 +202,7 @@ func TestHeartbeatAction_Failure_SigningError(t *testing.T) {
 		logger,
 		hostChain,
 		wallet{
-			publicKey: unmarshalPublicKey(walletPublicKeyHex),
+			publicKey: mustUnmarshalPublicKey(t, walletPublicKeyHex),
 		},
 		mockExecutor,
 		proposal,
@@ -281,7 +281,7 @@ func TestHeartbeatAction_Failure_TooFewActiveOperators(t *testing.T) {
 		logger,
 		hostChain,
 		wallet{
-			publicKey: unmarshalPublicKey(walletPublicKeyHex),
+			publicKey: mustUnmarshalPublicKey(t, walletPublicKeyHex),
 		},
 		mockExecutor,
 		proposal,
@@ -361,7 +361,7 @@ func TestHeartbeatAction_Failure_CounterExceeded(t *testing.T) {
 		logger,
 		hostChain,
 		wallet{
-			publicKey: unmarshalPublicKey(walletPublicKeyHex),
+			publicKey: mustUnmarshalPublicKey(t, walletPublicKeyHex),
 		},
 		mockExecutor,
 		proposal,
@@ -442,7 +442,7 @@ func TestHeartbeatAction_Failure_InactivityExecutionFailure(t *testing.T) {
 		logger,
 		hostChain,
 		wallet{
-			publicKey: unmarshalPublicKey(walletPublicKeyHex),
+			publicKey: mustUnmarshalPublicKey(t, walletPublicKeyHex),
 		},
 		mockExecutor,
 		proposal,

--- a/pkg/tbtc/internal/test/marshaling.go
+++ b/pkg/tbtc/internal/test/marshaling.go
@@ -2,15 +2,15 @@ package test
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"time"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
-	"github.com/keep-network/keep-core/pkg/tecdsa"
+	"github.com/keep-network/keep-core/pkg/crypto/secp256k1"
 )
 
 // UnmarshalJSON implements a custom JSON unmarshaling logic to produce a
@@ -51,15 +51,13 @@ func (dsts *DepositSweepTestScenario) UnmarshalJSON(data []byte) error {
 	dsts.Title = unmarshaled.Title
 
 	// Unmarshal wallet public key.
-	x, y := elliptic.Unmarshal(
-		tecdsa.Curve,
+	walletPublicKey, err := secp256k1.Unmarshal(
 		hexToSlice(unmarshaled.WalletPublicKey),
 	)
-	dsts.WalletPublicKey = &ecdsa.PublicKey{
-		Curve: tecdsa.Curve,
-		X:     x,
-		Y:     y,
+	if err != nil {
+		return fmt.Errorf("cannot unmarshal wallet public key: [%w]", err)
 	}
+	dsts.WalletPublicKey = walletPublicKey
 
 	// Unmarshal wallet private key.
 	dsts.WalletPrivateKey = new(big.Int).SetBytes(
@@ -193,15 +191,13 @@ func (rts *RedemptionTestScenario) UnmarshalJSON(data []byte) error {
 	rts.Title = unmarshaled.Title
 
 	// Unmarshal wallet public key.
-	x, y := elliptic.Unmarshal(
-		tecdsa.Curve,
+	walletPublicKey, err := secp256k1.Unmarshal(
 		hexToSlice(unmarshaled.WalletPublicKey),
 	)
-	rts.WalletPublicKey = &ecdsa.PublicKey{
-		Curve: tecdsa.Curve,
-		X:     x,
-		Y:     y,
+	if err != nil {
+		return fmt.Errorf("cannot unmarshal wallet public key: [%w]", err)
 	}
+	rts.WalletPublicKey = walletPublicKey
 
 	// Unmarshal wallet private key.
 	rts.WalletPrivateKey = new(big.Int).SetBytes(
@@ -299,15 +295,13 @@ func (mfts *MovingFundsTestScenario) UnmarshalJSON(data []byte) error {
 	mfts.Title = unmarshaled.Title
 
 	// Unmarshal wallet public key.
-	x, y := elliptic.Unmarshal(
-		tecdsa.Curve,
+	walletPublicKey, err := secp256k1.Unmarshal(
 		hexToSlice(unmarshaled.WalletPublicKey),
 	)
-	mfts.WalletPublicKey = &ecdsa.PublicKey{
-		Curve: tecdsa.Curve,
-		X:     x,
-		Y:     y,
+	if err != nil {
+		return fmt.Errorf("cannot unmarshal wallet public key: [%w]", err)
 	}
+	mfts.WalletPublicKey = walletPublicKey
 
 	// Unmarshal wallet main UTXO.
 	mfts.WalletMainUtxo = unmarshaled.WalletMainUtxo.convert()
@@ -391,15 +385,13 @@ func (mfts *MovedFundsSweepTestScenario) UnmarshalJSON(data []byte) error {
 	mfts.Title = unmarshaled.Title
 
 	// Unmarshal wallet public key.
-	x, y := elliptic.Unmarshal(
-		tecdsa.Curve,
+	walletPublicKey, err := secp256k1.Unmarshal(
 		hexToSlice(unmarshaled.WalletPublicKey),
 	)
-	mfts.WalletPublicKey = &ecdsa.PublicKey{
-		Curve: tecdsa.Curve,
-		X:     x,
-		Y:     y,
+	if err != nil {
+		return fmt.Errorf("cannot unmarshal wallet public key: [%w]", err)
 	}
+	mfts.WalletPublicKey = walletPublicKey
 
 	// Unmarshal wallet main UTXO.
 	mfts.MovedFundsUtxo = unmarshaled.MovedFundsUtxo.convert()

--- a/pkg/tbtc/marshaling.go
+++ b/pkg/tbtc/marshaling.go
@@ -2,7 +2,6 @@ package tbtc
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"fmt"
 	"math"
 	"math/big"
@@ -12,6 +11,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/keep-network/keep-core/pkg/chain"
+	"github.com/keep-network/keep-core/pkg/crypto/secp256k1"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/tbtc/gen/pb"
 	"github.com/keep-network/keep-core/pkg/tecdsa"
@@ -61,7 +61,10 @@ func (s *signer) Unmarshal(bytes []byte) error {
 		return fmt.Errorf("cannot unmarshal signer: [%w]", err)
 	}
 
-	walletPublicKey := unmarshalPublicKey(pbSigner.Wallet.PublicKey)
+	walletPublicKey, err := unmarshalPublicKey(pbSigner.Wallet.PublicKey)
+	if err != nil {
+		return fmt.Errorf("cannot unmarshal wallet public key: [%w]", err)
+	}
 
 	walletSigningGroupOperators := make(
 		[]chain.Address,
@@ -470,26 +473,13 @@ func marshalPublicKey(publicKey *ecdsa.PublicKey) ([]byte, error) {
 		return nil, errIncompatiblePublicKey
 	}
 
-	return elliptic.Marshal(
-		publicKey.Curve,
-		publicKey.X,
-		publicKey.Y,
-	), nil
+	return secp256k1.Marshal(publicKey), nil
 }
 
 // unmarshalPublicKey converts a byte array (uncompressed) to an ECDSA
 // public key.
-func unmarshalPublicKey(bytes []byte) *ecdsa.PublicKey {
-	x, y := elliptic.Unmarshal(
-		tecdsa.Curve,
-		bytes,
-	)
-
-	return &ecdsa.PublicKey{
-		Curve: tecdsa.Curve,
-		X:     x,
-		Y:     y,
-	}
+func unmarshalPublicKey(bytes []byte) (*ecdsa.PublicKey, error) {
+	return secp256k1.Unmarshal(bytes)
 }
 
 func validateMemberIndex(protoIndex uint32) error {

--- a/pkg/tbtc/marshaling_test.go
+++ b/pkg/tbtc/marshaling_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
@@ -15,7 +16,9 @@ import (
 	"github.com/keep-network/keep-core/internal/testutils"
 	"github.com/keep-network/keep-core/pkg/internal/pbutils"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
+	"github.com/keep-network/keep-core/pkg/tbtc/gen/pb"
 	"github.com/keep-network/keep-core/pkg/tecdsa"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestSignerMarshalling(t *testing.T) {
@@ -46,6 +49,34 @@ func TestSignerMarshalling_NonTECDSAKey(t *testing.T) {
 	_, err := signer.Marshal()
 
 	testutils.AssertErrorsSame(t, errIncompatiblePublicKey, err)
+}
+
+func TestSignerUnmarshalling_InvalidPublicKey(t *testing.T) {
+	marshaled, err := proto.Marshal(&pb.Signer{
+		Wallet: &pb.Wallet{PublicKey: []byte{0x04}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = (&signer{}).Unmarshal(marshaled)
+	if err == nil {
+		t.Fatal("expected an error for a malformed wallet public key")
+	}
+	if !strings.Contains(err.Error(), "cannot unmarshal wallet public key") {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+}
+
+func mustUnmarshalPublicKey(t *testing.T, bytes []byte) *ecdsa.PublicKey {
+	t.Helper()
+
+	publicKey, err := unmarshalPublicKey(bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return publicKey
 }
 
 func TestSigningDoneMessage_MarshalingRoundtrip(t *testing.T) {

--- a/pkg/tbtc/registry.go
+++ b/pkg/tbtc/registry.go
@@ -2,12 +2,12 @@ package tbtc
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"encoding/hex"
 	"fmt"
 	"sync"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/crypto/secp256k1"
 
 	"github.com/keep-network/keep-common/pkg/persistence"
 )
@@ -367,11 +367,7 @@ func (ws *walletStorage) loadSigners() map[string][]*signer {
 // getWalletStorageKey compute the wallet storage key that is used to identify
 // the given wallet for caching and storage purposes.
 func getWalletStorageKey(walletPublicKey *ecdsa.PublicKey) string {
-	walletPublicKeyBytes := elliptic.Marshal(
-		walletPublicKey.Curve,
-		walletPublicKey.X,
-		walletPublicKey.Y,
-	)
+	walletPublicKeyBytes := secp256k1.Marshal(walletPublicKey)
 
 	// Strip the 04 prefix to limit the key length to 128 characters in order
 	// to make it usable as a directory name.

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"encoding/hex"
 	"fmt"
 	"math/big"
@@ -17,6 +16,7 @@ import (
 	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/clientinfo"
+	"github.com/keep-network/keep-core/pkg/crypto/secp256k1"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/tecdsa"
 	"go.uber.org/zap"
@@ -502,11 +502,7 @@ func (w *wallet) membersByOperator(operator chain.Address) []group.MemberIndex {
 }
 
 func (w *wallet) String() string {
-	publicKey := elliptic.Marshal(
-		w.publicKey.Curve,
-		w.publicKey.X,
-		w.publicKey.Y,
-	)
+	publicKey := secp256k1.Marshal(w.publicKey)
 
 	return fmt.Sprintf("public key [0x%x]", publicKey)
 }

--- a/pkg/tecdsa/dkg/protocol_test.go
+++ b/pkg/tecdsa/dkg/protocol_test.go
@@ -3,7 +3,6 @@ package dkg
 import (
 	"bytes"
 	"context"
-	"crypto/elliptic"
 	"encoding/hex"
 	"fmt"
 	"math/big"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/keep-network/keep-core/internal/testutils"
 	"github.com/keep-network/keep-core/pkg/crypto/ephemeral"
+	"github.com/keep-network/keep-core/pkg/crypto/secp256k1"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
@@ -1013,11 +1013,7 @@ func TestTssFinalize(t *testing.T) {
 
 		groupPublicKey := member.Result().PrivateKeyShare.PublicKey()
 
-		groupPublicKeyBytes := elliptic.Marshal(
-			groupPublicKey.Curve,
-			groupPublicKey.X,
-			groupPublicKey.Y,
-		)
+		groupPublicKeyBytes := secp256k1.Marshal(groupPublicKey)
 
 		groupPublicKeys[hex.EncodeToString(groupPublicKeyBytes)] = true
 	}

--- a/pkg/tecdsa/dkg/result.go
+++ b/pkg/tecdsa/dkg/result.go
@@ -2,10 +2,10 @@ package dkg
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"fmt"
 	"sort"
 
+	"github.com/keep-network/keep-core/pkg/crypto/secp256k1"
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/tecdsa"
 )
@@ -42,11 +42,7 @@ func (r *Result) GroupPublicKeyBytes() ([]byte, error) {
 		return nil, err
 	}
 
-	return elliptic.Marshal(
-		publicKey.Curve,
-		publicKey.X,
-		publicKey.Y,
-	), nil
+	return secp256k1.Marshal(publicKey), nil
 }
 
 // MisbehavedMembersIndexes returns the indexes of group members that misbehaved


### PR DESCRIPTION
## Summary

- add a shared secp256k1 public-key codec backed by the existing btcec dependency
- replace all deprecated `elliptic.Marshal` and `elliptic.Unmarshal` calls while preserving the 65-byte uncompressed SEC 1 encoding
- reject compressed, hybrid, wrong-prefix, and off-curve encodings and propagate malformed persisted wallet-key errors

The affected keys use secp256k1, which is not supported by `crypto/ecdh`, so this uses the repository's existing btcec implementation.

## Testing

- `go test ./pkg/crypto/secp256k1 ./pkg/bitcoin ./pkg/chain/ethereum ./pkg/protocol/inactivity ./pkg/tbtc ./pkg/tbtc/internal/test -count=1`
- `go test ./pkg/tecdsa/dkg -run 'Test(TssFinalize|TssRoundTwo_IncomingMessageMissing|TssRoundTwo_SymmetricKeyMissing)$' -count=1`
- Staticcheck 2025.1.1 with `-checks=SA1019 ./...`: 0 deprecated elliptic findings; 58 pre-existing generated-protobuf findings remain

A full local `pkg/tecdsa/dkg` run hit the two timing-sensitive round-one deadline tests listed above under concurrent load; both passed when rerun in isolation with the changed finalization path.

Fixes #3832


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized secp256k1 public-key encoding and decoding.
  * Added validation for malformed and invalid public keys.

* **Bug Fixes**
  * Improved error handling when wallet public keys cannot be decoded.
  * Ensured consistent public-key serialization across Bitcoin, TBTC, and signing workflows.

* **Tests**
  * Added coverage for valid round trips, malformed keys, curve validation, and invalid coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->