### PR TITLE
ci(solidity): run contracts CI on stacked PRs, and filter it by path

### DIFF
--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -2,8 +2,6 @@ name: Solidity ECDSA
 
 on:
   pull_request:
-    branches:
-      - main
   # We intend to use `workflow dispatch` in two different situations/paths
   # 1. If a workflow will be manually dispatched from branch named
   #    `dapp-development`, workflow will deploy the contracts on the selected
@@ -35,14 +33,24 @@ jobs:
   contracts-detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      path-filter: ${{ steps.set-output.outputs.path-filter }}
+      path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - name: Set path-filter output
-        id: set-output
-        run: echo "path-filter=true" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+        if: github.event_name == 'pull_request'
+      - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            path-filter:
+              - './solidity/ecdsa/**'
+              - './.github/workflows/contracts-ecdsa.yml'
 
   contracts-lint:
     needs: contracts-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -69,6 +77,9 @@ jobs:
 
   contracts-slither:
     needs: contracts-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -111,6 +122,9 @@ jobs:
 
   contracts-build-and-test:
     needs: contracts-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -138,6 +152,9 @@ jobs:
 
   contracts-deployment-dry-run:
     needs: contracts-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -2,8 +2,6 @@ name: Solidity Random Beacon
 
 on:
   pull_request:
-    branches:
-      - main
   # We intend to use `workflow dispatch` in two different situations/paths:
   # 1. If a workflow will be manually dispatched from branch named
   #    `dapp-development`, workflow will deploy the contracts on the selected
@@ -35,14 +33,24 @@ jobs:
   contracts-detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      path-filter: ${{ steps.set-output.outputs.path-filter }}
+      path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - name: Set path-filter output
-        id: set-output
-        run: echo "path-filter=true" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+        if: github.event_name == 'pull_request'
+      - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            path-filter:
+              - './solidity/random-beacon/**'
+              - './.github/workflows/contracts-random-beacon.yml'
 
   contracts-lint:
     needs: contracts-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -69,6 +77,9 @@ jobs:
 
   contracts-slither:
     needs: contracts-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -109,6 +120,9 @@ jobs:
 
   contracts-build-and-test:
     needs: contracts-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -136,6 +150,9 @@ jobs:
 
   contracts-deployment-dry-run:
     needs: contracts-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Both contracts workflows only trigger on `pull_request` targeting `main`:

```yaml
on:
  pull_request:
    branches:
      - main
```

So a PR based on any other branch gets **no solidity CI at all**. That is currently true of the entire in-flight stack — #4203, #4206, #4207 and #4208 have not run a single contracts job between them. #4207 adds a `tsc --noEmit` gate to `contracts-lint`; that gate has never executed in CI.

Each PR only gets verified when it is retargeted to `main`, which is the moment it merges — the least useful time to find out.

## Why this is three changes and not one

Opening the trigger on its own is wrong. `contracts-detect-changes` was a stub:

```yaml
- name: Set path-filter output
  id: set-output
  run: echo "path-filter=true" >> $GITHUB_OUTPUT
```

Unconditionally true, so both suites would then run on *every* PR to the repo, including client-only Go changes. And it turns out **nothing consumed the output** — none of the four jobs carried an `if:` referencing it, so the filter has been decorative for as long as it has existed. Wiring a real filter without adding those conditions would have changed nothing at all.

So:

1. Drop the `branches: [main]` restriction.
2. Replace the stub with a real `dorny/paths-filter@v2`, scoped to the package the workflow builds — matching `contracts-ecdsa-docs.yml`, `contracts-random-beacon-docs.yml` and `client.yml`, which all already do this.
3. Add the `if:` that consumes the result, in the exact form `client.yml` uses:

```yaml
if: |
  github.event_name != 'pull_request'
    || needs.contracts-detect-changes.outputs.path-filter == 'true'
```

The `github.event_name != 'pull_request'` half keeps `workflow_dispatch` runs unconditional, since the filter step is skipped for those and the output would be empty.

## Two things checked rather than assumed

**Filtering per package is safe.** `ecdsa` depends on `@keep-network/random-beacon` through the npm `development` dist-tag, not the local sources, so a random-beacon-only change cannot affect an ecdsa build.

**Deployment jobs are untouched.** `contracts-deployment-testnet` and `contracts-dapp-development-deployment-testnet` gate on `github.event_name == 'workflow_dispatch'` and need `contracts-build-and-test`, which still runs unconditionally for that event.

## Verification

Both files parse (`js-yaml`), `pull_request` resolves to the bare all-branches form, all four jobs in each workflow are gated, and `contracts-detect-changes` now runs `actions/checkout` + `dorny/paths-filter`.

Beyond that, **this PR is its own test case**: it edits both workflow files, and both are named in their own filters, so both suites should run here. If they do, the trigger and the filter are both correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contract validation workflows to run for pull requests targeting any branch.
  * Added change detection so contract checks run only when relevant Solidity files or workflow configurations are modified.
  * Improved conditional execution for linting, security analysis, builds, tests, and deployment dry runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->