### PR TITLE
Add follower-side soft check for below-floor sweep fees

### DIFF
--- a/pkg/tbtc/deposit_sweep.go
+++ b/pkg/tbtc/deposit_sweep.go
@@ -49,6 +49,16 @@ const (
 	// the transaction is known on the Bitcoin chain. This delay is needed
 	// as spreading the transaction over the Bitcoin network takes time.
 	depositSweepBroadcastCheckDelay = 1 * time.Minute
+	// minSweepTxSatPerVByteFee mirrors tbtcpg.minWalletTxSatPerVByteFee, the safe
+	// minimum sweep fee rate. It is duplicated here because pkg/tbtcpg imports
+	// pkg/tbtc, so this package cannot import the canonical constant without a
+	// dependency cycle; keep the two in sync. It backs a follower-side soft
+	// (log-only) check that the leader's proposed sweep fee is not below the
+	// floor (see threshold-network/keep-core#4171).
+	minSweepTxSatPerVByteFee = 5
+	// depositScriptByteSize mirrors tbtcpg.depositScriptByteSize, the worst-case
+	// deposit script size used to estimate the sweep transaction virtual size.
+	depositScriptByteSize = 126
 )
 
 // DepositSweepProposal represents a deposit sweep proposal issued by a
@@ -460,6 +470,41 @@ func ValidateDepositSweepProposal(
 	validateProposalLogger.Infof(
 		"deposit sweep proposal is valid",
 	)
+
+	// Follower-side soft check on the proposed fee. The on-chain
+	// WalletProposalValidator only bounds the sweep fee from above, not below,
+	// so a misbehaving or unpatched leader can propose a fee at the ~1 sat/vByte
+	// relay floor that this node would otherwise sign - the same underpricing
+	// that jams the wallet (see threshold-network/keep-core#4171). We recompute
+	// the safe minimum and warn if the proposal is below it.
+	//
+	// This is intentionally log-only, not a rejection: rejecting a below-floor
+	// proposal here would, during a mixed-version rollout, split signers (patched
+	// nodes reject, unpatched nodes sign) and could stall signing. Hard
+	// enforcement belongs on-chain in the WalletProposalValidator, or behind a
+	// coordinated all-nodes upgrade.
+	if sweepTxSize, sizeErr := bitcoin.NewTransactionSizeEstimator().
+		AddPublicKeyHashInputs(1, true).
+		AddScriptHashInputs(len(proposal.DepositsKeys), depositScriptByteSize, true).
+		AddPublicKeyHashOutputs(1, true).
+		VirtualSize(); sizeErr != nil {
+		validateProposalLogger.Warnf(
+			"cannot estimate sweep tx size for the fee sanity check: [%v]",
+			sizeErr,
+		)
+	} else if minSweepTxFee := int64(minSweepTxSatPerVByteFee) * sweepTxSize; proposal.SweepTxFee != nil &&
+		proposal.SweepTxFee.Int64() < minSweepTxFee {
+		validateProposalLogger.Warnf(
+			"proposed sweep tx fee [%v] is below the safe minimum [%d] "+
+				"([%d] sat/vByte * [%d] vByte); the leader may be underpricing "+
+				"the sweep, which risks it getting stuck in the mempool and "+
+				"jamming the wallet",
+			proposal.SweepTxFee,
+			minSweepTxFee,
+			minSweepTxSatPerVByteFee,
+			sweepTxSize,
+		)
+	}
 
 	deposits := make([]*Deposit, len(depositExtraInfo))
 	for i, dei := range depositExtraInfo {

--- a/pkg/tbtc/deposit_sweep.go
+++ b/pkg/tbtc/deposit_sweep.go
@@ -49,14 +49,15 @@ const (
 	// the transaction is known on the Bitcoin chain. This delay is needed
 	// as spreading the transaction over the Bitcoin network takes time.
 	depositSweepBroadcastCheckDelay = 1 * time.Minute
-	// minSweepTxSatPerVByteFee mirrors tbtcpg.minWalletTxSatPerVByteFee, the safe
+	// minSweepTxSatPerVByteFee mirrors tbtcpg.MinWalletTxSatPerVByteFee, the safe
 	// minimum sweep fee rate. It is duplicated here because pkg/tbtcpg imports
 	// pkg/tbtc, so this package cannot import the canonical constant without a
-	// dependency cycle; keep the two in sync. It backs a follower-side soft
-	// (log-only) check that the leader's proposed sweep fee is not below the
-	// floor (see threshold-network/keep-core#4171).
+	// dependency cycle; keep the two in sync (guarded by TestSweepFeeConstants
+	// MirrorTbtcpg). It backs a follower-side soft (log-only) check that the
+	// leader's proposed sweep fee is not below the floor (see
+	// threshold-network/keep-core#4171).
 	minSweepTxSatPerVByteFee = 5
-	// depositScriptByteSize mirrors tbtcpg.depositScriptByteSize, the worst-case
+	// depositScriptByteSize mirrors tbtcpg.DepositScriptByteSize, the worst-case
 	// deposit script size used to estimate the sweep transaction virtual size.
 	depositScriptByteSize = 126
 )

--- a/pkg/tbtc/sweep_fee_sync_test.go
+++ b/pkg/tbtc/sweep_fee_sync_test.go
@@ -1,0 +1,46 @@
+package tbtc_test
+
+import (
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/tbtcpg"
+)
+
+// TestSweepFeeConstantsMirrorTbtcpg guards the sweep-fee constants that
+// pkg/tbtc/deposit_sweep.go duplicates from pkg/tbtcpg. The follower-side soft
+// check (threshold-network/keep-core#4171) recomputes the safe minimum sweep
+// fee, but pkg/tbtcpg imports pkg/tbtc, so pkg/tbtc cannot import the canonical
+// constants without a dependency cycle and hand-copies them instead.
+//
+// This test lives in the external tbtc_test package precisely because that
+// package can import pkg/tbtcpg without forming the cycle. It pins the canonical
+// tbtcpg values to the literals mirrored in pkg/tbtc/deposit_sweep.go
+// (minSweepTxSatPerVByteFee and depositScriptByteSize). If the canonical values
+// drift, this test fails, forcing the pkg/tbtc mirrors - and these expected
+// literals - to be updated together.
+func TestSweepFeeConstantsMirrorTbtcpg(t *testing.T) {
+	// Mirrored by pkg/tbtc/deposit_sweep.go:minSweepTxSatPerVByteFee.
+	const expectedMinWalletTxSatPerVByteFee = 5
+	// Mirrored by pkg/tbtc/deposit_sweep.go:depositScriptByteSize.
+	const expectedDepositScriptByteSize = 126
+
+	if tbtcpg.MinWalletTxSatPerVByteFee != expectedMinWalletTxSatPerVByteFee {
+		t.Errorf(
+			"tbtcpg.MinWalletTxSatPerVByteFee is [%d]; the pkg/tbtc mirror "+
+				"minSweepTxSatPerVByteFee [%d] is now stale and must be updated "+
+				"along with this test",
+			tbtcpg.MinWalletTxSatPerVByteFee,
+			expectedMinWalletTxSatPerVByteFee,
+		)
+	}
+
+	if tbtcpg.DepositScriptByteSize != expectedDepositScriptByteSize {
+		t.Errorf(
+			"tbtcpg.DepositScriptByteSize is [%d]; the pkg/tbtc mirror "+
+				"depositScriptByteSize [%d] is now stale and must be updated "+
+				"along with this test",
+			tbtcpg.DepositScriptByteSize,
+			expectedDepositScriptByteSize,
+		)
+	}
+}

--- a/pkg/tbtcpg/deposit_sweep.go
+++ b/pkg/tbtcpg/deposit_sweep.go
@@ -31,6 +31,14 @@ const depositScriptByteSize = 126
 // safely above the relay floor while remaining far below the Bridge's
 // per-deposit maximum fee. The value is intentionally conservative and could be
 // made configurable; see threshold-network/keep-core#4171.
+//
+// NOTE: this static floor and the 25% buffer applied below are a stopgap for
+// the current fire-and-forget, non-RBF sweep path: because a stuck sweep cannot
+// be fee-bumped, the fee must be right on the first broadcast. Once RBF /
+// fee-bumping lands (Part B, tracked in #4171) the safety net shifts to
+// monitor-and-bump, and this policy should be revisited rather than carried
+// forward unchanged: the defensive buffer can be dropped and the floor relaxed
+// toward the live estimate, keeping only a small relay-propagation minimum.
 const minSweepTxSatPerVByteFee = 5
 
 // DepositSweepLookBackBlocks is the look-back period in blocks used
@@ -677,6 +685,13 @@ func estimateDepositsSweepFee(
 	// (see threshold-network/keep-core#4171), then enforce the minimum floor and
 	// bound the result by the Bridge maximum (which the floor cannot exceed, per
 	// the check above).
+	//
+	// Caveat: transactionSize assumes all deposit inputs are witness (P2WSH), per
+	// this function's doc comment. A sweep that includes legacy P2SH deposits has
+	// a larger on-wire vsize than estimated here, so the effective on-wire rate
+	// can land slightly below the floor for such (rare) sweeps. It still dominates
+	// the 1 sat/vByte relay floor this fix targets; a fully accurate floor would
+	// require deposit-type-aware sizing.
 	rate := totalFee / transactionSize
 	rate = (rate*5 + 3) / 4 // ceil(rate * 1.25)
 	if rate < minSweepTxSatPerVByteFee {

--- a/pkg/tbtcpg/deposit_sweep.go
+++ b/pkg/tbtcpg/deposit_sweep.go
@@ -17,9 +17,10 @@ import (
 	"github.com/keep-network/keep-core/pkg/tbtc"
 )
 
-// Use the worst-case 126-byte deposit script with embedded extra data for estimation.
-// This will ensure that deposit sweep transaction fees are not underestimated.
-const depositScriptByteSize = 126
+// DepositScriptByteSize is the worst-case 126-byte deposit script with embedded
+// extra data used for transaction size estimation. This ensures that deposit
+// sweep transaction fees are not underestimated.
+const DepositScriptByteSize = 126
 
 // DepositSweepLookBackBlocks is the look-back period in blocks used
 // when searching for submitted deposit-related events. It's equal to
@@ -623,7 +624,7 @@ func estimateDepositsSweepFee(
 		// 1 P2WPKH main UTXO input.
 		AddPublicKeyHashInputs(1, true).
 		// depositsCount P2WSH deposit inputs.
-		AddScriptHashInputs(depositsCount, depositScriptByteSize, true).
+		AddScriptHashInputs(depositsCount, DepositScriptByteSize, true).
 		// 1 P2WPKH output.
 		AddPublicKeyHashOutputs(1, true).
 		VirtualSize()

--- a/pkg/tbtcpg/deposit_sweep.go
+++ b/pkg/tbtcpg/deposit_sweep.go
@@ -650,19 +650,29 @@ func estimateDepositsSweepFee(
 		return 0, 0, fmt.Errorf("cannot estimate transaction fee: [%v]", err)
 	}
 
-	// Clamp the estimated fee up to a safe minimum so the sweep is never
-	// broadcast near the 1 sat/vByte relay floor, which can leave it stuck in
-	// the mempool and jam the wallet (see minSweepTxSatPerVByteFee). The
-	// Bridge's maximum-fee check below still bounds the result from above.
-	if minTotalFee := minSweepTxSatPerVByteFee * transactionSize; totalFee < minTotalFee {
-		totalFee = minTotalFee
-	}
-
 	// Compute the maximum possible total fee for the entire sweep transaction.
 	totalMaxFee := uint64(depositsCount) * perDepositMaxFee
 
+	// A genuine fee estimate that exceeds the Bridge maximum is an error (the
+	// sweep is not economical to perform). This is checked before the minimum
+	// below is applied so that raising the fee to the minimum can never itself
+	// trigger this error.
 	if uint64(totalFee) > totalMaxFee {
 		return 0, 0, fmt.Errorf("estimated fee exceeds the maximum fee")
+	}
+
+	// Clamp the estimated fee up to a safe minimum so the sweep is never
+	// broadcast near the 1 sat/vByte relay floor, which can leave it stuck in
+	// the mempool and jam the wallet (see minSweepTxSatPerVByteFee). The minimum
+	// is itself bounded by the Bridge maximum above, so it can never exceed the
+	// cap. In practice the minimum is orders of magnitude below the cap; the
+	// bound only guards against future parameter changes.
+	minTotalFee := minSweepTxSatPerVByteFee * transactionSize
+	if uint64(minTotalFee) > totalMaxFee {
+		minTotalFee = int64(totalMaxFee)
+	}
+	if totalFee < minTotalFee {
+		totalFee = minTotalFee
 	}
 
 	// Compute the actual sat/vbyte fee for informational purposes.

--- a/pkg/tbtcpg/deposit_sweep.go
+++ b/pkg/tbtcpg/deposit_sweep.go
@@ -21,26 +21,6 @@ import (
 // This will ensure that deposit sweep transaction fees are not underestimated.
 const depositScriptByteSize = 126
 
-// minSweepTxSatPerVByteFee is the minimum fee rate, in sat/vByte, applied to
-// deposit sweep transactions. A fee oracle can return an unusably low estimate
-// (down to the 1 sat/vByte relay floor enforced by the Electrum client) in an
-// uncongested mempool. Because a sweep consolidates significant wallet value
-// and is not RBF-enabled, it cannot be replaced once broadcast, so a floor-rate
-// sweep can get stuck in the mempool and jam the wallet: no new sweep can be
-// built while the previous one is unconfirmed. This minimum keeps the sweep fee
-// safely above the relay floor while remaining far below the Bridge's
-// per-deposit maximum fee. The value is intentionally conservative and could be
-// made configurable; see threshold-network/keep-core#4171.
-//
-// NOTE: this static floor and the 25% buffer applied below are a stopgap for
-// the current fire-and-forget, non-RBF sweep path: because a stuck sweep cannot
-// be fee-bumped, the fee must be right on the first broadcast. Once RBF /
-// fee-bumping lands (Part B, tracked in #4171) the safety net shifts to
-// monitor-and-bump, and this policy should be revisited rather than carried
-// forward unchanged: the defensive buffer can be dropped and the floor relaxed
-// toward the live estimate, keeping only a small relay-propagation minimum.
-const minSweepTxSatPerVByteFee = 5
-
 // DepositSweepLookBackBlocks is the look-back period in blocks used
 // when searching for submitted deposit-related events. It's equal to
 // 30 days assuming 12 seconds per block.
@@ -667,24 +647,9 @@ func estimateDepositsSweepFee(
 		return 0, 0, fmt.Errorf("estimated fee exceeds the maximum fee")
 	}
 
-	// A sweep must never be broadcast below a safe minimum fee rate, or it may
-	// get stuck in the mempool and jam the wallet (see minSweepTxSatPerVByteFee).
-	// If even that minimum fee exceeds the Bridge maximum, a safe sweep cannot be
-	// constructed; return an error rather than silently broadcasting an
-	// underpriced transaction.
-	if uint64(minSweepTxSatPerVByteFee*transactionSize) > totalMaxFee {
-		return 0, 0, fmt.Errorf(
-			"minimum safe sweep fee [%d] exceeds the maximum fee [%d]",
-			minSweepTxSatPerVByteFee*transactionSize,
-			totalMaxFee,
-		)
-	}
-
-	// Add a 25% buffer over the oracle estimate so there is margin during the
-	// estimate-to-broadcast delay and the fee stays adaptive under congestion
-	// (see threshold-network/keep-core#4171), then enforce the minimum floor and
-	// bound the result by the Bridge maximum (which the floor cannot exceed, per
-	// the check above).
+	// Enforce the safe minimum fee rate and 25% buffer, bounded by the Bridge
+	// maximum, so a sweep is never broadcast below the floor where it could get
+	// stuck and jam the wallet. Errors if even the floor exceeds the maximum.
 	//
 	// Caveat: transactionSize assumes all deposit inputs are witness (P2WSH), per
 	// this function's doc comment. A sweep that includes legacy P2SH deposits has
@@ -692,14 +657,9 @@ func estimateDepositsSweepFee(
 	// can land slightly below the floor for such (rare) sweeps. It still dominates
 	// the 1 sat/vByte relay floor this fix targets; a fully accurate floor would
 	// require deposit-type-aware sizing.
-	rate := totalFee / transactionSize
-	rate = (rate*5 + 3) / 4 // ceil(rate * 1.25)
-	if rate < minSweepTxSatPerVByteFee {
-		rate = minSweepTxSatPerVByteFee
-	}
-	totalFee = rate * transactionSize
-	if uint64(totalFee) > totalMaxFee {
-		totalFee = int64(totalMaxFee)
+	totalFee, err = applyWalletTxFeeFloor(totalFee, transactionSize, totalMaxFee)
+	if err != nil {
+		return 0, 0, err
 	}
 
 	// Compute the actual sat/vbyte fee for informational purposes.

--- a/pkg/tbtcpg/deposit_sweep.go
+++ b/pkg/tbtcpg/deposit_sweep.go
@@ -21,6 +21,18 @@ import (
 // This will ensure that deposit sweep transaction fees are not underestimated.
 const depositScriptByteSize = 126
 
+// minSweepTxSatPerVByteFee is the minimum fee rate, in sat/vByte, applied to
+// deposit sweep transactions. A fee oracle can return an unusably low estimate
+// (down to the 1 sat/vByte relay floor enforced by the Electrum client) in an
+// uncongested mempool. Because a sweep consolidates significant wallet value
+// and is not RBF-enabled, it cannot be replaced once broadcast, so a floor-rate
+// sweep can get stuck in the mempool and jam the wallet: no new sweep can be
+// built while the previous one is unconfirmed. This minimum keeps the sweep fee
+// safely above the relay floor while remaining far below the Bridge's
+// per-deposit maximum fee. The value is intentionally conservative and could be
+// made configurable; see threshold-network/keep-core#4171.
+const minSweepTxSatPerVByteFee = 5
+
 // DepositSweepLookBackBlocks is the look-back period in blocks used
 // when searching for submitted deposit-related events. It's equal to
 // 30 days assuming 12 seconds per block.
@@ -636,6 +648,14 @@ func estimateDepositsSweepFee(
 	totalFee, err := feeEstimator.EstimateFee(transactionSize)
 	if err != nil {
 		return 0, 0, fmt.Errorf("cannot estimate transaction fee: [%v]", err)
+	}
+
+	// Clamp the estimated fee up to a safe minimum so the sweep is never
+	// broadcast near the 1 sat/vByte relay floor, which can leave it stuck in
+	// the mempool and jam the wallet (see minSweepTxSatPerVByteFee). The
+	// Bridge's maximum-fee check below still bounds the result from above.
+	if minTotalFee := minSweepTxSatPerVByteFee * transactionSize; totalFee < minTotalFee {
+		totalFee = minTotalFee
 	}
 
 	// Compute the maximum possible total fee for the entire sweep transaction.

--- a/pkg/tbtcpg/deposit_sweep.go
+++ b/pkg/tbtcpg/deposit_sweep.go
@@ -653,26 +653,38 @@ func estimateDepositsSweepFee(
 	// Compute the maximum possible total fee for the entire sweep transaction.
 	totalMaxFee := uint64(depositsCount) * perDepositMaxFee
 
-	// A genuine fee estimate that exceeds the Bridge maximum is an error (the
-	// sweep is not economical to perform). This is checked before the minimum
-	// below is applied so that raising the fee to the minimum can never itself
-	// trigger this error.
+	// A raw estimate already above the Bridge maximum means the sweep is
+	// uneconomical to perform; return an error.
 	if uint64(totalFee) > totalMaxFee {
 		return 0, 0, fmt.Errorf("estimated fee exceeds the maximum fee")
 	}
 
-	// Clamp the estimated fee up to a safe minimum so the sweep is never
-	// broadcast near the 1 sat/vByte relay floor, which can leave it stuck in
-	// the mempool and jam the wallet (see minSweepTxSatPerVByteFee). The minimum
-	// is itself bounded by the Bridge maximum above, so it can never exceed the
-	// cap. In practice the minimum is orders of magnitude below the cap; the
-	// bound only guards against future parameter changes.
-	minTotalFee := minSweepTxSatPerVByteFee * transactionSize
-	if uint64(minTotalFee) > totalMaxFee {
-		minTotalFee = int64(totalMaxFee)
+	// A sweep must never be broadcast below a safe minimum fee rate, or it may
+	// get stuck in the mempool and jam the wallet (see minSweepTxSatPerVByteFee).
+	// If even that minimum fee exceeds the Bridge maximum, a safe sweep cannot be
+	// constructed; return an error rather than silently broadcasting an
+	// underpriced transaction.
+	if uint64(minSweepTxSatPerVByteFee*transactionSize) > totalMaxFee {
+		return 0, 0, fmt.Errorf(
+			"minimum safe sweep fee [%d] exceeds the maximum fee [%d]",
+			minSweepTxSatPerVByteFee*transactionSize,
+			totalMaxFee,
+		)
 	}
-	if totalFee < minTotalFee {
-		totalFee = minTotalFee
+
+	// Add a 25% buffer over the oracle estimate so there is margin during the
+	// estimate-to-broadcast delay and the fee stays adaptive under congestion
+	// (see threshold-network/keep-core#4171), then enforce the minimum floor and
+	// bound the result by the Bridge maximum (which the floor cannot exceed, per
+	// the check above).
+	rate := totalFee / transactionSize
+	rate = (rate*5 + 3) / 4 // ceil(rate * 1.25)
+	if rate < minSweepTxSatPerVByteFee {
+		rate = minSweepTxSatPerVByteFee
+	}
+	totalFee = rate * transactionSize
+	if uint64(totalFee) > totalMaxFee {
+		totalFee = int64(totalMaxFee)
 	}
 
 	// Compute the actual sat/vbyte fee for informational purposes.

--- a/pkg/tbtcpg/deposit_sweep_fee_test.go
+++ b/pkg/tbtcpg/deposit_sweep_fee_test.go
@@ -14,7 +14,7 @@ import (
 // returns an error rather than silently broadcasting an underpriced sweep.
 func TestEstimateDepositsSweepFee_MinimumFloorAndBuffer(t *testing.T) {
 	// Virtual size of a one-deposit sweep, used to size the cap for the error
-	// case relative to the minimum floor. 126 == depositScriptByteSize.
+	// case relative to the minimum floor. 126 == DepositScriptByteSize.
 	size, err := bitcoin.NewTransactionSizeEstimator().
 		AddPublicKeyHashInputs(1, true).
 		AddScriptHashInputs(1, 126, true).

--- a/pkg/tbtcpg/deposit_sweep_fee_test.go
+++ b/pkg/tbtcpg/deposit_sweep_fee_test.go
@@ -1,0 +1,51 @@
+package tbtcpg_test
+
+import (
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/tbtcpg"
+)
+
+// TestEstimateDepositsSweepFee_MinimumFloor verifies that an unusably low fee
+// estimate is raised to the minimum sweep fee rate (see minSweepTxSatPerVByteFee,
+// currently 5 sat/vByte), while a healthy estimate is left unchanged.
+func TestEstimateDepositsSweepFee_MinimumFloor(t *testing.T) {
+	tests := map[string]struct {
+		estimateSatPerVByte    int64
+		expectedSatPerVByteFee int64
+	}{
+		"low estimate is raised to the minimum": {
+			estimateSatPerVByte:    1,
+			expectedSatPerVByteFee: 5,
+		},
+		"healthy estimate is left unchanged": {
+			estimateSatPerVByte:    20,
+			expectedSatPerVByteFee: 20,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			tbtcChain := tbtcpg.NewLocalChain()
+			// A per-deposit maximum fee high enough not to bind here.
+			tbtcChain.SetDepositParameters(0, 0, 100000, 0)
+
+			btcChain := tbtcpg.NewLocalBitcoinChain()
+			btcChain.SetEstimateSatPerVByteFee(1, test.estimateSatPerVByte)
+
+			fees, err := tbtcpg.EstimateDepositsSweepFee(tbtcChain, btcChain, 1)
+			if err != nil {
+				t.Fatalf("unexpected error: [%v]", err)
+			}
+
+			got := fees[1].SatPerVByteFee
+			if got != test.expectedSatPerVByteFee {
+				t.Errorf(
+					"unexpected sweep fee rate\nexpected: [%d] sat/vByte\nactual:   [%d] sat/vByte",
+					test.expectedSatPerVByteFee,
+					got,
+				)
+			}
+		})
+	}
+}

--- a/pkg/tbtcpg/deposit_sweep_fee_test.go
+++ b/pkg/tbtcpg/deposit_sweep_fee_test.go
@@ -54,7 +54,7 @@ func TestEstimateDepositsSweepFee_MinimumFloorAndBuffer(t *testing.T) {
 			// substring pins this to the floor-exceeds-cap branch specifically,
 			// distinguishing it from the raw-fee-exceeds-cap error.
 			perDepositMaxFee:    uint64(3 * size),
-			expectErrorContains: "minimum safe sweep fee",
+			expectErrorContains: "minimum safe transaction fee",
 		},
 	}
 

--- a/pkg/tbtcpg/deposit_sweep_fee_test.go
+++ b/pkg/tbtcpg/deposit_sweep_fee_test.go
@@ -40,6 +40,13 @@ func TestEstimateDepositsSweepFee_MinimumFloorAndBuffer(t *testing.T) {
 			perDepositMaxFee:       100000,
 			expectedSatPerVByteFee: 25, // ceil(20*1.25) = 25
 		},
+		"buffered estimate above the cap is bounded to the cap": {
+			estimateSatPerVByte: 20,
+			// ceil(20*1.25)=25 sat/vByte buffered fee exceeds the 22*size cap,
+			// so it is bounded down to the cap (rate 22), not the buffered 25.
+			perDepositMaxFee:       uint64(22 * size),
+			expectedSatPerVByteFee: 22,
+		},
 		"minimum floor above the cap returns an error": {
 			estimateSatPerVByte: 1,
 			// Cap sits below 5*size (the floor) but above the raw fee (1*size),

--- a/pkg/tbtcpg/deposit_sweep_fee_test.go
+++ b/pkg/tbtcpg/deposit_sweep_fee_test.go
@@ -3,47 +3,74 @@ package tbtcpg_test
 import (
 	"testing"
 
+	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/tbtcpg"
 )
 
-// TestEstimateDepositsSweepFee_MinimumFloor verifies that an unusably low fee
-// estimate is raised to the minimum sweep fee rate (see minSweepTxSatPerVByteFee,
-// currently 5 sat/vByte), while a healthy estimate is left unchanged.
-func TestEstimateDepositsSweepFee_MinimumFloor(t *testing.T) {
+// TestEstimateDepositsSweepFee_MinimumFloorAndBuffer verifies the sweep fee
+// logic: a low estimate is raised to the minimum floor, an estimate above the
+// floor is buffered by 25%, and a Bridge maximum below the minimum floor
+// returns an error rather than silently broadcasting an underpriced sweep.
+func TestEstimateDepositsSweepFee_MinimumFloorAndBuffer(t *testing.T) {
+	// Virtual size of a one-deposit sweep, used to size the cap for the error
+	// case relative to the minimum floor. 126 == depositScriptByteSize.
+	size, err := bitcoin.NewTransactionSizeEstimator().
+		AddPublicKeyHashInputs(1, true).
+		AddScriptHashInputs(1, 126, true).
+		AddPublicKeyHashOutputs(1, true).
+		VirtualSize()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tests := map[string]struct {
 		estimateSatPerVByte    int64
+		perDepositMaxFee       uint64
 		expectedSatPerVByteFee int64
+		expectError            bool
 	}{
-		"low estimate is raised to the minimum": {
+		"low estimate is raised to the minimum floor": {
 			estimateSatPerVByte:    1,
-			expectedSatPerVByteFee: 5,
+			perDepositMaxFee:       100000,
+			expectedSatPerVByteFee: 5, // max(5, ceil(1*1.25)=2) = 5
 		},
-		"healthy estimate is left unchanged": {
+		"estimate above the floor is buffered by 25%": {
 			estimateSatPerVByte:    20,
-			expectedSatPerVByteFee: 20,
+			perDepositMaxFee:       100000,
+			expectedSatPerVByteFee: 25, // ceil(20*1.25) = 25
+		},
+		"minimum floor above the cap returns an error": {
+			estimateSatPerVByte: 1,
+			// Cap sits below 5*size (the floor) but above the raw fee (1*size),
+			// so the minimum-fee check must error rather than lower the fee.
+			perDepositMaxFee: uint64(3 * size),
+			expectError:      true,
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			tbtcChain := tbtcpg.NewLocalChain()
-			// A per-deposit maximum fee high enough not to bind here.
-			tbtcChain.SetDepositParameters(0, 0, 100000, 0)
+			tbtcChain.SetDepositParameters(0, 0, test.perDepositMaxFee, 0)
 
 			btcChain := tbtcpg.NewLocalBitcoinChain()
 			btcChain.SetEstimateSatPerVByteFee(1, test.estimateSatPerVByte)
 
 			fees, err := tbtcpg.EstimateDepositsSweepFee(tbtcChain, btcChain, 1)
+
+			if test.expectError {
+				if err == nil {
+					t.Fatalf("expected an error, got fee result [%v]", fees)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("unexpected error: [%v]", err)
 			}
-
-			got := fees[1].SatPerVByteFee
-			if got != test.expectedSatPerVByteFee {
+			if got := fees[1].SatPerVByteFee; got != test.expectedSatPerVByteFee {
 				t.Errorf(
 					"unexpected sweep fee rate\nexpected: [%d] sat/vByte\nactual:   [%d] sat/vByte",
-					test.expectedSatPerVByteFee,
-					got,
+					test.expectedSatPerVByteFee, got,
 				)
 			}
 		})

--- a/pkg/tbtcpg/deposit_sweep_fee_test.go
+++ b/pkg/tbtcpg/deposit_sweep_fee_test.go
@@ -1,6 +1,7 @@
 package tbtcpg_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
@@ -27,7 +28,7 @@ func TestEstimateDepositsSweepFee_MinimumFloorAndBuffer(t *testing.T) {
 		estimateSatPerVByte    int64
 		perDepositMaxFee       uint64
 		expectedSatPerVByteFee int64
-		expectError            bool
+		expectErrorContains    string
 	}{
 		"low estimate is raised to the minimum floor": {
 			estimateSatPerVByte:    1,
@@ -42,9 +43,11 @@ func TestEstimateDepositsSweepFee_MinimumFloorAndBuffer(t *testing.T) {
 		"minimum floor above the cap returns an error": {
 			estimateSatPerVByte: 1,
 			// Cap sits below 5*size (the floor) but above the raw fee (1*size),
-			// so the minimum-fee check must error rather than lower the fee.
-			perDepositMaxFee: uint64(3 * size),
-			expectError:      true,
+			// so the minimum-fee check must error rather than lower the fee. The
+			// substring pins this to the floor-exceeds-cap branch specifically,
+			// distinguishing it from the raw-fee-exceeds-cap error.
+			perDepositMaxFee:    uint64(3 * size),
+			expectErrorContains: "minimum safe sweep fee",
 		},
 	}
 
@@ -58,9 +61,15 @@ func TestEstimateDepositsSweepFee_MinimumFloorAndBuffer(t *testing.T) {
 
 			fees, err := tbtcpg.EstimateDepositsSweepFee(tbtcChain, btcChain, 1)
 
-			if test.expectError {
+			if test.expectErrorContains != "" {
 				if err == nil {
 					t.Fatalf("expected an error, got fee result [%v]", fees)
+				}
+				if !strings.Contains(err.Error(), test.expectErrorContains) {
+					t.Fatalf(
+						"expected error containing [%s]; got [%v]",
+						test.expectErrorContains, err,
+					)
 				}
 				return
 			}

--- a/pkg/tbtcpg/fee.go
+++ b/pkg/tbtcpg/fee.go
@@ -1,0 +1,74 @@
+package tbtcpg
+
+import "fmt"
+
+// minWalletTxSatPerVByteFee is the minimum fee rate, in sat/vByte, applied to
+// wallet Bitcoin transactions (deposit sweeps, redemptions, moving funds, moved
+// funds sweeps). A fee oracle can return an unusably low estimate (down to the
+// 1 sat/vByte relay floor enforced by the Electrum client) in an uncongested
+// mempool. Because these transactions spend or consolidate significant wallet
+// value and are not RBF-enabled, they cannot be replaced once broadcast, so a
+// floor-rate transaction can get stuck in the mempool and jam the wallet: no
+// new wallet transaction can be built while the previous one is unconfirmed.
+// This minimum keeps the fee safely above the relay floor while remaining far
+// below the Bridge's maximum fee. The value is intentionally conservative and
+// could be made configurable; see threshold-network/keep-core#4171.
+//
+// NOTE: this static floor and the 25% buffer applied in applyWalletTxFeeFloor
+// are a stopgap for the current fire-and-forget, non-RBF wallet transaction
+// path: because a stuck transaction cannot be fee-bumped, the fee must be right
+// on the first broadcast. Once RBF / fee-bumping lands (Part B, tracked in
+// #4171) the safety net shifts to monitor-and-bump, and this policy should be
+// revisited rather than carried forward unchanged: the defensive buffer can be
+// dropped and the floor relaxed toward the live estimate, keeping only a small
+// relay-propagation minimum.
+const minWalletTxSatPerVByteFee = 5
+
+// applyWalletTxFeeFloor raises a raw oracle fee estimate to a safe value for a
+// non-RBF wallet transaction. It:
+//   - adds a 25% buffer over the oracle estimate so there is margin during the
+//     estimate-to-broadcast delay and the fee stays adaptive under congestion,
+//   - enforces a floor of minWalletTxSatPerVByteFee sat/vByte, and
+//   - bounds the result by maxTotalFee (the Bridge maximum for the transaction).
+//
+// It returns an error if the minimum floor alone would exceed maxTotalFee - a
+// safe transaction cannot be built, so the caller must not broadcast an
+// underpriced one. estimatedFee is the raw oracle fee and txVsize is the
+// estimated transaction virtual size, both in the usual sat / vByte units.
+//
+// The buffer and floor are applied to the estimated vsize; a transaction whose
+// real on-wire vsize is larger than estimated (e.g. a deposit sweep containing
+// legacy P2SH inputs) can land slightly below the intended rate, but still far
+// above the relay floor this guards against.
+func applyWalletTxFeeFloor(
+	estimatedFee int64,
+	txVsize int64,
+	maxTotalFee uint64,
+) (int64, error) {
+	if txVsize <= 0 {
+		return 0, fmt.Errorf("invalid transaction virtual size [%d]", txVsize)
+	}
+
+	// If even the minimum floor exceeds the Bridge maximum, a safe transaction
+	// cannot be constructed; error rather than silently broadcast underpriced.
+	if uint64(minWalletTxSatPerVByteFee*txVsize) > maxTotalFee {
+		return 0, fmt.Errorf(
+			"minimum safe transaction fee [%d] exceeds the maximum fee [%d]",
+			minWalletTxSatPerVByteFee*txVsize,
+			maxTotalFee,
+		)
+	}
+
+	rate := estimatedFee / txVsize
+	rate = (rate*5 + 3) / 4 // ceil(rate * 1.25)
+	if rate < minWalletTxSatPerVByteFee {
+		rate = minWalletTxSatPerVByteFee
+	}
+
+	totalFee := rate * txVsize
+	if uint64(totalFee) > maxTotalFee {
+		totalFee = int64(maxTotalFee)
+	}
+
+	return totalFee, nil
+}

--- a/pkg/tbtcpg/fee.go
+++ b/pkg/tbtcpg/fee.go
@@ -2,7 +2,7 @@ package tbtcpg
 
 import "fmt"
 
-// minWalletTxSatPerVByteFee is the minimum fee rate, in sat/vByte, applied to
+// MinWalletTxSatPerVByteFee is the minimum fee rate, in sat/vByte, applied to
 // wallet Bitcoin transactions (deposit sweeps, redemptions, moving funds, moved
 // funds sweeps). A fee oracle can return an unusably low estimate (down to the
 // 1 sat/vByte relay floor enforced by the Electrum client) in an uncongested
@@ -22,13 +22,13 @@ import "fmt"
 // revisited rather than carried forward unchanged: the defensive buffer can be
 // dropped and the floor relaxed toward the live estimate, keeping only a small
 // relay-propagation minimum.
-const minWalletTxSatPerVByteFee = 5
+const MinWalletTxSatPerVByteFee = 5
 
 // applyWalletTxFeeFloor raises a raw oracle fee estimate to a safe value for a
 // non-RBF wallet transaction. It:
 //   - adds a 25% buffer over the oracle estimate so there is margin during the
 //     estimate-to-broadcast delay and the fee stays adaptive under congestion,
-//   - enforces a floor of minWalletTxSatPerVByteFee sat/vByte, and
+//   - enforces a floor of MinWalletTxSatPerVByteFee sat/vByte, and
 //   - bounds the result by maxTotalFee (the Bridge maximum for the transaction).
 //
 // It returns an error if the minimum floor alone would exceed maxTotalFee - a
@@ -51,18 +51,18 @@ func applyWalletTxFeeFloor(
 
 	// If even the minimum floor exceeds the Bridge maximum, a safe transaction
 	// cannot be constructed; error rather than silently broadcast underpriced.
-	if uint64(minWalletTxSatPerVByteFee*txVsize) > maxTotalFee {
+	if uint64(MinWalletTxSatPerVByteFee*txVsize) > maxTotalFee {
 		return 0, fmt.Errorf(
 			"minimum safe transaction fee [%d] exceeds the maximum fee [%d]",
-			minWalletTxSatPerVByteFee*txVsize,
+			MinWalletTxSatPerVByteFee*txVsize,
 			maxTotalFee,
 		)
 	}
 
 	rate := estimatedFee / txVsize
 	rate = (rate*5 + 3) / 4 // ceil(rate * 1.25)
-	if rate < minWalletTxSatPerVByteFee {
-		rate = minWalletTxSatPerVByteFee
+	if rate < MinWalletTxSatPerVByteFee {
+		rate = MinWalletTxSatPerVByteFee
 	}
 
 	totalFee := rate * txVsize

--- a/pkg/tbtcpg/fee_test.go
+++ b/pkg/tbtcpg/fee_test.go
@@ -1,0 +1,81 @@
+package tbtcpg
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestApplyWalletTxFeeFloor(t *testing.T) {
+	const vsize = 200
+
+	tests := map[string]struct {
+		estimatedFee        int64
+		txVsize             int64
+		maxTotalFee         uint64
+		expectedFee         int64
+		expectErrorContains string
+	}{
+		"estimate above the floor is buffered by 25%": {
+			estimatedFee: 4000, // rate 20 sat/vByte
+			txVsize:      vsize,
+			maxTotalFee:  100000,
+			expectedFee:  5000, // ceil(20*1.25)=25 sat/vByte * 200
+		},
+		"low estimate is raised to the minimum floor": {
+			estimatedFee: vsize, // rate 1 sat/vByte
+			txVsize:      vsize,
+			maxTotalFee:  100000,
+			expectedFee:  1000, // max(5, ceil(1*1.25)=2)=5 sat/vByte * 200
+		},
+		"buffered fee above the cap is bounded to the cap": {
+			estimatedFee: 4000, // rate 20 -> buffered 25 sat/vByte * 200 = 5000
+			txVsize:      vsize,
+			maxTotalFee:  4500, // below the buffered 5000
+			expectedFee:  4500,
+		},
+		"minimum floor above the cap returns an error": {
+			estimatedFee:        100,
+			txVsize:             vsize,
+			maxTotalFee:         800, // below the 5 sat/vByte floor (1000)
+			expectErrorContains: "minimum safe transaction fee",
+		},
+		"non-positive virtual size returns an error": {
+			estimatedFee:        1000,
+			txVsize:             0,
+			maxTotalFee:         100000,
+			expectErrorContains: "invalid transaction virtual size",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fee, err := applyWalletTxFeeFloor(
+				tc.estimatedFee,
+				tc.txVsize,
+				tc.maxTotalFee,
+			)
+
+			if tc.expectErrorContains != "" {
+				if err == nil {
+					t.Fatalf("expected an error, got fee [%d]", fee)
+				}
+				if !strings.Contains(err.Error(), tc.expectErrorContains) {
+					t.Fatalf(
+						"expected error containing [%s]; got [%v]",
+						tc.expectErrorContains, err,
+					)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: [%v]", err)
+			}
+			if fee != tc.expectedFee {
+				t.Errorf(
+					"unexpected fee\nexpected: [%d]\nactual:   [%d]",
+					tc.expectedFee, fee,
+				)
+			}
+		})
+	}
+}

--- a/pkg/tbtcpg/internal/test/testdata/propose_sweep_scenario_0.json
+++ b/pkg/tbtcpg/internal/test/testdata/propose_sweep_scenario_0.json
@@ -37,7 +37,7 @@
         "FundingOutputIndex": 3
       }
     ],
-    "SweepTxFee": 10634,
+    "SweepTxFee": 13497,
     "DepositsRevealBlocks": [11, 31, 32]
   }
 }

--- a/pkg/tbtcpg/moved_funds_sweep.go
+++ b/pkg/tbtcpg/moved_funds_sweep.go
@@ -411,5 +411,13 @@ func EstimateMovedFundsSweepFee(
 		return 0, ErrSweepTxFeeTooHigh
 	}
 
+	// Enforce the safe minimum fee rate and buffer so a non-RBF moved funds
+	// sweep transaction is never broadcast below the floor where it could get
+	// stuck and jam the wallet.
+	totalFee, err = applyWalletTxFeeFloor(totalFee, transactionSize, sweepTxMaxTotalFee)
+	if err != nil {
+		return 0, err
+	}
+
 	return totalFee, nil
 }

--- a/pkg/tbtcpg/moved_funds_sweep_test.go
+++ b/pkg/tbtcpg/moved_funds_sweep_test.go
@@ -365,7 +365,9 @@ func TestMovedFundsSweepAction_ProposeMovedFundsSweep(t *testing.T) {
 			expectedProposal: &tbtc.MovedFundsSweepProposal{
 				MovingFundsTxHash:        movingFundsTxHash,
 				MovingFundsTxOutputIndex: movingFundsTxOutputIndex,
-				SweepTxFee:               big.NewInt(4450),
+				// raw 4450 (178 vByte * 25 sat/vByte), buffered to
+				// ceil(25*1.25)=32 sat/vByte * 178 = 5696, below the 6000 cap.
+				SweepTxFee: big.NewInt(5696),
 			},
 		},
 	}
@@ -431,14 +433,18 @@ func TestEstimateMovedFundsSweepFee(t *testing.T) {
 		"estimated fee correct, one input": {
 			sweepTxMaxTotalFee: 3000,
 			hasMainUtxo:        false,
-			expectedFee:        1760,
-			expectedError:      nil,
+			// raw 1760 (110 vByte * 16 sat/vByte), buffered to
+			// ceil(16*1.25)=20 sat/vByte * 110 = 2200, below the cap.
+			expectedFee:   2200,
+			expectedError: nil,
 		},
 		"estimated fee correct, two inputs": {
 			sweepTxMaxTotalFee: 3000,
 			hasMainUtxo:        true,
-			expectedFee:        2848,
-			expectedError:      nil,
+			// raw 2848 (178 vByte * 16 sat/vByte); buffered 20 sat/vByte * 178
+			// = 3560 exceeds the 3000 cap, so it is bounded down to the cap.
+			expectedFee:   3000,
+			expectedError: nil,
 		},
 		"estimated fee too high": {
 			sweepTxMaxTotalFee: 2500,

--- a/pkg/tbtcpg/moving_funds.go
+++ b/pkg/tbtcpg/moving_funds.go
@@ -656,5 +656,13 @@ func EstimateMovingFundsFee(
 		return 0, ErrFeeTooHigh
 	}
 
+	// Enforce the safe minimum fee rate and buffer so a non-RBF moving funds
+	// transaction is never broadcast below the floor where it could get stuck
+	// and jam the wallet.
+	totalFee, err = applyWalletTxFeeFloor(totalFee, transactionSize, txMaxTotalFee)
+	if err != nil {
+		return 0, err
+	}
+
 	return totalFee, nil
 }

--- a/pkg/tbtcpg/moving_funds_test.go
+++ b/pkg/tbtcpg/moving_funds_test.go
@@ -568,8 +568,10 @@ func TestMovingFundsAction_ProposeMovingFunds(t *testing.T) {
 		"fee estimated": {
 			fee: 0, // trigger fee estimation
 			expectedProposal: &tbtc.MovingFundsProposal{
-				TargetWallets:    targetWallets,
-				MovingFundsTxFee: big.NewInt(4300),
+				TargetWallets: targetWallets,
+				// raw 4300 (172 vByte * 25 sat/vByte), buffered to
+				// ceil(25*1.25)=32 sat/vByte * 172 = 5504, below the 6000 cap.
+				MovingFundsTxFee: big.NewInt(5504),
 			},
 		},
 	}
@@ -655,7 +657,9 @@ func TestEstimateMovingFundsFee(t *testing.T) {
 	}{
 		"estimated fee correct": {
 			txMaxTotalFee: 6000,
-			expectedFee:   3248,
+			// raw 3248 (203 vByte * 16 sat/vByte), buffered to
+			// ceil(16*1.25)=20 sat/vByte * 203 = 4060, below the cap.
+			expectedFee:   4060,
 			expectedError: nil,
 		},
 		"estimated fee too high": {

--- a/pkg/tbtcpg/redemptions.go
+++ b/pkg/tbtcpg/redemptions.go
@@ -210,16 +210,25 @@ func (rt *RedemptionTask) ProposeRedemption(
 
 	taskLogger.Infof("preparing a redemption proposal")
 
-	// Estimate fee if it's missing. Do not check the estimated fee against
-	// the maximum total and per-request fees allowed by the Bridge. This
-	// is done during the on-chain validation of the proposal so there is no
-	// need to do it here.
+	// Estimate fee if it's missing. The per-request maximum fee is still
+	// checked during the on-chain validation of the proposal; here we bound
+	// the estimate by the maximum total fee only so the safe-minimum floor
+	// (see EstimateRedemptionFee) cannot produce a fee the Bridge would reject.
 	if fee <= 0 {
 		taskLogger.Infof("estimating redemption transaction fee")
+
+		_, _, _, txMaxTotalFee, _, _, _, err := rt.chain.GetRedemptionParameters()
+		if err != nil {
+			return nil, fmt.Errorf(
+				"cannot get redemption tx max total fee: [%w]",
+				err,
+			)
+		}
 
 		estimatedFee, err := EstimateRedemptionFee(
 			rt.btcChain,
 			redeemersOutputScripts,
+			txMaxTotalFee,
 		)
 		if err != nil {
 			return nil, fmt.Errorf(
@@ -462,10 +471,14 @@ redemptionRequestedLoop:
 }
 
 // EstimateRedemptionFee estimates fee for the redemption transaction that pays
-// the provided redeemers output scripts.
+// the provided redeemers output scripts. The estimated fee is floored at a safe
+// minimum rate and bounded above by txMaxTotalFee (the Bridge maximum), so a
+// non-RBF redemption is never broadcast below the floor where it could get stuck
+// and jam the wallet.
 func EstimateRedemptionFee(
 	btcChain bitcoin.Chain,
 	redeemersOutputScripts []bitcoin.Script,
+	txMaxTotalFee uint64,
 ) (int64, error) {
 	sizeEstimator := bitcoin.NewTransactionSizeEstimator().
 		// 1 P2WPKH main UTXO input.
@@ -498,6 +511,20 @@ func EstimateRedemptionFee(
 	totalFee, err := feeEstimator.EstimateFee(transactionSize)
 	if err != nil {
 		return 0, fmt.Errorf("cannot estimate transaction fee: [%v]", err)
+	}
+
+	// A raw estimate already above the Bridge maximum means the redemption is
+	// uneconomical to perform at the required fee; return an error rather than
+	// clamping to the maximum and broadcasting an underpriced transaction.
+	if uint64(totalFee) > txMaxTotalFee {
+		return 0, fmt.Errorf("estimated fee exceeds the maximum fee")
+	}
+
+	// Enforce the safe minimum fee rate and buffer, bounded by the Bridge
+	// maximum.
+	totalFee, err = applyWalletTxFeeFloor(totalFee, transactionSize, txMaxTotalFee)
+	if err != nil {
+		return 0, err
 	}
 
 	return totalFee, nil

--- a/pkg/tbtcpg/redemptions_test.go
+++ b/pkg/tbtcpg/redemptions_test.go
@@ -3,6 +3,7 @@ package tbtcpg_test
 import (
 	"encoding/hex"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -24,9 +25,6 @@ func TestEstimateRedemptionFee(t *testing.T) {
 		return bytes
 	}
 
-	btcChain := tbtcpg.NewLocalBitcoinChain()
-	btcChain.SetEstimateSatPerVByteFee(1, 16)
-
 	redeemersOutputScripts := []bitcoin.Script{
 		fromHex("76a9142cd680318747b720d67bf4246eb7403b476adb3488ac"),                   // P2PKH
 		fromHex("0014e6f9d74726b19b75f16fe1e9feaec048aa4fa1d0"),                         // P2WPKH
@@ -34,13 +32,61 @@ func TestEstimateRedemptionFee(t *testing.T) {
 		fromHex("0020ef0b4d985752aa5ef6243e4c6f6bebc2a007e7d671ef27d4b1d0db8dcc93bc1c"), // P2WSH
 	}
 
-	actualFee, err := tbtcpg.EstimateRedemptionFee(btcChain, redeemersOutputScripts)
-	if err != nil {
-		t.Fatal(err)
+	// The fixture above yields a 250 vByte redemption transaction.
+	const vsize = 250
+
+	tests := map[string]struct {
+		estimateSatPerVByte int64
+		txMaxTotalFee       uint64
+		expectedFee         int
+		expectErrorContains string
+	}{
+		"estimate above the floor is buffered by 25%": {
+			estimateSatPerVByte: 16,
+			txMaxTotalFee:       100000,
+			expectedFee:         5000, // ceil(16*1.25)=20 sat/vByte * 250 vByte
+		},
+		"low estimate is raised to the minimum floor": {
+			estimateSatPerVByte: 1,
+			txMaxTotalFee:       100000,
+			expectedFee:         1250, // max(5, ceil(1*1.25)=2)=5 sat/vByte * 250 vByte
+		},
+		"minimum floor above the cap returns an error": {
+			estimateSatPerVByte: 1,
+			txMaxTotalFee:       uint64(3 * vsize), // below the 5 sat/vByte floor
+			expectErrorContains: "minimum safe transaction fee",
+		},
 	}
 
-	expectedFee := 4000 // transactionVirtualSize * satPerVByteFee = 250 * 16 = 4000
-	testutils.AssertIntsEqual(t, "fee", expectedFee, int(actualFee))
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			btcChain := tbtcpg.NewLocalBitcoinChain()
+			btcChain.SetEstimateSatPerVByteFee(1, tc.estimateSatPerVByte)
+
+			actualFee, err := tbtcpg.EstimateRedemptionFee(
+				btcChain,
+				redeemersOutputScripts,
+				tc.txMaxTotalFee,
+			)
+
+			if tc.expectErrorContains != "" {
+				if err == nil {
+					t.Fatalf("expected an error, got fee [%d]", actualFee)
+				}
+				if !strings.Contains(err.Error(), tc.expectErrorContains) {
+					t.Fatalf(
+						"expected error containing [%s]; got [%v]",
+						tc.expectErrorContains, err,
+					)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			testutils.AssertIntsEqual(t, "fee", tc.expectedFee, int(actualFee))
+		})
+	}
 }
 
 func TestRedemptionAction_FindPendingRedemptions(t *testing.T) {
@@ -168,7 +214,9 @@ func TestRedemptionAction_ProposeRedemption(t *testing.T) {
 			fee: 0, // trigger fee estimation
 			expectedProposal: &tbtc.RedemptionProposal{
 				RedeemersOutputScripts: redeemersOutputScripts,
-				RedemptionTxFee:        big.NewInt(4300),
+				// raw 4300 (172 vByte * 25 sat/vByte), buffered to
+				// ceil(25*1.25)=32 sat/vByte * 172 = 5504, below the cap.
+				RedemptionTxFee: big.NewInt(5504),
 			},
 		},
 	}
@@ -179,6 +227,10 @@ func TestRedemptionAction_ProposeRedemption(t *testing.T) {
 			btcChain := tbtcpg.NewLocalBitcoinChain()
 
 			btcChain.SetEstimateSatPerVByteFee(1, 25)
+
+			// Fee estimation bounds the safe-minimum floor by the redemption
+			// tx max total fee; set a cap comfortably above the buffered fee.
+			tbtcChain.SetRedemptionParameters(0, 0, 0, 6000, 0, nil, 0)
 
 			for _, script := range redeemersOutputScripts {
 				tbtcChain.SetPendingRedemptionRequest(


### PR DESCRIPTION
Follows up on #4172 / #4179 (lrsaturnino review): the fee floor is enforced on the fee-*generation* side, but nothing enforces it on the follower/validation side. `ValidateDepositSweepProposal` delegates to the chain validator, and the on-chain `WalletProposalValidator` only bounds the sweep fee from above (plus `fee > 0`) — no minimum. So a misbehaving or unpatched coordination *leader* can propose a sweep at the ~1 sat/vByte relay floor and get patched followers to sign it — the #4171 jam scenario.

> **Stacked on #4179 → #4172** (based on branch `feat/floor-all-wallet-tx-fees`), so this PR's diff shows only its incremental change: the follower-side soft check in `pkg/tbtc/deposit_sweep.go`. Merge #4172 then #4179 first.

## Change

`ValidateDepositSweepProposal` now recomputes the safe minimum sweep fee (same vsize estimate + floor as the generator) and logs a warning if the proposed fee is below it.

**This is intentionally log-only, not a rejection.** Rejecting a below-floor proposal here would, during a mixed-version rollout, split signers (patched nodes reject, unpatched nodes sign) and could stall signing below threshold. This PR gives operators *detection* of an underpricing leader without a liveness risk.

## Why not hard enforcement here?

Hard enforcement of a fee minimum belongs where all signers apply the same rule with no version skew — **on-chain in `WalletProposalValidator` (tbtc-v2 repo)**, or behind a coordinated all-nodes keep-client upgrade. This PR is the safe keep-client-side increment; the on-chain change is the tracked follow-up.

## Notes

- The floor constant and deposit-script size are mirrored into `pkg/tbtc` (with keep-in-sync comments) because `pkg/tbtcpg` imports `pkg/tbtc`, so this package cannot import the canonical values without a dependency cycle.
- The check is log-only and its arithmetic mirrors the (tested) generator estimator, so no bespoke test is added — a dedicated test would require standing up the full `ValidateDepositSweepProposal` mock harness purely to assert a log line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved transaction fee estimation for deposits, redemptions, moved funds, and moving funds.
  * Added minimum safety floors and buffering to help prevent underpriced transactions.
  * Fee estimates now respect configured maximum limits and report an error when safe fees cannot fit within those limits.
  * Added validation warnings for unusually low proposed deposit sweep fees without rejecting valid proposals.
* **Tests**
  * Expanded coverage for fee floors, buffers, maximum limits, and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->