### PR TITLE
chore(ci): move the solidity toolchain off end-of-life Node to 22 LTS

### DIFF
--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -55,7 +55,7 @@ jobs:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877
-          node-version: "18.15.0"
+          node-version: "22.23.1"
 
       - uses: ./.github/actions/install-yarn-deps
         with:
@@ -81,7 +81,7 @@ jobs:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877
-          node-version: "18.15.0"
+          node-version: "22.23.1"
 
       - uses: actions/setup-python@v4
         with:
@@ -123,7 +123,7 @@ jobs:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877
-          node-version: "18.15.0"
+          node-version: "22.23.1"
 
       - uses: ./.github/actions/install-yarn-deps
         with:
@@ -150,7 +150,7 @@ jobs:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877
-          node-version: "18.15.0"
+          node-version: "22.23.1"
 
       - uses: ./.github/actions/install-yarn-deps
         with:
@@ -183,7 +183,7 @@ jobs:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877
-          node-version: "18.15.0"
+          node-version: "22.23.1"
           registry-url: "https://registry.npmjs.org"
 
       - uses: ./.github/actions/install-yarn-deps
@@ -283,7 +283,7 @@ jobs:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877
-          node-version: "18.15.0"
+          node-version: "22.23.1"
           registry-url: "https://registry.npmjs.org"
 
       - uses: ./.github/actions/install-yarn-deps

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -55,7 +55,7 @@ jobs:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877
-          node-version: "18.15.0"
+          node-version: "22.23.1"
 
       - uses: ./.github/actions/install-yarn-deps
         with:
@@ -81,7 +81,7 @@ jobs:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877
-          node-version: "18.15.0"
+          node-version: "22.23.1"
 
       - uses: actions/setup-python@v4
         with:
@@ -121,7 +121,7 @@ jobs:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877
-          node-version: "18.15.0"
+          node-version: "22.23.1"
 
       - uses: ./.github/actions/install-yarn-deps
         with:
@@ -148,7 +148,7 @@ jobs:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877
-          node-version: "18.15.0"
+          node-version: "22.23.1"
 
       - uses: ./.github/actions/install-yarn-deps
         with:
@@ -181,7 +181,7 @@ jobs:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877
-          node-version: "18.15.0"
+          node-version: "22.23.1"
           registry-url: "https://registry.npmjs.org"
 
       - uses: ./.github/actions/install-yarn-deps
@@ -279,7 +279,7 @@ jobs:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877
-          node-version: "18.15.0"
+          node-version: "22.23.1"
           registry-url: "https://registry.npmjs.org"
 
       - uses: ./.github/actions/install-yarn-deps

--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -28,7 +28,7 @@ jobs:
           # Using fixed version, because 18.16 may cause issues with the
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877.
-          node-version: "18.15.0"
+          node-version: "22.23.1"
           registry-url: "https://registry.npmjs.org"
 
       - uses: ./.github/actions/install-yarn-deps

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -28,7 +28,7 @@ jobs:
           # Using fixed version, because 18.16 may cause issues with the
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877.
-          node-version: "18.15.0"
+          node-version: "22.23.1"
           registry-url: "https://registry.npmjs.org"
 
       - uses: ./.github/actions/setup-git-for-yarn

--- a/.github/workflows/reusable-solidity-docs.yml
+++ b/.github/workflows/reusable-solidity-docs.yml
@@ -125,7 +125,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.15.0"
+          node-version: "22.23.1"
 
       - uses: ./.github/actions/install-yarn-deps
         with:

