### PR TITLE
fix(electrum): set Network on all integration test configs

### DIFF
--- a/pkg/bitcoin/electrum/electrum_integration_test.go
+++ b/pkg/bitcoin/electrum/electrum_integration_test.go
@@ -42,25 +42,21 @@ type testConfig struct {
 	network      bitcoin.Network
 }
 
-// init propagates each test config's Bitcoin network into its Electrum
-// connection config. In production the network is injected during config
-// resolution; mirroring that here ensures the integration tests exercise the
-// same network-gated behavior (e.g. the low-fee estimate fallback) instead of
-// leaving Config.Network at its zero value (bitcoin.Unknown), which would
-// disable the fallback.
-func init() {
-	for key, tc := range testConfigs {
-		tc.clientConfig.Network = tc.network
-		testConfigs[key] = tc
-	}
-}
-
 // Servers details were taken from a public Electrum servers list published
 // at https://1209k.com/bitcoin-eye/ele.php?chain=tbtc.
+//
+// Every clientConfig must set Network explicitly, mirroring production config
+// resolution (config/electrum.go): the client gates network-dependent behavior
+// — e.g. the low-fee estimate fallback in EstimateSatPerVByteFee — on
+// Config.Network, and the zero value (bitcoin.Unknown) fails closed like
+// mainnet. Do not rely on post-registration propagation: an init-order bug
+// once left entries registered by a later init (the embedded servers) with an
+// unset Network.
 var testConfigs = map[string]testConfig{
 	"electrs-esplora tcp": {
 		clientConfig: electrum.Config{
 			URL:                 "tcp://electrum.blockstream.info:60001",
+			Network:             bitcoin.Testnet,
 			RequestTimeout:      requestTimeout * 2,
 			RequestRetryTimeout: requestRetryTimeout * 2,
 		},
@@ -69,6 +65,7 @@ var testConfigs = map[string]testConfig{
 	"electrs-esplora ssl": {
 		clientConfig: electrum.Config{
 			URL:                 "ssl://electrum.blockstream.info:60002",
+			Network:             bitcoin.Testnet,
 			RequestTimeout:      requestTimeout * 2,
 			RequestRetryTimeout: requestRetryTimeout * 2,
 		},
@@ -77,6 +74,7 @@ var testConfigs = map[string]testConfig{
 	"electrumx wss": {
 		clientConfig: electrum.Config{
 			URL:                 "wss://electrum.testnet.boar.network:443/QxbJgaSLUHqrgAa9BW7bDpnGPxrlhnCa",
+			Network:             bitcoin.Testnet,
 			RequestTimeout:      requestTimeout,
 			RequestRetryTimeout: requestRetryTimeout,
 		},
@@ -85,6 +83,7 @@ var testConfigs = map[string]testConfig{
 	"fulcrum tcp": {
 		clientConfig: electrum.Config{
 			URL:                 "tcp://testnet.aranguren.org:51001",
+			Network:             bitcoin.Testnet,
 			RequestTimeout:      requestTimeout * 2,
 			RequestRetryTimeout: requestRetryTimeout * 2,
 		},
@@ -111,6 +110,7 @@ func init() {
 			testConfigs[serverName] = testConfig{
 				clientConfig: electrum.Config{
 					URL:                 server,
+					Network:             network,
 					RequestTimeout:      requestTimeout,
 					RequestRetryTimeout: requestRetryTimeout,
 				},


### PR DESCRIPTION
## Problem

The nightly and per-PR `client-integration-test` job keeps failing on `TestEstimateSatPerVByteFee_Integration/embedded/testnet4/ssl://mempool.space:40002` with `errNo: -32603, errMsg: cannot estimate fee for 1008 blocks`. mempool.space's testnet4 Electrum endpoint intermittently has no fee data and rejects every confirmation target in the fallback ladder, so the failure comes and goes between runs; it hit four of the last six nightly runs on `main`, including the run right after #4170 removed the dead fulcrum server, and is the last remaining breaker of this job.

The client already handles this exact situation: when every target fails with a fee-oracle error, `EstimateSatPerVByteFee` falls back to a fixed low feerate, but only when `Config.Network` identifies a test network. The integration harness was supposed to provide that via an `init` that copied each test config's network into its Electrum client config. Go runs same-file `init` functions in source order, and that propagation `init` sits above the `init` that registers the embedded servers, so it runs first: the four static configs get their `Network` set while every `embedded/*` entry, including the testnet4 one, connects with `Network` left at its zero value (`bitcoin.Unknown`), which fails closed like mainnet and surfaces the oracle error instead of falling back.

## Solution

Set `Network` explicitly in every `clientConfig` literal, both in the static entries and in the embedded-server registration loop, mirroring production where the network is injected during config resolution. The propagation `init` is removed so registration order can no longer silently strand an entry without a network, and a comment on `testConfigs` records the constraint. With the network populated, an all-targets oracle failure on testnet4 resolves to the designed low-fee fallback and the test's minimum-fee assertion passes deterministically, while mainnet entries keep today's fail-closed behavior.

## Tests

`gofmt` is clean and `go vet` passes with and without the `integration` tag, and the package unit tests pass. The full `TestEstimateSatPerVByteFee_Integration` suite was run locally against all live servers: all six subtests pass, including the previously failing testnet4 endpoint, which resolved through the network-gated looser-target path. The fallback branch itself is already unit-covered for testnet4 in `electrum_test.go`; this change makes the integration harness actually reach it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test configuration by explicitly specifying the Bitcoin network for each Electrum server.
  * Updated embedded server test setup and comments to ensure network-specific behavior is validated consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->