### PR TITLE
fix: quiet noisy WARN logs, add join-failure observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,14 @@ tmp/
 out/
 data/
 logs/
-storage/
+storage/.ralph/
+__pycache__/
+.venv/
+venv/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+target/
+dist/
+build/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,8 @@ tmp/
 out/
 data/
 logs/
-storage/.ralph/
+storage/
+.ralph/
 __pycache__/
 .venv/
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -78,5 +78,4 @@ venv/
 .ruff_cache/
 target/
 dist/
-build/
 .DS_Store

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -104,6 +104,10 @@ func start(cmd *cobra.Command) error {
 		}); ok {
 			setter.SetMetricsRecorder(perfMetrics)
 		}
+
+		// Wire performance metrics into firewall validation so live
+		// on-chain IsRecognized calls are counted.
+		firewall.SetMetricsRecorder(perfMetrics)
 	}
 
 	// Initialize beacon and tbtc only for non-bootstrap nodes.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.24.0
 
 toolchain go1.24.1
 
-
 replace (
 	github.com/bnb-chain/tss-lib => github.com/threshold-network/tss-lib v0.0.0-20230901144531-2e712689cfbe
 	// btcd in version v.0.23 extracted `btcd/btcec` to a separate package `btcd/btcec/v2`.
@@ -217,7 +216,7 @@ require (
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
+	golang.org/x/time v0.5.0
 	golang.org/x/tools v0.29.0 // indirect
 	gonum.org/v1/gonum v0.15.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/infrastructure/kube/keep-prd/monitoring/grafana/dashboards/keep/keep-nodes.json
+++ b/infrastructure/kube/keep-prd/monitoring/grafana/dashboards/keep/keep-nodes.json
@@ -970,6 +970,221 @@
             ],
             "title": "Uptime (experimental)",
             "type": "state-timeline"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P09205B1DD12FB1C6"
+            },
+            "description": "Inbound network join requests across all monitored nodes, with the failure-reason breakdown. A high failure share is expected: unrecognized peers probing the network are rejected by the on-chain firewall check. Investigate when the mix shifts (e.g. firewall rpc error or timeout growth) or when bursts coincide with peer loss.",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineStyle": {
+                            "fill": "solid"
+                        },
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 20,
+                "w": 11,
+                "x": 0,
+                "y": 81
+            },
+            "id": 15,
+            "interval": "1m",
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "last"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true,
+                    "sortBy": "Last",
+                    "sortDesc": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "total",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_success_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "success",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_failed_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "failed",
+                    "range": true,
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_failed_timeout_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "failed: timeout",
+                    "range": true,
+                    "refId": "D"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_failed_eof_reset_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "failed: eof/reset",
+                    "range": true,
+                    "refId": "E"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_failed_protocol_crypto_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "failed: protocol/crypto",
+                    "range": true,
+                    "refId": "F"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_failed_firewall_unrecognized_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "failed: firewall unrecognized",
+                    "range": true,
+                    "refId": "G"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_failed_firewall_rpc_error_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "failed: firewall rpc error",
+                    "range": true,
+                    "refId": "H"
+                }
+            ],
+            "title": "Network Join Requests (per 10m)",
+            "type": "timeseries"
         }
     ],
     "refresh": false,

--- a/infrastructure/kube/keep-prd/monitoring/prometheus/config/config.yaml
+++ b/infrastructure/kube/keep-prd/monitoring/prometheus/config/config.yaml
@@ -2,6 +2,8 @@ global:
   scrape_interval: 1m
   scrape_timeout: 10s
   evaluation_interval: 1m
+rule_files:
+  - /etc/prometheus/rules.yaml
 scrape_configs:
   - job_name: keep-discovered-nodes
     honor_timestamps: true

--- a/infrastructure/kube/keep-prd/monitoring/prometheus/config/rules.yaml
+++ b/infrastructure/kube/keep-prd/monitoring/prometheus/config/rules.yaml
@@ -1,5 +1,4 @@
 groups:
-  # TODO: Define some common rules to record: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
   - name: keep-network-join-requests
     rules:
       # Fires only when an abnormal burst of inbound join-request failures

--- a/infrastructure/kube/keep-prd/monitoring/prometheus/kustomization.yaml
+++ b/infrastructure/kube/keep-prd/monitoring/prometheus/kustomization.yaml
@@ -13,6 +13,7 @@ configMapGenerator:
   - name: prometheus-config
     files:
       - config/config.yaml
+      - config/rules.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/infrastructure/kube/keep-test/monitoring/grafana/dashboards/keep/keep-network-nodes.json
+++ b/infrastructure/kube/keep-test/monitoring/grafana/dashboards/keep/keep-network-nodes.json
@@ -1019,6 +1019,221 @@
             ],
             "title": "Node Instances",
             "type": "state-timeline"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P09205B1DD12FB1C6"
+            },
+            "description": "Inbound network join requests across all monitored nodes, with the failure-reason breakdown. A high failure share is expected: unrecognized peers probing the network are rejected by the on-chain firewall check. Investigate when the mix shifts (e.g. firewall rpc error or timeout growth) or when bursts coincide with peer loss.",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineStyle": {
+                            "fill": "solid"
+                        },
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 20,
+                "w": 11,
+                "x": 0,
+                "y": 81
+            },
+            "id": 15,
+            "interval": "1m",
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "last"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true,
+                    "sortBy": "Last",
+                    "sortDesc": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "total",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_success_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "success",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_failed_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "failed",
+                    "range": true,
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_failed_timeout_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "failed: timeout",
+                    "range": true,
+                    "refId": "D"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_failed_eof_reset_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "failed: eof/reset",
+                    "range": true,
+                    "refId": "E"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_failed_protocol_crypto_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "failed: protocol/crypto",
+                    "range": true,
+                    "refId": "F"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_failed_firewall_unrecognized_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "failed: firewall unrecognized",
+                    "range": true,
+                    "refId": "G"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P09205B1DD12FB1C6"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(increase(performance_network_join_requests_failed_firewall_rpc_error_total{job=\"keep-discovered-nodes\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "failed: firewall rpc error",
+                    "range": true,
+                    "refId": "H"
+                }
+            ],
+            "title": "Network Join Requests (per 10m)",
+            "type": "timeseries"
         }
     ],
     "refresh": false,

--- a/pkg/clientinfo/performance.go
+++ b/pkg/clientinfo/performance.go
@@ -138,7 +138,13 @@ func (pm *PerformanceMetrics) registerAllMetrics() {
 		MetricNetworkJoinRequestsSuccessTotal,
 		MetricNetworkJoinRequestsFailedTotal,
 		MetricFirewallRejectionsTotal,
+		MetricFirewallOnChainChecksTotal,
 		MetricWalletDispatcherRejectedTotal,
+	}
+
+	// Register per-reason network join failure counters
+	for _, reason := range GetAllNetworkJoinFailureReasons() {
+		counters = append(counters, NetworkJoinFailureMetricName(reason))
 	}
 
 	// First, initialize all counters in the map