--- a/solidity/ecdsa/Dockerfile
+++ b/solidity/ecdsa/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:22.23.1-alpine
 
 RUN apk add --update --no-cache \
     git \

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -79,7 +79,7 @@
     "@threshold-network/solidity-contracts": "1.3.0-dev.14"
   },
   "engines": {
-    "node": ">=18.15.0"
+    "node": ">=22.0.0"
   },
   "resolutions": {
     "ethereumjs-abi": "npm:0.6.8",

--- a/solidity/random-beacon/Dockerfile
+++ b/solidity/random-beacon/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:22.23.1-alpine
 
 RUN apk add --update --no-cache \
     git \

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -74,7 +74,7 @@
     "typescript": "^4.4.3"
   },
   "engines": {
-    "node": ">=18.15.0"
+    "node": ">=22.0.0"
   },
   "resolutions": {
     "ethereumjs-abi": "npm:0.6.8"


### PR DESCRIPTION
**Nine files, runtime pins only.** No dependency changes.

This previously carried all of #4109's commits and showed a 257-file diff — enough
that CodeRabbit declined to review it, and enough that merging it would have landed
the security release as a side effect. It has been rebased onto `main` and now
contains a single commit of its own.

Rebasing rather than retargeting at #4109 was the right move on two counts: that
branch lives on a fork (`lionakhnazarov/keep-core`), so GitHub cannot base a PR on
it; and there is no dependency to preserve — #4201's nine files are disjoint from
all 249 of #4109's. Merging in either order is conflict-free, verified by
simulating both.

> **The branch name is wrong.** `chore/ci-node-24-lts` says 24; this goes to
> **22**. Renaming would break the PR, so it stands — the title and the diff are
> the accurate ones, and the reason is below.

## The problem

All five workflows that build and test the contracts pin **Node 18.15.0**, which
reached end of life **2025-04-30** and receives no further security patches:

`contracts-ecdsa`, `contracts-random-beacon`, `npm-ecdsa`, `npm-random-beacon`,
`reusable-solidity-docs`

`engines.node` in both solidity manifests and both contract Dockerfiles say the
same.

## Why 22 and not 24

On support alone 24 is the better target — current LTS, EOL 2028-04-30, against
22's 2027-04-30. **This repo cannot reach it yet.**

Both solidity packages pin `hardhat 2.10.0`, which resolves `undici 5.19.1`.
Hardhat 2.x on the undici 5 line cannot download a compiler on Node 24: npm's
undici and Node 24's bundled undici share a global-dispatcher symbol, so
Hardhat's solc download reaches Node's internal dispatcher, which rejects
`maxRedirections`. Measured on this branch, `solidity/random-beacon`, cold
compiler cache:

```
Node v24.11.1   hardhat compile --force
                Error HH502: Couldn't download compiler versions list.
```

**A local run does not catch this.** HH502 is on the download path, so once a
compiler is cached the run succeeds. CI runners always start cold, which is
exactly where it fires. An earlier revision of this description reported a clean
Node 24 run and concluded 24 was safe; that run had a warm cache.

The fix is `hardhat >= 2.26`, and that is blocked on something larger:

- `@defi-wonderland/smock` (`^2.0.7`, resolved 2.0.7 in both packages) breaks at
  hardhat **2.20.0** — `Sandbox.create` — and is archived upstream, so no
  forward version is coming
- Node 24 needs hardhat **>= 2.26**

Disjoint ranges, so **smock has to go before Node 24 is reachable**. That is the
same chain tbtc-v2 worked through in threshold-network/tbtc-v2#1062 → #1063 →
#1064 — a contract-backed mock replacing smock, then hardhat 2.29 and Node 24
bumped together in one commit — and it is why that repo is on 24 and this one is
not. It has already paid for it.

So this is the interim step: off an end-of-life runtime now, onto the highest
version the current dependencies actually support. 24 follows the smock removal.

**Worth a separate issue:** `@defi-wonderland/smock` is pinned as `^2.0.7`. The
lockfile holds 2.0.7 today, but the range floats to 2.4.1 on any regeneration —
silently, into an archived package. Same trap tbtc-v2 hit.

## Verified

No dependency changes; runtime pins only.

`solidity/random-beacon`, full suite on this branch, via the package's own
`test` script (`hardhat typechain && hardhat check-accounts-count &&
USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_BEACON=true hardhat test`):

```
Node v18.20.8   934 passing, 6 pending, 0 failing
Node v22.23.1   934 passing, 6 pending, 0 failing
```

Identical. Node 24 is deliberately not quoted as passing — see above.

An earlier revision of this description quoted `168 passing, 12 failing` with
the 12 being `No deployment found for: T`. That does not reproduce: run through
the package's own script, which sets `USE_EXTERNAL_DEPLOY=true`, the external
deployment resolves and the suite is clean on both runtimes.

## `infrastructure/` deliberately untouched

It contains the worst offender in the repo (a **`node:11`** init container, EOL
2019, carrying 7 open Dependabot alerts), but **nothing there is built by CI**:

- `client.yml` lists `infrastructure/**` under `paths-ignore`
- the only build contexts across all workflows are `.`, `./solidity/ecdsa`,
  `./solidity/random-beacon`
- the init container image is pulled pre-built from
  `gcr.io/keep-dev-fe24/initcontainer-provision-keep-client-ethereum`, and is
  referenced only by `keep-dev` and `keep-test` — `keep-prd` has no keep-client
  manifests at all
- its `package-lock.json` has not changed since 2023-04-17

So those alerts are against a build this repo never performs. That wants a
decision about whether the image is still deployed — delete it, or move its build
into CI so the alerts mean something — rather than a version bump to a file
nothing builds. Same for `docker/ethereum/geth-node` (geth **v1.9.6**, 2019) and
`docker/ethereum/dashboard-node` (untagged `ubuntu`), both untouched since 2019
and referenced by nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated contract development, testing, documentation, deployment, and publishing workflows to use Node.js 22.
  * Updated container environments to Node.js 22.
  * Raised the minimum required Node.js version to 22 for the Solidity ECDSA and random beacon packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->