### PR TITLE
fix(electrum): replace dead fulcrum tcp integration test server

### DIFF
--- a/pkg/bitcoin/electrum/electrum_integration_test.go
+++ b/pkg/bitcoin/electrum/electrum_integration_test.go
@@ -84,7 +84,7 @@ var testConfigs = map[string]testConfig{
 	},
 	"fulcrum tcp": {
 		clientConfig: electrum.Config{
-			URL:                 "tcp://v22019051929289916.bestsrv.de:50001",
+			URL:                 "tcp://testnet.aranguren.org:51001",
 			RequestTimeout:      requestTimeout * 2,
 			RequestRetryTimeout: requestRetryTimeout * 2,
 		},


### PR DESCRIPTION
## Summary

- replace the dead `fulcrum tcp` public test server used by the Electrum integration test suite
- `v22019051929289916.bestsrv.de:50001` refuses connections, failing every test that connects through it (`TestConnect_Integration`, `TestGetTransaction_Integration`, `TestGetLatestBlockHeight_Integration`, etc.) via `newTestConnection`'s `t.Fatal` on connect failure
- this has been failing `client-integration-test` on `main` for at least the last 5 nightly runs, unrelated to any recent feature work

## Fix

Swapped the dead hostname for `testnet.aranguren.org:51001`, a currently-live public testnet3 Fulcrum server (confirmed via a `server.version` JSON-RPC handshake), keeping the same "fulcrum tcp" category/transport this test config represents.

## Testing

- `go build -tags integration ./pkg/bitcoin/electrum/...`
- `go test -tags integration ./pkg/bitcoin/electrum/... -run 'TestConnect_Integration/fulcrum_tcp$' -v` → PASS against the new endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Electrum test environment to use a new testnet server endpoint.
  * No changes were made to application behavior or test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->