@@ -673,6 +679,7 @@ const (
 	MetricNetworkJoinRequestsFailedTotal  = "network_join_requests_failed_total"  // Failed joins (handshake failure)
 	MetricNetworkHandshakeDurationSeconds = "network_handshake_duration_seconds"  // Handshake duration
 	MetricFirewallRejectionsTotal         = "firewall_rejections_total"           // Firewall rejections
+	MetricFirewallOnChainChecksTotal      = "firewall_onchain_checks_total"       // Live on-chain IsRecognized calls
 
 	// Wallet Dispatcher Metrics
 	MetricWalletDispatcherActiveActions = "wallet_dispatcher_active_actions"
@@ -687,11 +694,52 @@ const (
 	MetricSwapUtilizationPercent = "swap_utilization_percent"
 )
 
+// Network join request failure reasons. These are the low-cardinality
+// dimensions of MetricNetworkJoinRequestsFailedTotal, exposed as per-reason
+// counters generated with NetworkJoinFailureMetricName. They tell apart the
+// distinct causes that the aggregate failed-joins counter conflates.
+const (
+	// JoinFailureReasonTimeout is a handshake aborted by an I/O deadline.
+	JoinFailureReasonTimeout = "timeout"
+	// JoinFailureReasonEOFReset is a connection closed or reset mid-handshake.
+	JoinFailureReasonEOFReset = "eof_reset"
+	// JoinFailureReasonProtocolCrypto is a handshake protocol violation or a
+	// cryptographic failure (bad signature, key mismatch, malformed message).
+	JoinFailureReasonProtocolCrypto = "protocol_crypto"
+	// JoinFailureReasonFirewallUnrecognized is a peer rejected because no
+	// application recognizes its operator (including negative-cache hits).
+	JoinFailureReasonFirewallUnrecognized = "firewall_unrecognized"
+	// JoinFailureReasonFirewallRPCError is a firewall validation aborted by
+	// an application/RPC error rather than a genuine non-recognition.
+	JoinFailureReasonFirewallRPCError = "firewall_rpc_error"
+)
+
 // WalletActionMetricName generates a metric name for a specific wallet action type.
 // actionType should be the string representation of the action (e.g., "heartbeat", "deposit_sweep").
 // metricType should be one of: "total", "success_total", "failed_total", "duration_seconds"
 func WalletActionMetricName(actionType string, metricType string) string {
 	return fmt.Sprintf("wallet_action_%s_%s", actionType, metricType)
+}
+
+// NetworkJoinFailureMetricName generates the per-reason counter name for a
+// network join request failure. reason should be one of the
+// JoinFailureReason* constants.
+// Format: network_join_requests_failed_{reason}_total
+// Example: network_join_requests_failed_timeout_total
+func NetworkJoinFailureMetricName(reason string) string {
+	return fmt.Sprintf("network_join_requests_failed_%s_total", reason)
+}
+
+// GetAllNetworkJoinFailureReasons returns all network join request failure
+// reasons that should be tracked.
+func GetAllNetworkJoinFailureReasons() []string {
+	return []string{
+		JoinFailureReasonTimeout,
+		JoinFailureReasonEOFReset,
+		JoinFailureReasonProtocolCrypto,
+		JoinFailureReasonFirewallUnrecognized,
+		JoinFailureReasonFirewallRPCError,
+	}
 }
 
 // GetAllWalletActionTypes returns all wallet action types that should be tracked.

--- a/pkg/clientinfo/performance_test.go
+++ b/pkg/clientinfo/performance_test.go
@@ -372,3 +372,61 @@ func TestContextCancelation(t *testing.T) {
 	pm.SetGauge(MetricIncomingMessageQueueSize, 5)
 	pm.RecordDuration("signing_duration_seconds", 100*time.Millisecond)
 }
+
+// TestNetworkJoinFailureMetricName tests per-reason join failure counter
+// name generation.
+func TestNetworkJoinFailureMetricName(t *testing.T) {
+	tests := map[string]string{
+		JoinFailureReasonTimeout:              "network_join_requests_failed_timeout_total",
+		JoinFailureReasonEOFReset:             "network_join_requests_failed_eof_reset_total",
+		JoinFailureReasonProtocolCrypto:       "network_join_requests_failed_protocol_crypto_total",
+		JoinFailureReasonFirewallUnrecognized: "network_join_requests_failed_firewall_unrecognized_total",
+		JoinFailureReasonFirewallRPCError:     "network_join_requests_failed_firewall_rpc_error_total",
+	}
+
+	for reason, expectedName := range tests {
+		if actualName := NetworkJoinFailureMetricName(reason); actualName != expectedName {
+			t.Errorf(
+				"unexpected metric name for reason %s\nexpected: %s\nactual: %s",
+				reason,
+				expectedName,
+				actualName,
+			)
+		}
+	}
+}
+
+// TestJoinFailureAndOnChainCountersRegistered tests that the per-reason join
+// failure counters and the firewall on-chain checks counter are registered
+// upfront so they appear in the metrics endpoint before any increment.
+func TestJoinFailureAndOnChainCountersRegistered(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	registry := &Registry{keepclientinfo.NewRegistry(), ctx}
+	pm := NewPerformanceMetrics(ctx, registry)
+
+	expectedCounters := []string{MetricFirewallOnChainChecksTotal}
+	for _, reason := range GetAllNetworkJoinFailureReasons() {
+		expectedCounters = append(expectedCounters, NetworkJoinFailureMetricName(reason))
+	}
+
+	for _, counterName := range expectedCounters {
+		pm.countersMutex.RLock()
+		_, exists := pm.counters[counterName]
+		pm.countersMutex.RUnlock()
+		if !exists {
+			t.Errorf("counter %s should be registered upfront", counterName)
+			continue
+		}
+
+		if value := pm.GetCounterValue(counterName); value != 0 {
+			t.Errorf("counter %s should start at 0, got %v", counterName, value)
+		}
+
+		pm.IncrementCounter(counterName, 1)
+		if value := pm.GetCounterValue(counterName); value != 1 {
+			t.Errorf("counter %s should increment to 1, got %v", counterName, value)
+		}
+	}
+}

--- a/pkg/clientinfo/rpc_health.go
+++ b/pkg/clientinfo/rpc_health.go
@@ -3,6 +3,7 @@ package clientinfo
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sync"
 	"time"
 
@@ -13,6 +14,28 @@ import (
 )
 
 var rpcHealthLogger = log.Logger("keep-rpc-health")
+
+// benignBtcHeaderErrorPattern matches the JSON-RPC error code -32602
+// ("invalid params") returned by some Electrum servers that reject the
+// `cp_height` parameter of `blockchain.block.header`. The condition is
+// known-benign: the endpoint is reachable and serving data
+// (GetLatestBlockHeight already succeeded in the same check), the server
+// just does not support that parameter. Such errors are counted and logged
+// at debug level instead of warning to avoid flooding logs on every
+// health-check tick.
+//
+// The underlying JSON-RPC error type is not exported by the Electrum client
+// library, so the code is matched against the library's serialized error
+// form (`errNo: %d, errMsg: %s`). The match is anchored to the `errNo`
+// field with token boundaries so adjacent codes (e.g. -326020) or the
+// digits appearing elsewhere in an unrelated message do not match.
+var benignBtcHeaderErrorPattern = regexp.MustCompile(`\berrNo: -32602\b`)
+
+// isKnownBenignBtcHeaderError returns true if the GetBlockHeader health-check
+// error is the known-benign JSON-RPC -32602 ("invalid params") response.
+func isKnownBenignBtcHeaderError(err error) bool {
+	return err != nil && benignBtcHeaderErrorPattern.MatchString(err.Error())
+}
 
 // RPCHealthChecker performs periodic health checks on Ethereum and Bitcoin RPC endpoints
 // by making actual RPC calls (not just ICMP ping) to verify the services are working.
@@ -33,7 +56,11 @@ type RPCHealthChecker struct {
 	btcLastSuccess  time.Time
 	btcLastError    error
 	btcLastDuration time.Duration // Last successful RPC call duration
-	btcMutex        sync.RWMutex
+	// Count of known-benign -32602 GetBlockHeader errors observed. Kept as
+	// a counter so the condition remains observable through metrics even
+	// though it is no longer logged at warning level.
+	btcBenignHeaderErrors float64
+	btcMutex              sync.RWMutex
 
 	// Configuration
 	checkInterval time.Duration
@@ -221,15 +248,29 @@ func (r *RPCHealthChecker) checkBitcoinHealth(ctx context.Context) {
 	_, err = r.btcChain.GetBlockHeader(latestHeight)
 	if err != nil {
 		headerErr := fmt.Errorf("failed to get block header for height %d: %w", latestHeight, err)
+		benign := isKnownBenignBtcHeaderError(err)
 		r.btcMutex.Lock()
 		r.btcLastCheck = startTime
 		r.btcLastError = headerErr
+		if benign {
+			r.btcBenignHeaderErrors++
+		}
 		r.btcMutex.Unlock()
-		rpcHealthLogger.Warnf(
-			"Bitcoin RPC health check failed (GetBlockHeader): [%v] (duration: %v)",
-			headerErr,
-			time.Since(startTime),
-		)
+		if benign {
+			rpcHealthLogger.Debugf(
+				"Bitcoin RPC health check failed (GetBlockHeader) with "+
+					"known-benign -32602 response (server does not support "+
+					"the cp_height parameter): [%v] (duration: %v)",
+				headerErr,
+				time.Since(startTime),
+			)
+		} else {
+			rpcHealthLogger.Warnf(
+				"Bitcoin RPC health check failed (GetBlockHeader): [%v] (duration: %v)",
+				headerErr,
+				time.Since(startTime),
+			)
+		}
 		return
 	}
 
@@ -267,6 +308,15 @@ func (r *RPCHealthChecker) GetBitcoinHealthStatus() (isHealthy bool, lastCheck t
 	return isHealthy, r.btcLastCheck, r.btcLastSuccess, r.btcLastError, r.btcLastDuration
 }
 
+// GetBitcoinBenignHeaderErrorCount returns the number of known-benign -32602
+// GetBlockHeader errors observed by the Bitcoin health check.
+func (r *RPCHealthChecker) GetBitcoinBenignHeaderErrorCount() float64 {
+	r.btcMutex.RLock()
+	defer r.btcMutex.RUnlock()
+
+	return r.btcBenignHeaderErrors
+}
+
 // registerMetrics registers metrics observers for RPC health status.
 func (r *RPCHealthChecker) registerMetrics() {
 	// Ethereum RPC response time
@@ -287,6 +337,17 @@ func (r *RPCHealthChecker) registerMetrics() {
 			"rpc_btc_response_time_seconds": func() float64 {
 				_, _, _, _, lastDuration := r.GetBitcoinHealthStatus()
 				return lastDuration.Seconds()
+			},
+		},
+	)
+
+	// Known-benign -32602 GetBlockHeader errors. Kept observable as a
+	// counter since they are no longer logged at warning level.
+	r.registry.ObserveApplicationSource(
+		"performance",
+		map[string]Source{
+			"rpc_btc_health_check_benign_errors_total": func() float64 {
+				return r.GetBitcoinBenignHeaderErrorCount()
 			},
 		},
 	)

--- a/pkg/clientinfo/rpc_health_test.go
+++ b/pkg/clientinfo/rpc_health_test.go
@@ -1,10 +1,16 @@
 package clientinfo
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	log2 "github.com/ipfs/go-log/v2"
 
 	keepclientinfo "github.com/keep-network/keep-common/pkg/clientinfo"
 	"github.com/keep-network/keep-core/pkg/bitcoin"
@@ -329,6 +335,193 @@ func TestRPCHealthChecker_BitcoinHealthTransition(t *testing.T) {
 	}
 	if lastSuccess.IsZero() {
 		t.Error("expected lastSuccess to be updated on recovery")
+	}
+}
+
+// --- log capture helper ---
+
+type capturedLogEntry struct {
+	Level   string `json:"level"`
+	Logger  string `json:"logger"`
+	Message string `json:"msg"`
+}
+
+// captureLogs runs fn while capturing log entries emitted by the given
+// logger subsystem and returns the captured entries.
+func captureLogs(t *testing.T, subsystem string, fn func()) []capturedLogEntry {
+	t.Helper()
+
+	if err := log2.SetLogLevel(subsystem, "debug"); err != nil {
+		t.Fatal(err)
+	}
+
+	pipe := log2.NewPipeReader()
+
+	var mutex sync.Mutex
+	var entries []capturedLogEntry
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		scanner := bufio.NewScanner(pipe)
+		for scanner.Scan() {
+			var entry capturedLogEntry
+			if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+				continue
+			}
+			if entry.Logger != subsystem {
+				continue
+			}
+			mutex.Lock()
+			entries = append(entries, entry)
+			mutex.Unlock()
+		}
+	}()
+
+	fn()
+
+	if err := pipe.Close(); err != nil {
+		t.Logf("could not close log pipe reader: %v", err)
+	}
+	<-done
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	return append([]capturedLogEntry(nil), entries...)
+}
+
+func countLogEntries(
+	entries []capturedLogEntry,
+	level string,
+	messageFragment string,
+) int {
+	count := 0
+	for _, entry := range entries {
+		if entry.Level == level &&
+			strings.Contains(entry.Message, messageFragment) {
+			count++
+		}
+	}
+	return count
+}
+
+// --- Bitcoin benign -32602 header error tests ---
+
+func TestRPCHealthChecker_BitcoinBenignHeaderError_LoggedAtDebugAndCounted(t *testing.T) {
+	btc := &fakeBitcoinChain{
+		latestHeight: 800000,
+		headerErr: fmt.Errorf(
+			"failed to get block header: [errNo: -32602, errMsg: Invalid params]",
+		),
+	}
+	checker := newTestChecker(nil, btc)
+
+	entries := captureLogs(t, "keep-rpc-health", func() {
+		checker.checkBitcoinHealth(context.Background())
+	})
+
+	if warns := countLogEntries(entries, "warn", "GetBlockHeader"); warns != 0 {
+		t.Errorf(
+			"known-benign -32602 header error should not be logged "+
+				"at warning level, got %d warning entries",
+			warns,
+		)
+	}
+	if debugs := countLogEntries(entries, "debug", "known-benign"); debugs != 1 {
+		t.Errorf(
+			"expected 1 debug entry for known-benign -32602 header error, "+
+				"got %d",
+			debugs,
+		)
+	}
+
+	if count := checker.GetBitcoinBenignHeaderErrorCount(); count != 1 {
+		t.Errorf("expected benign error count 1, got %v", count)
+	}
+
+	// Health state semantics are unchanged: the check still records the
+	// error and reports unhealthy.
+	healthy, _, _, lastErr, _ := checker.GetBitcoinHealthStatus()
+	if healthy {
+		t.Error("expected unhealthy when GetBlockHeader fails")
+	}
+	if lastErr == nil {
+		t.Error("expected error to be stored for benign header failure")
+	}
+
+	// A subsequent benign failure increments the counter again.
+	checker.checkBitcoinHealth(context.Background())
+	if count := checker.GetBitcoinBenignHeaderErrorCount(); count != 2 {
+		t.Errorf("expected benign error count 2 after second check, got %v", count)
+	}
+}
+
+func TestRPCHealthChecker_BitcoinOtherHeaderErrors_StillLoggedAtWarn(t *testing.T) {
+	tests := map[string]error{
+		"other JSON-RPC error code": fmt.Errorf(
+			"failed to get block header: [errNo: -32600, errMsg: Invalid request]",
+		),
+		"adjacent JSON-RPC error code": fmt.Errorf(
+			"failed to get block header: [errNo: -326020, errMsg: Invalid params]",
+		),
+		"unrelated message containing the benign code digits": fmt.Errorf(
+			"connection reset by peer at offset -32602",
+		),
+		"non JSON-RPC error": fmt.Errorf("connection refused"),
+	}
+
+	for testName, headerErr := range tests {
+		t.Run(testName, func(t *testing.T) {
+			btc := &fakeBitcoinChain{
+				latestHeight: 800000,
+				headerErr:    headerErr,
+			}
+			checker := newTestChecker(nil, btc)
+
+			entries := captureLogs(t, "keep-rpc-health", func() {
+				checker.checkBitcoinHealth(context.Background())
+			})
+
+			if warns := countLogEntries(entries, "warn", "GetBlockHeader"); warns != 1 {
+				t.Errorf(
+					"expected 1 warning entry for non-benign header error, "+
+						"got %d",
+					warns,
+				)
+			}
+
+			if count := checker.GetBitcoinBenignHeaderErrorCount(); count != 0 {
+				t.Errorf(
+					"benign error count should not change for non-benign "+
+						"errors, got %v",
+					count,
+				)
+			}
+		})
+	}
+}
+
+func TestIsKnownBenignBtcHeaderError(t *testing.T) {
+	tests := map[string]struct {
+		err      error
+		expected bool
+	}{
+		"nil error":                      {nil, false},
+		"-32602 code":                    {fmt.Errorf("errNo: -32602, errMsg: Invalid params"), true},
+		"-32602 code wrapped":            {fmt.Errorf("failed to get block header: [errNo: -32602, errMsg: x]"), true},
+		"-32602 code at end of message":  {fmt.Errorf("errNo: -32602"), true},
+		"other JSON-RPC code":            {fmt.Errorf("errNo: -32600, errMsg: Invalid request"), false},
+		"adjacent longer numeric code":   {fmt.Errorf("errNo: -326020, errMsg: Invalid params"), false},
+		"digits outside the errNo field": {fmt.Errorf("connection reset by peer at offset -32602"), false},
+		"unrelated error message":        {fmt.Errorf("connection refused"), false},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			if actual := isKnownBenignBtcHeaderError(test.err); actual != test.expected {
+				t.Errorf("expected %v, got %v", test.expected, actual)
+			}
+		})
 	}
 }
 

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -2,9 +2,11 @@ package firewall
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/keep-network/keep-common/pkg/cache"
+	"github.com/keep-network/keep-core/pkg/clientinfo"
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/operator"
 )
@@ -66,9 +68,41 @@ const (
 	NegativeIsRecognizedCachePeriod = 1 * time.Hour
 )
 
-var errNotRecognized = fmt.Errorf(
+// ErrNotRecognized is returned by Validate when the remote peer is not
+// recognized by any application. It lets callers tell a genuine
+// non-recognition apart from an application/RPC error during validation.
+var ErrNotRecognized = fmt.Errorf(
 	"remote peer has not been recognized by any application",
 )
+
+// globalMetricsRecorder allows recording firewall metrics without threading
+// a recorder through construction; the firewall is created before the
+// metrics subsystem. It can be nil if metrics are not enabled.
+var (
+	globalMetricsRecorderMu sync.RWMutex
+	globalMetricsRecorder   interface {
+		IncrementCounter(name string, value float64)
+	}
+)
+
+// SetMetricsRecorder sets the metrics recorder used by firewall validation.
+// It should be called once during startup, after metrics are initialized.
+func SetMetricsRecorder(recorder interface {
+	IncrementCounter(name string, value float64)
+}) {
+	globalMetricsRecorderMu.Lock()
+	defer globalMetricsRecorderMu.Unlock()
+	globalMetricsRecorder = recorder
+}
+
+// getMetricsRecorder safely retrieves the metrics recorder.
+func getMetricsRecorder() interface {
+	IncrementCounter(name string, value float64)
+} {
+	globalMetricsRecorderMu.RLock()
+	defer globalMetricsRecorderMu.RUnlock()
+	return globalMetricsRecorder
+}
 
 func AnyApplicationPolicy(
 	applications []Application,
@@ -115,11 +149,18 @@ func (aap *anyApplicationPolicy) Validate(
 	remotePeerPublicKeyHex := remotePeerPublicKey.String()
 
 	if aap.negativeResultCache.Has(remotePeerPublicKeyHex) {
-		return errNotRecognized
+		return ErrNotRecognized
 	}
 
 	validationSuccessful := false
 	for _, application := range aap.applications {
+		// Count the live on-chain check. The negative-cache short-circuit
+		// above and the allowlist bypass issue no chain call and are
+		// intentionally not counted here.
+		if recorder := getMetricsRecorder(); recorder != nil {
+			recorder.IncrementCounter(clientinfo.MetricFirewallOnChainChecksTotal, 1)
+		}
+
 		isRecognized, err := application.IsRecognized(remotePeerPublicKey)
 		if err != nil {
 			return fmt.Errorf(
@@ -137,7 +178,7 @@ func (aap *anyApplicationPolicy) Validate(
 		// Add this address to the negative result cache.
 		// `IsRecognized` will not be called again for the entire caching period.
 		aap.negativeResultCache.Add(remotePeerPublicKeyHex)
-		return errNotRecognized
+		return ErrNotRecognized
 	}
 
 	return nil

--- a/pkg/firewall/firewall_test.go
+++ b/pkg/firewall/firewall_test.go
@@ -2,12 +2,14 @@ package firewall
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/keep-network/keep-common/pkg/cache"
 	"github.com/keep-network/keep-core/internal/testutils"
 	"github.com/keep-network/keep-core/pkg/chain/local_v1"
+	"github.com/keep-network/keep-core/pkg/clientinfo"
 	"github.com/keep-network/keep-core/pkg/operator"
 )
 
@@ -28,7 +30,7 @@ func TestValidate_PeerNotRecognized_NoApplications(t *testing.T) {
 	}
 
 	err = policy.Validate(peerOperatorPublicKey)
-	testutils.AssertErrorsSame(t, errNotRecognized, err)
+	testutils.AssertErrorsSame(t, ErrNotRecognized, err)
 }
 
 func TestValidate_PeerNotRecognized_MultipleApplications(t *testing.T) {
@@ -48,7 +50,7 @@ func TestValidate_PeerNotRecognized_MultipleApplications(t *testing.T) {
 	}
 
 	err = policy.Validate(peerOperatorPublicKey)
-	testutils.AssertErrorsSame(t, errNotRecognized, err)
+	testutils.AssertErrorsSame(t, ErrNotRecognized, err)
 }
 
 func TestValidate_PeerRecognized_FirstApplicationRecognizes(t *testing.T) {
@@ -177,7 +179,7 @@ func TestValidate_PeerRecognized_Rechecked(t *testing.T) {
 	})
 
 	err = policy.Validate(peerOperatorPublicKey)
-	testutils.AssertErrorsSame(t, errNotRecognized, err)
+	testutils.AssertErrorsSame(t, ErrNotRecognized, err)
 }
 
 func TestValidate_PeerNotRecognized_CacheEmptied(t *testing.T) {
@@ -216,7 +218,7 @@ func TestValidate_PeerNotRecognized_CacheEmptied(t *testing.T) {
 	time.Sleep(cachingPeriod)
 
 	err = policy.Validate(peerOperatorPublicKey)
-	testutils.AssertErrorsSame(t, errNotRecognized, err)
+	testutils.AssertErrorsSame(t, ErrNotRecognized, err)
 }
 
 func TestValidate_PeerNotRecognized_Cached(t *testing.T) {
@@ -235,7 +237,7 @@ func TestValidate_PeerNotRecognized_Cached(t *testing.T) {
 	}
 
 	err = policy.Validate(peerOperatorPublicKey)
-	testutils.AssertErrorsSame(t, errNotRecognized, err)
+	testutils.AssertErrorsSame(t, ErrNotRecognized, err)
 
 	// Ensure the application recognizes the operator, but the validation should
 	// fail since the result from the previous call has been cached.
@@ -245,7 +247,7 @@ func TestValidate_PeerNotRecognized_Cached(t *testing.T) {
 	})
 
 	err = policy.Validate(peerOperatorPublicKey)
-	testutils.AssertErrorsSame(t, errNotRecognized, err)
+	testutils.AssertErrorsSame(t, ErrNotRecognized, err)
 }
 
 func TestValidate_PeerRecognized_CacheEmptied(t *testing.T) {
@@ -269,7 +271,7 @@ func TestValidate_PeerRecognized_CacheEmptied(t *testing.T) {
 	}
 
 	err = policy.Validate(peerOperatorPublicKey)
-	testutils.AssertErrorsSame(t, errNotRecognized, err)
+	testutils.AssertErrorsSame(t, ErrNotRecognized, err)
 
 	// Ensure the application recognizes the operator. Wait for the caching
 	// period to elapse. The validation should pass since the result from the
@@ -358,7 +360,7 @@ func TestValidate_EmptyAllowList_UnrecognizedPeerRejected(t *testing.T) {
 	}
 
 	err = policy.Validate(peerOperatorPublicKey)
-	testutils.AssertErrorsSame(t, errNotRecognized, err)
+	testutils.AssertErrorsSame(t, ErrNotRecognized, err)
 }
 
 func TestValidate_EmptyAllowList_PreviouslyAllowlistedPeerMustPassIsRecognized(t *testing.T) {
@@ -380,7 +382,197 @@ func TestValidate_EmptyAllowList_PreviouslyAllowlistedPeerMustPassIsRecognized(t
 	}
 
 	err = policy.Validate(peerOperatorPublicKey)
-	testutils.AssertErrorsSame(t, errNotRecognized, err)
+	testutils.AssertErrorsSame(t, ErrNotRecognized, err)
+}
+
+// --- on-chain IsRecognized call counter tests ---
+
+type fakeMetricsRecorder struct {
+	mutex    sync.Mutex
+	counters map[string]float64
+}
+
+func newFakeMetricsRecorder() *fakeMetricsRecorder {
+	return &fakeMetricsRecorder{
+		counters: make(map[string]float64),
+	}
+}
+
+func (f *fakeMetricsRecorder) IncrementCounter(name string, value float64) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	f.counters[name] += value
+}
+
+func (f *fakeMetricsRecorder) counterValue(name string) float64 {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	return f.counters[name]
+}
+
+// setTestMetricsRecorder installs a fake metrics recorder for the duration
+// of the test and removes it on cleanup.
+func setTestMetricsRecorder(t *testing.T) *fakeMetricsRecorder {
+	t.Helper()
+
+	recorder := newFakeMetricsRecorder()
+	SetMetricsRecorder(recorder)
+	t.Cleanup(func() {
+		SetMetricsRecorder(nil)
+	})
+
+	return recorder
+}
+
+func TestValidate_OnChainCheckCounter_LiveCallCounted(t *testing.T) {
+	recorder := setTestMetricsRecorder(t)
+
+	_, peerOperatorPublicKey, err := operator.GenerateKeyPair(
+		local_v1.DefaultCurve,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	application := newMockApplication()
+	application.setIsRecognized(peerOperatorPublicKey, result{
+		isRecognized: true,
+		err:          nil,
+	})
+
+	policy := &anyApplicationPolicy{
+		applications:        []Application{application},
+		allowList:           EmptyAllowList(),
+		negativeResultCache: cache.NewTimeCache(cachingPeriod),
+	}
+
+	err = policy.Validate(peerOperatorPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if count := recorder.counterValue(
+		clientinfo.MetricFirewallOnChainChecksTotal,
+	); count != 1 {
+		t.Errorf("expected 1 on-chain check counted, got %v", count)
+	}
+}
+
+func TestValidate_OnChainCheckCounter_NegativeCacheHitNotCounted(t *testing.T) {
+	recorder := setTestMetricsRecorder(t)
+
+	_, peerOperatorPublicKey, err := operator.GenerateKeyPair(
+		local_v1.DefaultCurve,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	policy := &anyApplicationPolicy{
+		applications:        []Application{newMockApplication()},
+		allowList:           EmptyAllowList(),
+		negativeResultCache: cache.NewTimeCache(cachingPeriod),
+	}
+
+	// First validation makes a live check and caches the negative result.
+	err = policy.Validate(peerOperatorPublicKey)
+	testutils.AssertErrorsSame(t, ErrNotRecognized, err)
+
+	if count := recorder.counterValue(
+		clientinfo.MetricFirewallOnChainChecksTotal,
+	); count != 1 {
+		t.Fatalf("expected 1 on-chain check after first validation, got %v", count)
+	}
+
+	// Second validation within the caching period is served from the
+	// negative result cache without a live check.
+	err = policy.Validate(peerOperatorPublicKey)
+	testutils.AssertErrorsSame(t, ErrNotRecognized, err)
+
+	if count := recorder.counterValue(
+		clientinfo.MetricFirewallOnChainChecksTotal,
+	); count != 1 {
+		t.Errorf(
+			"negative-cache hit should not be counted as an on-chain "+
+				"check, got %v",
+			count,
+		)
+	}
+}
+
+func TestValidate_OnChainCheckCounter_AllowlistBypassNotCounted(t *testing.T) {
+	recorder := setTestMetricsRecorder(t)
+
+	_, peerOperatorPublicKey, err := operator.GenerateKeyPair(
+		local_v1.DefaultCurve,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	policy := &anyApplicationPolicy{
+		applications:        []Application{newMockApplication()},
+		allowList:           NewAllowList([]*operator.PublicKey{peerOperatorPublicKey}),
+		negativeResultCache: cache.NewTimeCache(cachingPeriod),
+	}
+
+	err = policy.Validate(peerOperatorPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if count := recorder.counterValue(
+		clientinfo.MetricFirewallOnChainChecksTotal,
+	); count != 0 {
+		t.Errorf(
+			"allowlist bypass should not be counted as an on-chain "+
+				"check, got %v",
+			count,
+		)
+	}
+}
+
+func TestValidate_OnChainCheckCounter_OneIncrementPerApplicationCall(t *testing.T) {
+	recorder := setTestMetricsRecorder(t)
+
+	_, peerOperatorPublicKey, err := operator.GenerateKeyPair(
+		local_v1.DefaultCurve,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First application does not recognize the operator, second one does;
+	// both perform a live check.
+	application := newMockApplication()
+	application.setIsRecognized(peerOperatorPublicKey, result{
+		isRecognized: true,
+		err:          nil,
+	})
+
+	policy := &anyApplicationPolicy{
+		applications: []Application{
+			newMockApplication(),
+			application,
+		},
+		allowList:           EmptyAllowList(),
+		negativeResultCache: cache.NewTimeCache(cachingPeriod),
+	}
+
+	err = policy.Validate(peerOperatorPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if count := recorder.counterValue(
+		clientinfo.MetricFirewallOnChainChecksTotal,
+	); count != 2 {
+		t.Errorf(
+			"expected one counted on-chain check per application call, "+
+				"got %v",
+			count,
+		)
+	}
 }
 
 func newMockApplication() *mockApplication {

--- a/pkg/net/libp2p/authenticated_connection.go
+++ b/pkg/net/libp2p/authenticated_connection.go
@@ -14,6 +14,8 @@ import (
 	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"golang.org/x/time/rate"
+
 	"github.com/keep-network/keep-core/pkg/clientinfo"
 	"github.com/keep-network/keep-core/pkg/firewall"
 	keepNet "github.com/keep-network/keep-core/pkg/net"
@@ -28,6 +30,44 @@ import (
 
 // Enough space for a proto-encoded envelope with a message, peer.ID, and sig.
 const maxFrameSize = 1024
+
+// connectionFailureLogInterval and connectionFailureLogBurst configure the rate
+// limiter that throttles the INFO-level connection-failure log lines emitted by
+// newAuthenticatedInboundConnection and newAuthenticatedOutboundConnection.
+// Opening and failing a connection is cheap for a remote peer, so without
+// throttling a single noisy or hostile peer could emit one log line per failed
+// attempt and flood the logs. The limiter permits a short burst of lines to be
+// logged in full - covering normal, infrequent failures - then caps the
+// sustained rate so a flood cannot grow without bound. The per-reason failure
+// metrics are still incremented on every failure, so throttling the log line
+// never suppresses the observability signal.
+const (
+	connectionFailureLogInterval = 1 * time.Second
+	connectionFailureLogBurst    = 20
+)
+
+// connectionFailureLogLimiter throttles the connection-failure log lines. It is
+// a package-level limiter shared across all connection attempts so the cap
+// bounds total connection-failure log volume regardless of the remote source.
+var connectionFailureLogLimiter = newConnectionFailureLogLimiter()
+
+func newConnectionFailureLogLimiter() *rate.Limiter {
+	return rate.NewLimiter(
+		rate.Every(connectionFailureLogInterval),
+		connectionFailureLogBurst,
+	)
+}
+
+// logConnectionFailure emits an INFO-level connection-failure log line subject
+// to connectionFailureLogLimiter. When the limiter is saturated the line is
+// dropped, but callers still record the corresponding failure metrics on every
+// failure, so the observability signal is preserved even while the log output
+// is throttled.
+func logConnectionFailure(format string, args ...interface{}) {
+	if connectionFailureLogLimiter.Allow() {
+		logger.Infof(format, args...)
+	}
+}
 
 // authenticatedConnection turns inbound and outbound unauthenticated,
 // plain-text connections into authenticated, plain-text connections. Noticeably,
@@ -123,7 +163,7 @@ func newAuthenticatedInboundConnection(
 			metricsRecorder.IncrementCounter(clientinfo.NetworkJoinFailureMetricName(failureReason), 1)
 		}
 
-		logger.Infof(
+		logConnectionFailure(
 			"inbound connection handshake failed with reason [%v]: "+
 				"remote address [%v], remote peer [%v]: [%v]",
 			failureReason,
@@ -149,7 +189,7 @@ func newAuthenticatedInboundConnection(
 			metricsRecorder.IncrementCounter(clientinfo.NetworkJoinFailureMetricName(failureReason), 1)
 		}
 
-		logger.Infof(
+		logConnectionFailure(
 			"inbound connection rejected by firewall with reason [%v]: "+
 				"remote address [%v], remote peer [%v]: [%v]",
 			failureReason,
@@ -193,7 +233,7 @@ func newAuthenticatedOutboundConnection(
 
 	remotePublicKey, err := remotePeerID.ExtractPublicKey()
 	if err != nil {
-		logger.Infof(
+		logConnectionFailure(
 			"outbound connection setup failed with reason [%v]: "+
 				"remote address [%v], remote peer [%v]: [%v]",
 			clientinfo.JoinFailureReasonProtocolCrypto,
@@ -222,7 +262,7 @@ func newAuthenticatedOutboundConnection(
 	ac.initializePipe()
 
 	if err := ac.runHandshakeAsInitiator(); err != nil {
-		logger.Infof(
+		logConnectionFailure(
 			"outbound connection handshake failed with reason [%v]: "+
 				"remote address [%v], remote peer [%v]: [%v]",
 			classifyHandshakeFailure(err),
@@ -239,7 +279,7 @@ func newAuthenticatedOutboundConnection(
 	}
 
 	if failureReason, err := ac.checkFirewallRules(); err != nil {
-		logger.Infof(
+		logConnectionFailure(
 			"outbound connection rejected by firewall with reason [%v]: "+
 				"remote address [%v], remote peer [%v]: [%v]",
 			failureReason,

--- a/pkg/net/libp2p/authenticated_connection.go
+++ b/pkg/net/libp2p/authenticated_connection.go
@@ -3,9 +3,11 @@ package libp2p
 import (
 	"bufio"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
+	"syscall"
 	"time"
 
 	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
@@ -13,6 +15,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/keep-network/keep-core/pkg/clientinfo"
+	"github.com/keep-network/keep-core/pkg/firewall"
 	keepNet "github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/gen/pb"
 	"github.com/keep-network/keep-core/pkg/net/security/handshake"
@@ -112,10 +115,22 @@ func newAuthenticatedInboundConnection(
 	ac.initializePipe()
 
 	if err := ac.runHandshakeAsResponder(); err != nil {
+		failureReason := classifyHandshakeFailure(err)
+
 		// Track failed join request (handshake failure)
 		if metricsRecorder != nil {
 			metricsRecorder.IncrementCounter(clientinfo.MetricNetworkJoinRequestsFailedTotal, 1)
+			metricsRecorder.IncrementCounter(clientinfo.NetworkJoinFailureMetricName(failureReason), 1)
 		}
+
+		logger.Infof(
+			"inbound connection handshake failed with reason [%v]: "+
+				"remote address [%v], remote peer [%v]: [%v]",
+			failureReason,
+			ac.RemoteAddr(),
+			ac.remotePeerID,
+			err,
+		)
 
 		// close the conn before returning (if it hasn't already)
 		// otherwise we leak.
@@ -126,12 +141,22 @@ func newAuthenticatedInboundConnection(
 		return nil, fmt.Errorf("connection handshake failed: [%v]", err)
 	}
 
-	if err := ac.checkFirewallRules(); err != nil {
+	if failureReason, err := ac.checkFirewallRules(); err != nil {
 		// Track firewall rejection
 		if metricsRecorder != nil {
 			metricsRecorder.IncrementCounter(clientinfo.MetricFirewallRejectionsTotal, 1)
 			metricsRecorder.IncrementCounter(clientinfo.MetricNetworkJoinRequestsFailedTotal, 1)
+			metricsRecorder.IncrementCounter(clientinfo.NetworkJoinFailureMetricName(failureReason), 1)
 		}
+
+		logger.Infof(
+			"inbound connection rejected by firewall with reason [%v]: "+
+				"remote address [%v], remote peer [%v]: [%v]",
+			failureReason,
+			ac.RemoteAddr(),
+			ac.remotePeerID,
+			err,
+		)
 
 		if closeErr := ac.Close(); closeErr != nil {
 			logger.Debugf("could not close the connection: [%v]", closeErr)
@@ -168,6 +193,15 @@ func newAuthenticatedOutboundConnection(
 
 	remotePublicKey, err := remotePeerID.ExtractPublicKey()
 	if err != nil {
+		logger.Infof(
+			"outbound connection setup failed with reason [%v]: "+
+				"remote address [%v], remote peer [%v]: [%v]",
+			clientinfo.JoinFailureReasonProtocolCrypto,
+			unauthenticatedConn.RemoteAddr(),
+			remotePeerID,
+			err,
+		)
+
 		return nil, fmt.Errorf(
 			"could not create new authenticated outbound connection: [%v]",
 			err,
@@ -188,6 +222,15 @@ func newAuthenticatedOutboundConnection(
 	ac.initializePipe()
 
 	if err := ac.runHandshakeAsInitiator(); err != nil {
+		logger.Infof(
+			"outbound connection handshake failed with reason [%v]: "+
+				"remote address [%v], remote peer [%v]: [%v]",
+			classifyHandshakeFailure(err),
+			ac.RemoteAddr(),
+			ac.remotePeerID,
+			err,
+		)
+
 		if closeErr := ac.Close(); closeErr != nil {
 			logger.Debugf("could not close the connection: [%v]", closeErr)
 		}
@@ -195,7 +238,16 @@ func newAuthenticatedOutboundConnection(
 		return nil, fmt.Errorf("connection handshake failed: [%v]", err)
 	}
 
-	if err := ac.checkFirewallRules(); err != nil {
+	if failureReason, err := ac.checkFirewallRules(); err != nil {
+		logger.Infof(
+			"outbound connection rejected by firewall with reason [%v]: "+
+				"remote address [%v], remote peer [%v]: [%v]",
+			failureReason,
+			ac.RemoteAddr(),
+			ac.remotePeerID,
+			err,
+		)
+
 		if closeErr := ac.Close(); closeErr != nil {
 			logger.Debugf("could not close the connection: [%v]", closeErr)
 		}
@@ -211,16 +263,46 @@ func newAuthenticatedOutboundConnection(
 	return ac, nil
 }
 
-func (ac *authenticatedConnection) checkFirewallRules() error {
+// classifyHandshakeFailure maps a handshake error to one of the
+// low-cardinality join failure reasons defined in the clientinfo package.
+func classifyHandshakeFailure(err error) string {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return clientinfo.JoinFailureReasonTimeout
+	}
+
+	if errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, io.ErrClosedPipe) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE) {
+		return clientinfo.JoinFailureReasonEOFReset
+	}
+
+	return clientinfo.JoinFailureReasonProtocolCrypto
+}
+
+// checkFirewallRules validates the remote peer against the firewall. On
+// failure, it returns the join failure reason alongside the error so callers
+// can label metrics and logs without re-deriving the cause.
+func (ac *authenticatedConnection) checkFirewallRules() (string, error) {
 	operatorPublicKey, err := networkPublicKeyToOperatorPublicKey(ac.remotePeerPublicKey)
 	if err != nil {
-		return fmt.Errorf(
+		return clientinfo.JoinFailureReasonProtocolCrypto, fmt.Errorf(
 			"cannot convert libp2p public key to operator public key: [%v]",
 			err,
 		)
 	}
 
-	return ac.firewall.Validate(operatorPublicKey)
+	if err := ac.firewall.Validate(operatorPublicKey); err != nil {
+		if errors.Is(err, firewall.ErrNotRecognized) {
+			return clientinfo.JoinFailureReasonFirewallUnrecognized, err
+		}
+		return clientinfo.JoinFailureReasonFirewallRPCError, err
+	}
+
+	return "", nil
 }
 
 func (ac *authenticatedConnection) runHandshakeAsInitiator() error {

--- a/pkg/net/libp2p/authenticated_connection_test.go
+++ b/pkg/net/libp2p/authenticated_connection_test.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"reflect"
+	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -13,6 +16,8 @@ import (
 	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"github.com/keep-network/keep-core/pkg/clientinfo"
+	"github.com/keep-network/keep-core/pkg/firewall"
 	keepNet "github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/net/gen/pb"
 	"github.com/keep-network/keep-core/pkg/net/security/handshake"
@@ -313,6 +318,358 @@ func createTestConnectionConfig(t *testing.T) *testConnectionConfig {
 // on one end should be matched with writes on the other).
 func newConnPair() (net.Conn, net.Conn) {
 	return net.Pipe()
+}
+
+// --- join failure reason classification tests ---
+
+func TestClassifyHandshakeFailure(t *testing.T) {
+	tests := map[string]struct {
+		err            error
+		expectedReason string
+	}{
+		"deadline exceeded": {
+			err:            fmt.Errorf("read failed: %w", os.ErrDeadlineExceeded),
+			expectedReason: clientinfo.JoinFailureReasonTimeout,
+		},
+		"net op error with deadline exceeded": {
+			err:            &net.OpError{Op: "read", Err: os.ErrDeadlineExceeded},
+			expectedReason: clientinfo.JoinFailureReasonTimeout,
+		},
+		"eof": {
+			err:            io.EOF,
+			expectedReason: clientinfo.JoinFailureReasonEOFReset,
+		},
+		"unexpected eof wrapped": {
+			err:            fmt.Errorf("receive failed: %w", io.ErrUnexpectedEOF),
+			expectedReason: clientinfo.JoinFailureReasonEOFReset,
+		},
+		"closed pipe": {
+			err:            fmt.Errorf("send failed: %w", io.ErrClosedPipe),
+			expectedReason: clientinfo.JoinFailureReasonEOFReset,
+		},
+		"closed network connection": {
+			err:            fmt.Errorf("read failed: %w", net.ErrClosed),
+			expectedReason: clientinfo.JoinFailureReasonEOFReset,
+		},
+		"connection reset by peer": {
+			err:            &net.OpError{Op: "read", Err: syscall.ECONNRESET},
+			expectedReason: clientinfo.JoinFailureReasonEOFReset,
+		},
+		"broken pipe": {
+			err:            &net.OpError{Op: "write", Err: syscall.EPIPE},
+			expectedReason: clientinfo.JoinFailureReasonEOFReset,
+		},
+		"signature verification failure": {
+			err:            fmt.Errorf("invalid signature [0xff] on message from sender"),
+			expectedReason: clientinfo.JoinFailureReasonProtocolCrypto,
+		},
+		"pinned identity mismatch": {
+			err:            fmt.Errorf("pinned identity does not match sender identity"),
+			expectedReason: clientinfo.JoinFailureReasonProtocolCrypto,
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			actualReason := classifyHandshakeFailure(test.err)
+			if actualReason != test.expectedReason {
+				t.Errorf(
+					"unexpected failure reason\nexpected: %s\nactual: %s",
+					test.expectedReason,
+					actualReason,
+				)
+			}
+		})
+	}
+}
+
+// --- join request metrics and failure log tests ---
+
+type fakeMetricsRecorder struct {
+	mutex    sync.Mutex
+	counters map[string]float64
+}
+
+func newFakeMetricsRecorder() *fakeMetricsRecorder {
+	return &fakeMetricsRecorder{
+		counters: make(map[string]float64),
+	}
+}
+
+func (f *fakeMetricsRecorder) IncrementCounter(name string, value float64) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	f.counters[name] += value
+}
+
+func (f *fakeMetricsRecorder) RecordDuration(name string, duration time.Duration) {}
+
+func (f *fakeMetricsRecorder) counterValue(name string) float64 {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	return f.counters[name]
+}
+
+func (f *fakeMetricsRecorder) assertCounters(
+	t *testing.T,
+	expected map[string]float64,
+) {
+	t.Helper()
+	for name, expectedValue := range expected {
+		if actualValue := f.counterValue(name); actualValue != expectedValue {
+			t.Errorf(
+				"unexpected value of counter [%s]\nexpected: %v\nactual: %v",
+				name,
+				expectedValue,
+				actualValue,
+			)
+		}
+	}
+}
+
+// notRecognizedFirewall rejects every peer with the firewall's sentinel
+// non-recognition error.
+type notRecognizedFirewall struct{}
+
+func (f *notRecognizedFirewall) Validate(
+	remotePeerOperatorPublicKey *operator.PublicKey,
+) error {
+	return firewall.ErrNotRecognized
+}
+
+// erroringFirewall fails every validation with an application/RPC error.
+type erroringFirewall struct{}
+
+func (f *erroringFirewall) Validate(
+	remotePeerOperatorPublicKey *operator.PublicKey,
+) error {
+	return fmt.Errorf(
+		"could not validate if remote peer is recognized by application: " +
+			"[rpc timeout]",
+	)
+}
+
+func connectInitiatorAndResponderWithRecorder(
+	initiator *testConnectionConfig,
+	responder *testConnectionConfig,
+	firewall keepNet.Firewall,
+	recorder MetricsRecorder,
+) (inboundError error, outboundError error) {
+	initiatorConn, responderConn := newConnPair()
+
+	done := make(chan struct{})
+
+	go func() {
+		_, outboundError = newAuthenticatedOutboundConnection(
+			initiatorConn,
+			libp2pnetwork.ConnectionState{},
+			initiator.peerID,
+			initiator.networkPrivateKey,
+			responder.peerID,
+			firewall,
+			authProtocolID,
+			recorder,
+		)
+		done <- struct{}{}
+	}()
+
+	_, inboundError = newAuthenticatedInboundConnection(
+		responderConn,
+		libp2pnetwork.ConnectionState{},
+		responder.peerID,
+		responder.networkPrivateKey,
+		firewall,
+		authProtocolID,
+		recorder,
+	)
+
+	<-done // handshake is done
+
+	return
+}
+
+func TestInboundConnectionFirewallUnrecognizedReason(t *testing.T) {
+	initiator := createTestConnectionConfig(t)
+	responder := createTestConnectionConfig(t)
+
+	recorder := newFakeMetricsRecorder()
+
+	var inboundError error
+	entries := captureLogs(t, "keep-libp2p", func() {
+		inboundError, _ = connectInitiatorAndResponderWithRecorder(
+			initiator,
+			responder,
+			&notRecognizedFirewall{},
+			recorder,
+		)
+	})
+
+	if inboundError == nil {
+		t.Fatal("expected inbound connection to be rejected by the firewall")
+	}
+
+	recorder.assertCounters(t, map[string]float64{
+		clientinfo.MetricNetworkJoinRequestsTotal:        1,
+		clientinfo.MetricNetworkJoinRequestsFailedTotal:  1,
+		clientinfo.MetricNetworkJoinRequestsSuccessTotal: 0,
+		clientinfo.MetricFirewallRejectionsTotal:         1,
+		clientinfo.NetworkJoinFailureMetricName(
+			clientinfo.JoinFailureReasonFirewallUnrecognized,
+		): 1,
+		clientinfo.NetworkJoinFailureMetricName(
+			clientinfo.JoinFailureReasonFirewallRPCError,
+		): 0,
+	})
+
+	inboundLogs := countLogEntries(
+		entries,
+		"info",
+		"inbound connection rejected by firewall with reason "+
+			"[firewall_unrecognized]",
+	)
+	if inboundLogs != 1 {
+		t.Errorf(
+			"expected 1 inbound firewall rejection log entry, got %d",
+			inboundLogs,
+		)
+	}
+
+	outboundLogs := countLogEntries(
+		entries,
+		"info",
+		"outbound connection rejected by firewall with reason "+
+			"[firewall_unrecognized]",
+	)
+	if outboundLogs != 1 {
+		t.Errorf(
+			"expected 1 outbound firewall rejection log entry, got %d",
+			outboundLogs,
+		)
+	}
+}
+
+func TestInboundConnectionFirewallRPCErrorReason(t *testing.T) {
+	initiator := createTestConnectionConfig(t)
+	responder := createTestConnectionConfig(t)
+
+	recorder := newFakeMetricsRecorder()
+
+	inboundError, _ := connectInitiatorAndResponderWithRecorder(
+		initiator,
+		responder,
+		&erroringFirewall{},
+		recorder,
+	)
+
+	if inboundError == nil {
+		t.Fatal("expected inbound connection to be rejected by the firewall")
+	}
+
+	recorder.assertCounters(t, map[string]float64{
+		clientinfo.MetricNetworkJoinRequestsTotal:        1,
+		clientinfo.MetricNetworkJoinRequestsFailedTotal:  1,
+		clientinfo.MetricNetworkJoinRequestsSuccessTotal: 0,
+		clientinfo.MetricFirewallRejectionsTotal:         1,
+		clientinfo.NetworkJoinFailureMetricName(
+			clientinfo.JoinFailureReasonFirewallRPCError,
+		): 1,
+		clientinfo.NetworkJoinFailureMetricName(
+			clientinfo.JoinFailureReasonFirewallUnrecognized,
+		): 0,
+	})
+}
+
+func TestInboundConnectionHandshakeEOFReason(t *testing.T) {
+	responder := createTestConnectionConfig(t)
+
+	recorder := newFakeMetricsRecorder()
+
+	initiatorConn, responderConn := newConnPair()
+
+	// The initiator drops the connection without sending anything, so the
+	// responder's handshake fails with a closed-connection error.
+	go func() {
+		_ = initiatorConn.Close()
+	}()
+
+	var inboundError error
+	entries := captureLogs(t, "keep-libp2p", func() {
+		_, inboundError = newAuthenticatedInboundConnection(
+			responderConn,
+			libp2pnetwork.ConnectionState{},
+			responder.peerID,
+			responder.networkPrivateKey,
+			newMockFirewall(),
+			authProtocolID,
+			recorder,
+		)
+	})
+
+	if inboundError == nil {
+		t.Fatal("expected inbound connection handshake to fail")
+	}
+
+	recorder.assertCounters(t, map[string]float64{
+		clientinfo.MetricNetworkJoinRequestsTotal:        1,
+		clientinfo.MetricNetworkJoinRequestsFailedTotal:  1,
+		clientinfo.MetricNetworkJoinRequestsSuccessTotal: 0,
+		clientinfo.MetricFirewallRejectionsTotal:         0,
+		clientinfo.NetworkJoinFailureMetricName(
+			clientinfo.JoinFailureReasonEOFReset,
+		): 1,
+	})
+
+	handshakeLogs := countLogEntries(
+		entries,
+		"info",
+		"inbound connection handshake failed with reason [eof_reset]",
+	)
+	if handshakeLogs != 1 {
+		t.Errorf(
+			"expected 1 inbound handshake failure log entry, got %d",
+			handshakeLogs,
+		)
+	}
+}
+
+func TestInboundConnectionSuccessfulJoinCounters(t *testing.T) {
+	initiator := createTestConnectionConfig(t)
+	responder := createTestConnectionConfig(t)
+
+	firewall := newMockFirewall()
+	if err := firewall.updatePeer(initiator.networkPublicKey, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := firewall.updatePeer(responder.networkPublicKey, true); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := newFakeMetricsRecorder()
+
+	inboundError, outboundError := connectInitiatorAndResponderWithRecorder(
+		initiator,
+		responder,
+		firewall,
+		recorder,
+	)
+
+	if inboundError != nil {
+		t.Fatal(inboundError)
+	}
+	if outboundError != nil {
+		t.Fatal(outboundError)
+	}
+
+	expected := map[string]float64{
+		clientinfo.MetricNetworkJoinRequestsTotal:        1,
+		clientinfo.MetricNetworkJoinRequestsSuccessTotal: 1,
+		clientinfo.MetricNetworkJoinRequestsFailedTotal:  0,
+		clientinfo.MetricFirewallRejectionsTotal:         0,
+	}
+	for _, reason := range clientinfo.GetAllNetworkJoinFailureReasons() {
+		expected[clientinfo.NetworkJoinFailureMetricName(reason)] = 0
+	}
+	recorder.assertCounters(t, expected)
 }
 
 func newMockFirewall() *mockFirewall {

--- a/pkg/net/libp2p/authenticated_connection_test.go
+++ b/pkg/net/libp2p/authenticated_connection_test.go
@@ -16,6 +16,8 @@ import (
 	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"golang.org/x/time/rate"
+
 	"github.com/keep-network/keep-core/pkg/clientinfo"
 	"github.com/keep-network/keep-core/pkg/firewall"
 	keepNet "github.com/keep-network/keep-core/pkg/net"
@@ -494,6 +496,11 @@ func TestInboundConnectionFirewallUnrecognizedReason(t *testing.T) {
 
 	recorder := newFakeMetricsRecorder()
 
+	// Reset the shared package-level limiter so the throttled failure log
+	// lines below are emitted deterministically, independent of other tests
+	// that share the limiter.
+	connectionFailureLogLimiter = newConnectionFailureLogLimiter()
+
 	var inboundError error
 	entries := captureLogs(t, "keep-libp2p", func() {
 		inboundError, _ = connectInitiatorAndResponderWithRecorder(
@@ -584,6 +591,11 @@ func TestInboundConnectionHandshakeEOFReason(t *testing.T) {
 
 	recorder := newFakeMetricsRecorder()
 
+	// Reset the shared package-level limiter so the throttled failure log
+	// line below is emitted deterministically, independent of other tests
+	// that share the limiter.
+	connectionFailureLogLimiter = newConnectionFailureLogLimiter()
+
 	initiatorConn, responderConn := newConnPair()
 
 	// The initiator drops the connection without sending anything, so the
@@ -628,6 +640,77 @@ func TestInboundConnectionHandshakeEOFReason(t *testing.T) {
 		t.Errorf(
 			"expected 1 inbound handshake failure log entry, got %d",
 			handshakeLogs,
+		)
+	}
+}
+
+// TestConnectionFailureLogThrottling verifies that the INFO-level
+// connection-failure log line is rate limited so a burst of failures from the
+// same source cannot flood the logs, while the per-reason failure metrics are
+// still incremented for every single failure.
+func TestConnectionFailureLogThrottling(t *testing.T) {
+	responder := createTestConnectionConfig(t)
+
+	// Install a strict limiter that admits only a small burst of log lines and
+	// does not refill within the test window, then restore the production
+	// limiter afterwards.
+	const allowedLogLines = 2
+	originalLimiter := connectionFailureLogLimiter
+	connectionFailureLogLimiter = rate.NewLimiter(rate.Every(time.Hour), allowedLogLines)
+	defer func() { connectionFailureLogLimiter = originalLimiter }()
+
+	recorder := newFakeMetricsRecorder()
+
+	const failureCount = 10
+
+	entries := captureLogs(t, "keep-libp2p", func() {
+		for i := 0; i < failureCount; i++ {
+			initiatorConn, responderConn := newConnPair()
+
+			// The initiator drops the connection without sending anything, so
+			// the responder's handshake fails with a closed-connection error.
+			go func() { _ = initiatorConn.Close() }()
+
+			_, inboundError := newAuthenticatedInboundConnection(
+				responderConn,
+				libp2pnetwork.ConnectionState{},
+				responder.peerID,
+				responder.networkPrivateKey,
+				newMockFirewall(),
+				authProtocolID,
+				recorder,
+			)
+			if inboundError == nil {
+				t.Fatalf(
+					"expected inbound handshake failure on attempt %d", i,
+				)
+			}
+		}
+	})
+
+	// The failure metrics are incremented once per failure regardless of
+	// whether the log line was emitted - throttling the log must not hide the
+	// observability signal.
+	recorder.assertCounters(t, map[string]float64{
+		clientinfo.MetricNetworkJoinRequestsTotal:       failureCount,
+		clientinfo.MetricNetworkJoinRequestsFailedTotal: failureCount,
+		clientinfo.NetworkJoinFailureMetricName(
+			clientinfo.JoinFailureReasonEOFReset,
+		): failureCount,
+	})
+
+	// The log line is throttled to the limiter's burst even though every one of
+	// the failures above was recorded in the metrics.
+	loggedLines := countLogEntries(
+		entries,
+		"info",
+		"inbound connection handshake failed with reason [eof_reset]",
+	)
+	if loggedLines != allowedLogLines {
+		t.Errorf(
+			"expected connection-failure log throttled to %d lines, got %d",
+			allowedLogLines,
+			loggedLines,
 		)
 	}
 }

--- a/pkg/net/libp2p/bootstrap.go
+++ b/pkg/net/libp2p/bootstrap.go
@@ -70,8 +70,14 @@ func Bootstrap(
 	periodic := func(worker goprocess.Process) {
 		ctx := goprocessctx.OnClosingContext(worker)
 
+		// bootstrapRound returns an error only when the node ends the
+		// round connected to zero well-known peers (true isolation risk).
+		// The round already logged that outcome at warning level with the
+		// full unreachable/total ratio -- it is the single owner of the
+		// round summary log -- so the error is only traced here at debug
+		// level to avoid emitting a duplicate warning for the same round.
 		if err := bootstrapRound(ctx, host, cfg); err != nil {
-			logger.Warnf("bootstrap round error: [%v]", err)
+			logger.Debugf("well-known peers connection round error: [%v]", err)
 		}
 
 		<-doneWithRound
@@ -109,18 +115,21 @@ func bootstrapRound(
 	ctx, cancel := context.WithTimeout(ctx, cfg.ConnectionTimeout)
 	defer cancel()
 
-	logger.Debugf("starting bootstrap round")
+	logger.Debugf("starting well-known peers connection round")
 
-	// get bootstrap peers from config. retrieving them here makes
+	// get well-known peers from config. retrieving them here makes
 	// sure we remain observant of changes to client configuration.
 	peers := cfg.BootstrapPeers()
 
 	if len(peers) == 0 {
-		logger.Debugf("bootstrap round skipped; no bootstrap peers in config")
+		logger.Debugf(
+			"well-known peers connection round skipped; " +
+				"no well-known peers in config",
+		)
 		return nil
 	}
 
-	// filter out bootstrap nodes we are already connected to
+	// filter out well-known peers we are already connected to
 	var notConnected []peer.AddrInfo
 	for _, p := range peers {
 		if host.Network().Connectedness(p.ID) != network.Connected {
@@ -128,32 +137,66 @@ func bootstrapRound(
 		}
 	}
 
-	// if connected to all bootstrap peer candidates, exit
+	// if connected to all well-known peer candidates, exit
 	if len(notConnected) < 1 {
 		logger.Debugf(
-			"bootstrap round skipped; " +
-				"connected to all bootstrap peers from config",
+			"well-known peers connection round skipped; " +
+				"connected to all well-known peers from config",
 		)
 		return nil
 	}
 
-	logger.Debugf("bootstrapping to nodes: [%v]", notConnected)
+	logger.Debugf("connecting to well-known peers: [%v]", notConnected)
 
-	return bootstrapConnect(ctx, host, notConnected)
+	return bootstrapConnect(ctx, host, notConnected, peers)
 }
 
+// wellknownPeerDialFailure pairs a well-known peer with its dial error so
+// failure logs can be emitted after the round completes, once the node's
+// actual post-round connectivity is known.
+type wellknownPeerDialFailure struct {
+	peerID peer.ID
+	err    error
+}
+
+// connectedWellknownPeersCount returns the number of the given well-known
+// peers the host is currently connected to.
+func connectedWellknownPeersCount(ph host.Host, peers []peer.AddrInfo) int {
+	connectedCount := 0
+	for _, p := range peers {
+		if ph.Network().Connectedness(p.ID) == network.Connected {
+			connectedCount++
+		}
+	}
+	return connectedCount
+}
+
+// bootstrapConnect dials the given not-yet-connected well-known peers.
+// allPeers is the complete set of well-known peers from the config. Once
+// every dial attempt has finished -- even when none of them failed -- the
+// node's connectivity to the complete well-known peer set is queried live
+// and is the sole source of the round summary and its severity: the summary
+// reports how many of the configured well-known peers the node actually
+// ends the round not connected to, with dial failures logged only as
+// per-peer diagnostic details. WARN severity and a returned error are
+// reserved for a node that ends the round connected to zero well-known
+// peers (true isolation risk), while partial unreachability on an
+// otherwise-connected node is logged at info level. This function owns the
+// round summary log -- callers must not log the returned error above debug
+// level, or an isolated round would emit duplicate warnings.
 func bootstrapConnect(
 	ctx context.Context,
 	ph host.Host,
-	peers []peer.AddrInfo,
+	notConnected []peer.AddrInfo,
+	allPeers []peer.AddrInfo,
 ) error {
-	if len(peers) < 1 {
+	if len(notConnected) < 1 {
 		return ErrNotEnoughBootstrapPeers
 	}
 
-	errs := make(chan error, len(peers))
+	failures := make(chan wellknownPeerDialFailure, len(notConnected))
 	var wg sync.WaitGroup
-	for _, p := range peers {
+	for _, p := range notConnected {
 
 		// performed asynchronously because when performed synchronously, if
 		// one `Connect` call hangs, subsequent calls are more likely to
@@ -164,38 +207,80 @@ func bootstrapConnect(
 		go func(p peer.AddrInfo) {
 			defer wg.Done()
 
-			logger.Debugf("trying to establish connection with bootstrap peer [%v]", p.ID)
+			logger.Debugf("trying to establish connection with well-known peer [%v]", p.ID)
 
 			ph.Peerstore().AddAddrs(p.ID, p.Addrs, peerstore.PermanentAddrTTL)
 
 			if err := ph.Connect(ctx, p); err != nil {
-				logger.Warnf(
-					"could not establish connection with bootstrap peer [%v]: [%v]",
-					p.ID,
-					err,
-				)
-				errs <- err
+				failures <- wellknownPeerDialFailure{peerID: p.ID, err: err}
 				return
 			}
 
-			logger.Debugf("established connection with bootstrap peer [%v]", p.ID)
+			logger.Debugf("established connection with well-known peer [%v]", p.ID)
 		}(p)
 	}
 	wg.Wait()
 
-	// our failure condition is when no connection attempt succeeded.
-	// So drain the errs channel, counting the results.
-	close(errs)
-	count := 0
-	var err error
-	for err = range errs {
-		if err != nil {
-			count++
+	// drain the failures channel, collecting the failed connection attempts.
+	close(failures)
+	var dialFailures []wellknownPeerDialFailure
+	for failure := range failures {
+		dialFailures = append(dialFailures, failure)
+	}
+
+	// Connectivity is queried live over the complete well-known peer set
+	// after every dial batch -- including one with zero dial failures --
+	// instead of being derived from dial results and the pre-round snapshot:
+	// peers may have connected or dropped concurrently while dials were in
+	// flight, and only the node's actual post-round connectivity determines
+	// whether unreachable peers are routine churn or an isolation risk.
+	connectedCount := connectedWellknownPeersCount(ph, allPeers)
+	unreachableCount := len(allPeers) - connectedCount
+	isolated := connectedCount == 0
+
+	for _, failure := range dialFailures {
+		if isolated {
+			logger.Warnf(
+				"could not establish connection with well-known peer [%v]: [%v]",
+				failure.peerID,
+				failure.err,
+			)
+		} else {
+			logger.Debugf(
+				"could not establish connection with well-known peer [%v]: [%v]",
+				failure.peerID,
+				failure.err,
+			)
 		}
 	}
-	if count == len(peers) {
-		return fmt.Errorf("all bootstrap attempts failed")
+
+	if unreachableCount == 0 {
+		logger.Debugf(
+			"connected to all %d well-known peers from config",
+			len(allPeers),
+		)
+		return nil
 	}
+
+	if isolated {
+		summary := fmt.Sprintf(
+			"%d of %d well-known peers unreachable; "+
+				"node is not connected to any well-known peer",
+			unreachableCount,
+			len(allPeers),
+		)
+		logger.Warn(summary)
+		return errors.New(summary)
+	}
+
+	logger.Infof(
+		"%d of %d well-known peers unreachable; "+
+			"connected to %d well-known peer(s)",
+		unreachableCount,
+		len(allPeers),
+		connectedCount,
+	)
+
 	return nil
 }
 

--- a/pkg/net/libp2p/bootstrap_test.go
+++ b/pkg/net/libp2p/bootstrap_test.go
@@ -1,11 +1,23 @@
 package libp2p
 
 import (
+	"bufio"
+	"context"
+	"encoding/json"
 	"fmt"
-	"github.com/ipfs/go-ipfs-config"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	config "github.com/ipfs/go-ipfs-config"
+	log2 "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/test"
-	"testing"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	ma "github.com/multiformats/go-multiaddr"
 )
 
 func TestMultipleAddrsPerPeer(t *testing.T) {
@@ -44,5 +56,561 @@ func TestMultipleAddrsPerPeer(t *testing.T) {
 	pinfos := peers.toPeerInfos(bsps)
 	if len(pinfos) != len(bsps)/2 {
 		t.Fatal("expected fewer peers")
+	}
+}
+
+// --- log capture helpers ---
+
+type capturedLogEntry struct {
+	Level   string `json:"level"`
+	Logger  string `json:"logger"`
+	Message string `json:"msg"`
+}
+
+// captureLogs runs fn while capturing log entries emitted by the given
+// logger subsystem and returns the captured entries.
+func captureLogs(t *testing.T, subsystem string, fn func()) []capturedLogEntry {
+	t.Helper()
+
+	if err := log2.SetLogLevel(subsystem, "debug"); err != nil {
+		t.Fatal(err)
+	}
+
+	pipe := log2.NewPipeReader()
+
+	var mutex sync.Mutex
+	var entries []capturedLogEntry
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		scanner := bufio.NewScanner(pipe)
+		for scanner.Scan() {
+			var entry capturedLogEntry
+			if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+				continue
+			}
+			if entry.Logger != subsystem {
+				continue
+			}
+			mutex.Lock()
+			entries = append(entries, entry)
+			mutex.Unlock()
+		}
+	}()
+
+	fn()
+
+	if err := pipe.Close(); err != nil {
+		t.Logf("could not close log pipe reader: %v", err)
+	}
+	<-done
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	return append([]capturedLogEntry(nil), entries...)
+}
+
+func countLogEntries(
+	entries []capturedLogEntry,
+	level string,
+	messageFragment string,
+) int {
+	count := 0
+	for _, entry := range entries {
+		if entry.Level == level &&
+			strings.Contains(entry.Message, messageFragment) {
+			count++
+		}
+	}
+	return count
+}
+
+// --- well-known peers connection round tests ---
+
+// newWellknownPeersTestHost creates a mock-network-backed host acting as the
+// local node in well-known peers connection round tests.
+func newWellknownPeersTestHost(t *testing.T) (mocknet.Mocknet, host.Host) {
+	t.Helper()
+
+	mockNetwork := mocknet.New()
+	t.Cleanup(func() {
+		if err := mockNetwork.Close(); err != nil {
+			t.Logf("could not close mock network: %v", err)
+		}
+	})
+
+	localHost, err := mockNetwork.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return mockNetwork, localHost
+}
+
+// newConnectedWellknownPeer creates a well-known peer the local host is
+// connected to and returns its address info.
+func newConnectedWellknownPeer(
+	t *testing.T,
+	mockNetwork mocknet.Mocknet,
+	localHost host.Host,
+) peer.AddrInfo {
+	t.Helper()
+
+	remoteHost, err := mockNetwork.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mockNetwork.LinkPeers(localHost.ID(), remoteHost.ID()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mockNetwork.ConnectPeers(localHost.ID(), remoteHost.ID()); err != nil {
+		t.Fatal(err)
+	}
+
+	return peer.AddrInfo{ID: remoteHost.ID(), Addrs: remoteHost.Addrs()}
+}
+
+// newDialableWellknownPeer creates a well-known peer the local host is not
+// connected to but can successfully dial, and returns its address info.
+func newDialableWellknownPeer(
+	t *testing.T,
+	mockNetwork mocknet.Mocknet,
+	localHost host.Host,
+) peer.AddrInfo {
+	t.Helper()
+
+	remoteHost, err := mockNetwork.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mockNetwork.LinkPeers(localHost.ID(), remoteHost.ID()); err != nil {
+		t.Fatal(err)
+	}
+
+	return peer.AddrInfo{ID: remoteHost.ID(), Addrs: remoteHost.Addrs()}
+}
+
+// newUnreachableWellknownPeer returns address info of a well-known peer that
+// does not exist on the mock network, so every dial to it fails.
+func newUnreachableWellknownPeer(t *testing.T) peer.AddrInfo {
+	t.Helper()
+
+	peerID, err := test.RandPeerID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	address, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return peer.AddrInfo{ID: peerID, Addrs: []ma.Multiaddr{address}}
+}
+
+func TestBootstrapRound_ZeroWellknownPeersConnected_ReturnsErrorAndWarns(t *testing.T) {
+	_, localHost := newWellknownPeersTestHost(t)
+
+	wellknownPeers := []peer.AddrInfo{
+		newUnreachableWellknownPeer(t),
+		newUnreachableWellknownPeer(t),
+	}
+
+	var roundErr error
+	entries := captureLogs(t, "keep-libp2p", func() {
+		roundErr = bootstrapRound(
+			context.Background(),
+			localHost,
+			bootstrapConfigWithPeers(wellknownPeers),
+		)
+	})
+
+	if roundErr == nil {
+		t.Fatal(
+			"expected an error when the node is not connected to any " +
+				"well-known peer and all dials failed",
+		)
+	}
+
+	expectedMessage := "2 of 2 well-known peers unreachable; " +
+		"node is not connected to any well-known peer"
+	if !strings.Contains(roundErr.Error(), expectedMessage) {
+		t.Errorf(
+			"unexpected round error\nexpected to contain: %s\nactual: %v",
+			expectedMessage,
+			roundErr,
+		)
+	}
+
+	// With zero well-known peers connected, the summary is logged at
+	// warning level.
+	if count := countLogEntries(entries, "warn", expectedMessage); count != 1 {
+		t.Errorf(
+			"expected 1 warning entry with message [%s], got %d",
+			expectedMessage,
+			count,
+		)
+	}
+
+	// With zero well-known peers connected, per-peer dial failures are
+	// logged at warning level.
+	warns := countLogEntries(
+		entries,
+		"warn",
+		"could not establish connection with well-known peer",
+	)
+	if warns != 2 {
+		t.Errorf("expected 2 per-peer dial failure warnings, got %d", warns)
+	}
+}
+
+func TestBootstrapRound_ZeroConnectedAtStart_PartialDialSuccess_LogsInfoNotWarn(t *testing.T) {
+	mockNetwork, localHost := newWellknownPeersTestHost(t)
+
+	// The node starts the round with zero well-known peers connected: one
+	// peer is dialable and one is unreachable, so the round ends with the
+	// node connected to one well-known peer.
+	wellknownPeers := []peer.AddrInfo{
+		newDialableWellknownPeer(t, mockNetwork, localHost),
+		newUnreachableWellknownPeer(t),
+	}
+
+	var roundErr error
+	entries := captureLogs(t, "keep-libp2p", func() {
+		roundErr = bootstrapRound(
+			context.Background(),
+			localHost,
+			bootstrapConfigWithPeers(wellknownPeers),
+		)
+	})
+
+	if roundErr != nil {
+		t.Fatalf(
+			"round should not error when a dial succeeded and the node "+
+				"ends the round connected to a well-known peer: [%v]",
+			roundErr,
+		)
+	}
+
+	for _, level := range []string{"warn", "error"} {
+		if count := countLogEntries(entries, level, ""); count != 0 {
+			t.Errorf(
+				"expected no %s entries when the round ends with a "+
+					"well-known peer connected, got %d",
+				level,
+				count,
+			)
+		}
+	}
+
+	expectedSummary := "1 of 2 well-known peers unreachable; " +
+		"connected to 1 well-known peer(s)"
+	if count := countLogEntries(entries, "info", expectedSummary); count != 1 {
+		t.Errorf(
+			"expected 1 info entry with message [%s], got %d",
+			expectedSummary,
+			count,
+		)
+	}
+
+	// The dial failure is logged at debug level because the node ends the
+	// round connected, even though it started the round with zero
+	// well-known peers connected.
+	debugs := countLogEntries(
+		entries,
+		"debug",
+		"could not establish connection with well-known peer",
+	)
+	if debugs != 1 {
+		t.Errorf("expected 1 per-peer dial failure debug entry, got %d", debugs)
+	}
+}
+
+func TestBootstrapRound_SomeWellknownPeersConnected_LogsInfoNotWarn(t *testing.T) {
+	mockNetwork, localHost := newWellknownPeersTestHost(t)
+
+	wellknownPeers := []peer.AddrInfo{
+		newConnectedWellknownPeer(t, mockNetwork, localHost),
+		newUnreachableWellknownPeer(t),
+	}
+
+	var roundErr error
+	entries := captureLogs(t, "keep-libp2p", func() {
+		roundErr = bootstrapRound(
+			context.Background(),
+			localHost,
+			bootstrapConfigWithPeers(wellknownPeers),
+		)
+	})
+
+	if roundErr != nil {
+		t.Fatalf(
+			"round should not error when at least one well-known peer "+
+				"is connected: [%v]",
+			roundErr,
+		)
+	}
+
+	for _, level := range []string{"warn", "error"} {
+		if count := countLogEntries(entries, level, ""); count != 0 {
+			t.Errorf(
+				"expected no %s entries on a partially-connected node, "+
+					"got %d",
+				level,
+				count,
+			)
+		}
+	}
+
+	expectedSummary := "1 of 2 well-known peers unreachable; " +
+		"connected to 1 well-known peer(s)"
+	if count := countLogEntries(entries, "info", expectedSummary); count != 1 {
+		t.Errorf(
+			"expected 1 info entry with message [%s], got %d",
+			expectedSummary,
+			count,
+		)
+	}
+
+	// Per-peer dial failures are logged at debug level on a
+	// partially-connected node.
+	debugs := countLogEntries(
+		entries,
+		"debug",
+		"could not establish connection with well-known peer",
+	)
+	if debugs != 1 {
+		t.Errorf("expected 1 per-peer dial failure debug entry, got %d", debugs)
+	}
+}
+
+func TestBootstrapRound_AllWellknownPeersConnected_Silent(t *testing.T) {
+	mockNetwork, localHost := newWellknownPeersTestHost(t)
+
+	wellknownPeers := []peer.AddrInfo{
+		newConnectedWellknownPeer(t, mockNetwork, localHost),
+		newConnectedWellknownPeer(t, mockNetwork, localHost),
+	}
+
+	var roundErr error
+	entries := captureLogs(t, "keep-libp2p", func() {
+		roundErr = bootstrapRound(
+			context.Background(),
+			localHost,
+			bootstrapConfigWithPeers(wellknownPeers),
+		)
+	})
+
+	if roundErr != nil {
+		t.Fatalf("round should not error on a fully-connected node: [%v]", roundErr)
+	}
+
+	for _, level := range []string{"warn", "error"} {
+		if count := countLogEntries(entries, level, ""); count != 0 {
+			t.Errorf(
+				"expected no %s entries on a fully-connected node, got %d",
+				level,
+				count,
+			)
+		}
+	}
+
+	if count := countLogEntries(entries, "info", "unreachable"); count != 0 {
+		t.Errorf(
+			"expected no unreachability info entries on a fully-connected "+
+				"node, got %d",
+			count,
+		)
+	}
+}
+
+// dropWellknownPeer disconnects the local host from a previously-connected
+// well-known peer and verifies the disconnection took effect.
+func dropWellknownPeer(
+	t *testing.T,
+	mockNetwork mocknet.Mocknet,
+	localHost host.Host,
+	peerInfo peer.AddrInfo,
+) {
+	t.Helper()
+
+	if err := mockNetwork.DisconnectPeers(localHost.ID(), peerInfo.ID); err != nil {
+		t.Fatal(err)
+	}
+	if localHost.Network().Connectedness(peerInfo.ID) == network.Connected {
+		t.Fatal("well-known peer expected to be disconnected")
+	}
+}
+
+func TestBootstrapConnect_ConnectedPeerDropsDuringRound_WarnsWithLiveRatio(t *testing.T) {
+	mockNetwork, localHost := newWellknownPeersTestHost(t)
+
+	droppedPeer := newConnectedWellknownPeer(t, mockNetwork, localHost)
+	unreachablePeer := newUnreachableWellknownPeer(t)
+	wellknownPeers := []peer.AddrInfo{droppedPeer, unreachablePeer}
+
+	// The dial set passed below was computed while droppedPeer was still
+	// connected, so it contains only unreachablePeer. Dropping droppedPeer
+	// before the dial batch runs recreates a peer disconnecting mid-round,
+	// after the round-start connectivity snapshot but before the final
+	// severity decision.
+	dropWellknownPeer(t, mockNetwork, localHost, droppedPeer)
+
+	var connectErr error
+	entries := captureLogs(t, "keep-libp2p", func() {
+		connectErr = bootstrapConnect(
+			context.Background(),
+			localHost,
+			[]peer.AddrInfo{unreachablePeer},
+			wellknownPeers,
+		)
+	})
+
+	if connectErr == nil {
+		t.Fatal(
+			"expected an error when the node ends the round not connected " +
+				"to any well-known peer",
+		)
+	}
+
+	// The node ends the round connected to neither well-known peer, so the
+	// summary must report the live 2-of-2 ratio, not the single dial failure.
+	expectedMessage := "2 of 2 well-known peers unreachable; " +
+		"node is not connected to any well-known peer"
+	if !strings.Contains(connectErr.Error(), expectedMessage) {
+		t.Errorf(
+			"unexpected error\nexpected to contain: %s\nactual: %v",
+			expectedMessage,
+			connectErr,
+		)
+	}
+
+	if count := countLogEntries(entries, "warn", expectedMessage); count != 1 {
+		t.Errorf(
+			"expected 1 warning entry with message [%s], got %d",
+			expectedMessage,
+			count,
+		)
+	}
+
+	// Only the dialed peer produces a per-peer dial failure log; the dropped
+	// peer is reflected in the summary ratio alone.
+	warns := countLogEntries(
+		entries,
+		"warn",
+		"could not establish connection with well-known peer",
+	)
+	if warns != 1 {
+		t.Errorf("expected 1 per-peer dial failure warning, got %d", warns)
+	}
+}
+
+func TestBootstrapConnect_AllDialsSucceedButConnectedPeerDrops_LogsInfoRatio(t *testing.T) {
+	mockNetwork, localHost := newWellknownPeersTestHost(t)
+
+	droppedPeer := newConnectedWellknownPeer(t, mockNetwork, localHost)
+	dialablePeer := newDialableWellknownPeer(t, mockNetwork, localHost)
+	wellknownPeers := []peer.AddrInfo{droppedPeer, dialablePeer}
+
+	// droppedPeer disconnects after the dial set (only dialablePeer) was
+	// computed. Every dial in the batch then succeeds, yet the node still
+	// ends the round with one well-known peer unreachable -- the round must
+	// detect that from live connectivity, not from dial results.
+	dropWellknownPeer(t, mockNetwork, localHost, droppedPeer)
+
+	var connectErr error
+	entries := captureLogs(t, "keep-libp2p", func() {
+		connectErr = bootstrapConnect(
+			context.Background(),
+			localHost,
+			[]peer.AddrInfo{dialablePeer},
+			wellknownPeers,
+		)
+	})
+
+	if connectErr != nil {
+		t.Fatalf(
+			"round should not error when the node ends the round connected "+
+				"to a well-known peer: [%v]",
+			connectErr,
+		)
+	}
+
+	for _, level := range []string{"warn", "error"} {
+		if count := countLogEntries(entries, level, ""); count != 0 {
+			t.Errorf(
+				"expected no %s entries when the round ends with a "+
+					"well-known peer connected, got %d",
+				level,
+				count,
+			)
+		}
+	}
+
+	expectedSummary := "1 of 2 well-known peers unreachable; " +
+		"connected to 1 well-known peer(s)"
+	if count := countLogEntries(entries, "info", expectedSummary); count != 1 {
+		t.Errorf(
+			"expected 1 info entry with message [%s], got %d",
+			expectedSummary,
+			count,
+		)
+	}
+}
+
+func TestBootstrap_IsolatedRound_EmitsExactlyOneSummaryWarn(t *testing.T) {
+	_, localHost := newWellknownPeersTestHost(t)
+
+	wellknownPeers := []peer.AddrInfo{
+		newUnreachableWellknownPeer(t),
+		newUnreachableWellknownPeer(t),
+	}
+
+	cfg := bootstrapConfigWithPeers(wellknownPeers)
+	// A period far longer than the test ensures only the initial round runs
+	// before the supervisor is closed.
+	cfg.Period = time.Hour
+
+	entries := captureLogs(t, "keep-libp2p", func() {
+		// Bootstrap returns only after the initial round has completed, so
+		// all of the round's log entries are captured before the pipe closes.
+		supervisor, err := Bootstrap(localHost.ID(), localHost, nil, cfg)
+		if err != nil {
+			t.Errorf("unexpected error starting the supervisor: [%v]", err)
+			return
+		}
+		if err := supervisor.Close(); err != nil {
+			t.Errorf("could not close the supervisor: [%v]", err)
+		}
+	})
+
+	// An isolated round emits exactly one ratio warning -- owned by the
+	// round itself -- while the periodic supervisor only traces the returned
+	// error at debug level instead of duplicating the warning.
+	expectedMessage := "2 of 2 well-known peers unreachable; " +
+		"node is not connected to any well-known peer"
+	if count := countLogEntries(entries, "warn", expectedMessage); count != 1 {
+		t.Errorf(
+			"expected 1 warning entry with message [%s], got %d",
+			expectedMessage,
+			count,
+		)
+	}
+
+	roundErrorMessage := "well-known peers connection round error"
+	if count := countLogEntries(entries, "warn", roundErrorMessage); count != 0 {
+		t.Errorf(
+			"expected no warning entries with message [%s], got %d",
+			roundErrorMessage,
+			count,
+		)
+	}
+	if count := countLogEntries(entries, "debug", roundErrorMessage); count != 1 {
+		t.Errorf(
+			"expected 1 debug entry with message [%s], got %d",
+			roundErrorMessage,
+			count,
+		)
 	}
 }


### PR DESCRIPTION
## Problem

keep-core's release pipeline carries several long-standing, non-blocking log-noise and observability gaps around three specific areas. The periodic well-known-peer connection supervisor logged a binary "all bootstrap attempts failed" warning whenever every currently-disconnected peer failed to dial, even on a node connected to the large majority of its well-known peers, so the message routinely misrepresented a healthy node as isolated. The Bitcoin RPC health check logged a warning on every occurrence of a known-benign "invalid params" response from Electrum servers that don't support a particular parameter, flooding logs without signaling anything actionable. And the inbound connection handshake path silently swallowed the specific cause of every join failure into a single undifferentiated counter, with no log output at production levels to distinguish a timeout from a connection reset from a firewall rejection from a genuine on-chain RPC error.

## Solution

The well-known-peer connection log now reports the live unreachable/total ratio measured after all dials complete, with warning severity reserved for the case where the node ends a round connected to zero well-known peers; anything less severe than total isolation logs at info. The Bitcoin health check downgrades the specific known-benign Electrum error to debug level while keeping every other RPC error at warning, and tracks the benign case through a new counter so it stays observable without spamming logs. The inbound (and, for logging purposes, outbound) connection path now classifies every failure into one of five low-cardinality reasons, exposes a matching per-reason counter alongside the existing aggregate, and logs the remote address, peer ID, and reason on every failure branch. A new counter isolates the on-chain firewall-validation call volume from cache hits, and a Grafana panel plus a Prometheus alert cover the join-request metric family, with the alert gated on a failure-rate burst combined with peer loss or coordination degradation rather than the raw failure ratio alone, since a high ratio can be expected, correct behavior.

## Tests

Each change has new or extended unit test coverage in the package it touches: connectivity-ratio and severity behavior for the well-known-peer log across full, partial, and zero connectivity; the benign-versus-genuine Bitcoin RPC error distinction; failure classification and per-reason counter wiring for the inbound/outbound connection path; and the on-chain-check counter's cache-hit-versus-live-call distinction. gofmt, go vet, go build, staticcheck, gosec, and the full Go test suite all pass against these changes (verified locally against the same commands the CI workflow runs); the two pre-existing findings the broader repo carries outside these files were confirmed unrelated to this change and are unaffected by it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed network join request metrics, including success and failure reasons.
  * Added Bitcoin RPC health metrics for known benign header errors.
  * Improved connection-failure logging with clearer classifications and rate limiting.
  * Enhanced bootstrap connectivity reporting for isolated and partially connected nodes.

* **Monitoring**
  * Added Grafana visualizations for network join requests.
  * Added warnings for bursts of join failures alongside connectivity degradation.

* **Bug Fixes**
  * Known benign Bitcoin header errors are now logged at debug level while health status remains accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->